### PR TITLE
fix(goal): guard checkpoints and count delegated progress

### DIFF
--- a/extensions/goal-tool-names.ts
+++ b/extensions/goal-tool-names.ts
@@ -48,6 +48,10 @@ export const GOAL_PROGRESS_TOOL_NAMES = [
 	"grep",
 	"find",
 	"ls",
+	"subagent",
+	"Agent",
+	"get_subagent_result",
+	"steer_subagent",
 ] as const;
 
 export const POST_STOP_ALLOWED_TOOLS = ["get_goal"] as const;

--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -409,6 +409,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	let continuationScheduledFor: string | null = null;
 	let continuationTimer: ReturnType<typeof setTimeout> | null = null;
 	let runningGoalId: string | null = null;
+	let checkpointGoalId: string | null = null;
 	let terminalInputUnsubscribe: (() => void) | null = null;
 	let statusRefreshTimer: ReturnType<typeof setInterval> | null = null;
 	let statusRefreshCtx: ExtensionContext | null = null;
@@ -425,12 +426,15 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	// Per-turn flags reset in turn_start (#4, C9 fix).
 	// goalWorkToolCalledThisTurn: tracks whether a real goal-work tool was called.
 	//   If false at turn_end, we don't queue another autoContinue (empty chat turn).
+	// turnSeq: lightweight generation for hook-order/session resume gaps.
 	// turnStoppedFor: set by pause_goal / complete_goal / propose_goal_tweak
-	//   after their successful execute. Once set, pi.on("tool_call") blocks all
-	//   subsequent in-turn tool calls except POST_STOP_ALLOWED_TOOLS. This is the
-	//   schema fix for "agent keeps writing files after pause_goal".
+	//   after their successful execute. Once set for the current turnSeq,
+	//   pi.on("tool_call") blocks all subsequent in-turn tool calls except
+	//   POST_STOP_ALLOWED_TOOLS. Older markers self-clear so prior turns/sessions
+	//   cannot poison resumed active goals.
 	let goalWorkToolCalledThisTurn = false;
-	let turnStoppedFor: string | null = null;
+	let turnSeq = 0;
+	let turnStoppedFor: { goalId: string; turnSeq: number } | null = null;
 
 	// #5 post-compaction resync: when a compaction just happened, the next agent
 	// turn gets an extra reminder block. Set in session_compact, consumed
@@ -577,11 +581,43 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		accounting.lastAccountedAt = null;
 	}
 
-	function clearStoppedRuntimeState(): void {
-		clearContinuationState();
-		clearActiveAccounting();
+	function advanceTurnSeq(): void {
+		turnSeq += 1;
+		if (turnStoppedFor?.turnSeq !== turnSeq) turnStoppedFor = null;
 	}
 
+	function currentTurnStoppedGoalId(): string | null {
+		if (!turnStoppedFor) return null;
+		if (turnStoppedFor.turnSeq !== turnSeq) {
+			turnStoppedFor = null;
+			return null;
+		}
+		return turnStoppedFor.goalId;
+	}
+
+	function markGoalTurnStopped(goalId: string | null | undefined = checkpointGoalId ?? runningGoalId): void {
+		if (turnStoppedFor?.turnSeq !== turnSeq) turnStoppedFor = null;
+		const stoppedGoalId = goalId ?? null;
+		if (!stoppedGoalId) return;
+		turnStoppedFor = turnStoppedFor ?? { goalId: stoppedGoalId, turnSeq };
+	}
+
+	function clearGoalTurnRuntimeState(opts: { markStopped?: boolean; stoppedGoalId?: string | null } = {}): void {
+		if (opts.markStopped === true) markGoalTurnStopped(opts.stoppedGoalId);
+		else turnStoppedFor = null;
+		clearContinuationState();
+		clearActiveAccounting();
+		runningGoalId = null;
+		checkpointGoalId = null;
+	}
+
+	function isActionableContinuationGoal(goalId: string | null | undefined): goalId is string {
+		return !!goalId && state.goal?.id === goalId && state.goal.status === "active" && state.goal.autoContinue;
+	}
+
+	function isStaleCheckpointBlockedToolCall(toolName: string): boolean {
+		return !POST_STOP_ALLOWED_TOOL_SET.has(toolName);
+	}
 
 	const activeGetGoalTurnsByGoalId = new Map<string, number>();
 
@@ -612,7 +648,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			}
 			goalsById = fresh;
 			focusedGoalId = null;
-			clearStoppedRuntimeState();
+			clearGoalTurnRuntimeState();
 			if (current) resetGetGoalNudgeState(current.id);
 			if (tweakDraftingFor !== null) tweakDraftingFor = null;
 			syncGoalTools();
@@ -625,8 +661,8 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		goalsById = fresh;
 		goalsById.set(reconciled.id, reconciled);
 		focusedGoalId = reconciled.id;
-		if (reconciled.status !== "active" || !reconciled.autoContinue) clearContinuationState();
-		if (reconciled.status !== "active") clearActiveAccounting();
+		if (reconciled.status !== "active") clearGoalTurnRuntimeState();
+		else if (!reconciled.autoContinue) clearContinuationState();
 		return true;
 	}
 
@@ -638,8 +674,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		const previousGoalId = focusedGoalId;
 		focusedGoalId = goalId && goalsById.has(goalId) ? goalId : null;
 		if (previousGoalId !== focusedGoalId) {
-			clearContinuationState();
-			clearActiveAccounting();
+			clearGoalTurnRuntimeState();
 			resetGetGoalNudgeState(previousGoalId);
 			resetGetGoalNudgeState(focusedGoalId);
 			if (tweakDraftingFor !== null && tweakDraftingFor !== focusedGoalId) tweakDraftingFor = null;
@@ -664,6 +699,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		goalsById.set(next.id, next);
 		focusedGoalId = next.id;
 		if (previousGoalId !== focusedGoalId) {
+			clearGoalTurnRuntimeState();
 			resetGetGoalNudgeState(previousGoalId);
 			resetGetGoalNudgeState(focusedGoalId);
 		}
@@ -672,16 +708,21 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		updateUI(ctx);
 	}
 
+	function queueFocusedContinuationIfActionable(ctx: ExtensionContext, force = false): void {
+		if (isActionableContinuationGoal(state.goal?.id)) queueContinuation(ctx, force);
+	}
+
 	function armFocusedContinuation(ctx: ExtensionContext): void {
+		if (state.goal?.status === "active") clearGoalTurnRuntimeState();
 		beginAccounting();
-		if (state.goal?.status === "active" && state.goal.autoContinue) queueContinuation(ctx, true);
+		queueFocusedContinuationIfActionable(ctx, true);
 	}
 
 	function removeFocusedGoal(ctx: ExtensionContext, reason: GoalFocusReason): void {
 		const previousGoalId = focusedGoalId;
 		if (focusedGoalId) goalsById.delete(focusedGoalId);
 		focusedGoalId = null;
-		clearStoppedRuntimeState();
+		clearGoalTurnRuntimeState();
 		resetGetGoalNudgeState(previousGoalId);
 		appendFocusEntry(null, reason);
 		syncGoalTools();
@@ -902,8 +943,8 @@ export default function goalExtension(pi: ExtensionAPI): void {
 				goalsById.delete(id);
 			}
 		}
-		clearStoppedRuntimeState();
-		runningGoalId = null;
+		clearGoalTurnRuntimeState();
+		syncGoalTools();
 		updateUI(ctx);
 	}
 
@@ -911,19 +952,12 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		const previousGoalId = state.goal?.id ?? null;
 		state.goal = next;
 		const focusChanged = previousGoalId !== focusedGoalId;
+		clearGoalTurnRuntimeState();
 		if (focusChanged) {
-			clearContinuationState();
-			clearActiveAccounting();
 			resetGetGoalNudgeState(previousGoalId);
 			resetGetGoalNudgeState(focusedGoalId);
 		}
 		if (focusReason && focusChanged) appendFocusEntry(focusedGoalId, focusReason);
-		if (!state.goal || (state.goal.status !== "active") || !state.goal.autoContinue) {
-			clearContinuationState();
-		}
-		if (!state.goal || state.goal.status === "paused" || state.goal.status === "complete") {
-			clearActiveAccounting();
-		}
 		if (!state.goal || state.goal.id !== previousGoalId) {
 			// Drop any stale tweak-edit-gate that didn't belong to this goal.
 			if (tweakDraftingFor !== null && tweakDraftingFor !== state.goal?.id) tweakDraftingFor = null;
@@ -968,6 +1002,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		// User-initiated pause (Esc / aborted turn). Clear any stale agent pause reason.
 		state.goal = { ...state.goal, autoContinue: false, pauseReason: undefined, pauseSuggestedAction: undefined };
 		stopActiveGoal("paused", "user", ctx);
+		markGoalTurnStopped(pausedGoalId);
 		resetGetGoalNudgeState(pausedGoalId);
 		ctx.ui.notify("Goal paused.", "info");
 	}
@@ -1051,7 +1086,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 					goalsById.delete(prevId);
 					focusedGoalId = null;
 				}
-				clearStoppedRuntimeState();
+				clearGoalTurnRuntimeState();
 				syncGoalTools();
 				updateUI(ctx);
 				ctx.ui.notify("Debug goal removed", "info");
@@ -1283,10 +1318,15 @@ Verification contract:
 	}
 
 	function sendQueuedContinuation(ctx: ExtensionContext, goalId: string): void {
+		const goal = state.goal;
 		continuationTimer = null;
 		continuationScheduledFor = null;
 		syncGoalTools();
-		if (!state.goal || state.goal.id !== goalId || state.goal.status !== "active" || !state.goal.autoContinue) {
+		if (!goal) {
+			if (continuationQueuedFor === goalId) continuationQueuedFor = null;
+			return;
+		}
+		if (goal.id !== goalId || goal.status !== "active" || !goal.autoContinue) {
 			if (continuationQueuedFor === goalId) continuationQueuedFor = null;
 			return;
 		}
@@ -1305,18 +1345,19 @@ Verification contract:
 			continuationTimer.unref?.();
 			return;
 		}
+		const queuedGoal: GoalRecord = goal;
 		continuationQueuedFor = goalId;
 		const settings = loadGoalSettings(ctx.cwd);
 		pi.sendMessage<GoalEventDetails>(
 			{
 				customType: GOAL_EVENT_ENTRY,
-				content: continuationPrompt(state.goal, settings),
+				content: continuationPrompt(queuedGoal, settings),
 				display: false,
 				details: {
 					kind: "checkpoint",
-					goalId: state.goal.id,
-					status: state.goal.status,
-					objective: state.goal.objective,
+					goalId: queuedGoal.id,
+					status: queuedGoal.status,
+					objective: queuedGoal.objective,
 					timestamp: Date.now(),
 				},
 			},
@@ -1327,8 +1368,9 @@ Verification contract:
 
 	function queueContinuation(ctx: ExtensionContext, force = false): void {
 		if (confirmationIntent !== null || tweakDraftingFor !== null) return;
-		if (!state.goal || state.goal.status !== "active" || !state.goal.autoContinue) return;
-		const goalId = state.goal.id;
+		const goal = state.goal;
+		const goalId = goal?.id;
+		if (!goal || !isActionableContinuationGoal(goalId)) return;
 		if (!force && (continuationQueuedFor === goalId || continuationScheduledFor === goalId)) return;
 		clearContinuationTimer();
 		let delay = CONTINUATION_IDLE_RETRY_MS;
@@ -1373,8 +1415,7 @@ Verification contract:
 
 	async function startGoalTweakDrafting(hint: string, ctx: ExtensionContext): Promise<void> {
 		reconcileFocusedGoalFromDisk(ctx);
-		clearContinuationState();
-		clearActiveAccounting();
+		clearGoalTurnRuntimeState();
 		if (!state.goal) {
 			if (openGoals().length > 0) {
 				const selected = await chooseOpenGoal(ctx, "Tweak which open goal?");
@@ -1429,8 +1470,7 @@ Verification contract:
 	}
 
 	function startGoalDrafting(topic: string, focus: DraftingFocus, ctx: ExtensionContext): void {
-		clearContinuationState();
-		clearActiveAccounting();
+		clearGoalTurnRuntimeState();
 		const trimmed = topic.trim();
 		const label = focus === "sisyphus" ? "Sisyphus intent discussion" : "Goal intent discussion";
 		const hint = focus === "sisyphus"
@@ -1517,8 +1557,10 @@ Verification contract:
 		if (opts.replace) {
 			const replacementTarget = await chooseOpenGoal(ctx, "Replace which open goal?");
 			if (openGoals().length > 0 && !replacementTarget) return;
+			const replacedGoalId = state.goal?.id ?? checkpointGoalId ?? runningGoalId;
 			archiveCurrentGoal(ctx, "user");
 			setGoal(null, ctx, true, "cleared");
+			markGoalTurnStopped(replacedGoalId);
 		}
 		startGoalDrafting(topic, focus, ctx);
 	}
@@ -1531,11 +1573,12 @@ Verification contract:
 			return;
 		}
 		const { objective, verificationContract } = extractVerificationContract(raw);
-		clearContinuationState();
-		clearActiveAccounting();
+		const replacedGoalId = state.goal?.id ?? checkpointGoalId ?? runningGoalId;
+		clearGoalTurnRuntimeState();
 		confirmationIntent = null;
 		syncGoalTools();
 		replaceGoal({ objective, autoContinue: true, sisyphus: focus === "sisyphus" }, ctx, true, verificationContract);
+		markGoalTurnStopped(replacedGoalId);
 	}
 
 	async function showGoalStatus(ctx: ExtensionContext): Promise<void> {
@@ -1586,7 +1629,9 @@ Verification contract:
 		}
 		const resumeGate = validateResumeGoal(state.goal);
 		if (!resumeGate.ok) {
-			const level = resumeGate.message.includes("already running") ? "info" : "warning";
+			const alreadyRunning = resumeGate.message.includes("already running");
+			if (alreadyRunning && state.goal?.status === "active") armFocusedContinuation(ctx);
+			const level = alreadyRunning ? "info" : "warning";
 			ctx.ui.notify(resumeGate.message, level);
 			return;
 		}
@@ -1714,10 +1759,12 @@ Verification contract:
 			const selected = await chooseOpenGoal(ctx, "Clear which open goal?");
 			if (!selected) return;
 		}
+		const clearedGoalId = state.goal?.id ?? checkpointGoalId ?? runningGoalId;
 		const archived = archiveCurrentGoal(ctx, "user");
 		const didArchive = !!archived;
 		resetGetGoalNudgeState(state.goal?.id);
 		setGoal(null, ctx, true, "cleared");
+		markGoalTurnStopped(clearedGoalId);
 		// Phase 5 D: also abort any in-flight drafting so the agent's next turn
 		// doesn't try to propose into a cleared slot.
 		const wasDrafting = confirmationIntent !== null;
@@ -1741,10 +1788,12 @@ Verification contract:
 			const selected = await chooseOpenGoal(ctx, "Abort which open goal?");
 			if (!selected) return;
 		}
+		const abortedGoalId = state.goal?.id ?? checkpointGoalId ?? runningGoalId;
 		const archived = archiveCurrentGoal(ctx, "user");
 		const didArchive = !!archived;
 		resetGetGoalNudgeState(state.goal?.id);
 		setGoal(null, ctx, true, "aborted");
+		markGoalTurnStopped(abortedGoalId);
 		const wasDrafting = confirmationIntent !== null;
 		confirmationIntent = null;
 		syncGoalTools();
@@ -2255,7 +2304,7 @@ ${objective}` : objective,
 				// Reset autoContinue counter — plan changed, agent gets a fresh chain.
 				resetGetGoalNudgeState(state.goal.id);
 				// Mark turn-stopped so subsequent in-turn tool calls are blocked.
-				turnStoppedFor = state.goal.id;
+				markGoalTurnStopped(state.goal.id);
 				syncGoalTools();
 				updateUI(ctx);
 				ctx.ui.notify(`Goal tweaked: ${truncateText(changeSummary, 160)}`, "info");
@@ -2415,7 +2464,7 @@ ${objective}` : objective,
 				};
 				state.goal = writeActiveGoalFile(ctx, state.goal);
 				pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
-				turnStoppedFor = state.goal?.id ?? null;
+				markGoalTurnStopped(state.goal?.id);
 				resetGetGoalNudgeState(state.goal?.id);
 				syncGoalTools();
 				updateUI(ctx);
@@ -2482,7 +2531,7 @@ ${objective}` : objective,
 				};
 				state.goal = writeActiveGoalFile(ctx, state.goal);
 				pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
-				turnStoppedFor = state.goal?.id ?? null;
+				markGoalTurnStopped(state.goal?.id);
 				resetGetGoalNudgeState(state.goal?.id);
 				syncGoalTools();
 				updateUI(ctx);
@@ -2575,6 +2624,7 @@ ${objective}` : objective,
 			if (auditor.error === "Auditor aborted.") {
 				auditProgress = null;
 				goalWidgetComponent?.invalidate();
+
 				updateUI(ctx);
 
 				showingEscapeDialog = true;
@@ -2612,7 +2662,7 @@ ${objective}` : objective,
 					};
 					state.goal = writeActiveGoalFile(ctx, state.goal);
 					pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
-					turnStoppedFor = state.goal?.id ?? null;
+					markGoalTurnStopped(state.goal?.id);
 					resetGetGoalNudgeState(state.goal?.id);
 					syncGoalTools();
 					updateUI(ctx);
@@ -2729,7 +2779,7 @@ ${objective}` : objective,
 			};
 			state.goal = writeActiveGoalFile(ctx, state.goal);
 			pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
-			turnStoppedFor = state.goal?.id ?? null;
+			markGoalTurnStopped(state.goal?.id);
 			resetGetGoalNudgeState(state.goal?.id);
 			syncGoalTools();
 			updateUI(ctx);
@@ -2796,7 +2846,7 @@ ${objective}` : objective,
 			resetGetGoalNudgeState(next.id);
 			// C9 fix: mark turn-stopped so subsequent in-turn tool calls are blocked.
 			// This is the schema-level closure of "agent kept writing files after pause_goal".
-			turnStoppedFor = state.goal.id;
+			markGoalTurnStopped(state.goal.id);
 
 			const suggestionLine = suggested ? `\nSuggested: ${truncateText(suggested, 160)}` : "";
 			ctx.ui.notify(
@@ -2856,7 +2906,7 @@ ${objective}` : objective,
 			const archived = archiveCurrentGoal(ctx, "agent");
 			resetGetGoalNudgeState(abortedGoalId);
 			setGoal(null, ctx, true, "aborted");
-			turnStoppedFor = abortedGoalId;
+			markGoalTurnStopped(abortedGoalId);
 
 			const archiveLine = archived?.archivedPath ? `\nArchive: ${archived.archivedPath}` : "";
 			ctx.ui.notify(
@@ -3045,8 +3095,9 @@ ${objective}` : objective,
 			}
 			state.goal = { ...state.goal, taskList, updatedAt: now };
 			setGoal(state.goal, ctx);
-			turnStoppedFor = state.goal.id;
+			markGoalTurnStopped(state.goal.id);
 			resetGetGoalNudgeState(state.goal.id);
+
 			syncGoalTools();
 			updateUI(ctx);
 
@@ -3299,9 +3350,7 @@ promptGuidelines: [
 			const queuedGoalId = goalEventMessageId(candidate);
 			if (!queuedGoalId) return message;
 			if (
-				state.goal?.id === queuedGoalId
-				&& (state.goal.status === "active")
-				&& state.goal.autoContinue
+				isActionableContinuationGoal(queuedGoalId)
 				&& latestGoalEventIndex.get(queuedGoalId) === index
 			) return message;
 			changed = true;
@@ -3324,8 +3373,8 @@ promptGuidelines: [
 
 	pi.on("turn_start", async (_event, ctx) => {
 		// Per-turn flag resets (#4 + C9 fix).
+		advanceTurnSeq();
 		goalWorkToolCalledThisTurn = false;
-		turnStoppedFor = null;
 		beginAccounting();
 		updateUI(ctx);
 	});
@@ -3336,10 +3385,11 @@ promptGuidelines: [
 		// complete_goal / propose_goal_tweak fires in this turn, block all subsequent tool calls except
 		// read-only inspection. Forces the agent to yield the turn instead of "fixing"
 		// the situation by creating extra files etc.
-		if (turnStoppedFor !== null && !POST_STOP_ALLOWED_TOOL_SET.has(event.toolName)) {
+		const stoppedGoalId = currentTurnStoppedGoalId();
+		if (stoppedGoalId !== null && !POST_STOP_ALLOWED_TOOL_SET.has(event.toolName)) {
 			return {
 				block: true,
-				reason: `The goal was already stopped earlier in this turn (goalId=${turnStoppedFor}). ` +
+				reason: `The goal was already stopped earlier in this turn (goalId=${stoppedGoalId}). ` +
 					`Do not call more tools; end the turn with a brief summary and yield to the user.`,
 			};
 		}
@@ -3353,13 +3403,18 @@ promptGuidelines: [
 				// Nudge only: do not hard-block, but warn in tool response via get_goal execute
 			}
 		}
+		if (checkpointGoalId !== null && !isActionableContinuationGoal(checkpointGoalId) && isStaleCheckpointBlockedToolCall(event.toolName)) {
+			markGoalTurnStopped(checkpointGoalId);
+			return {
+				block: true,
+				reason: `The goal was already stopped earlier in this turn (goalId=${checkpointGoalId}). ` +
+					`Do not call more tools; end the turn with a brief summary and yield to the user.`,
+			};
+		}
 		// Track for #4 empty-turn gate.
 		if (isMeaningfulProgressToolCall(event.toolName, asRecord(event)?.args)) {
 			if (state.goal?.id) activeGetGoalTurnsByGoalId.delete(state.goal.id);
 			goalWorkToolCalledThisTurn = true;
-		} else if (state.goal?.status === "active" && state.goal.autoContinue && event.toolName !== "get_goal") {
-			// A non-progress tool should not create an infinite retry chain.
-			turnStoppedFor = state.goal.id;
 		}
 		return;
 	});
@@ -3426,21 +3481,14 @@ promptGuidelines: [
 	});
 
 	pi.on("session_start", async (event, ctx) => {
+		advanceTurnSeq();
 		loadState(ctx);
 		syncTerminalInputPause(ctx);
 		if (event.reason === "resume" && !state.goal && openGoals().length > 1 && ctx.hasUI) {
 			await focusGoalCommand(ctx);
 		}
-		// Codex behavior: prompt before reactivating a paused goal on resume.
-		if (event.reason === "resume" && state.goal?.status === "paused" && ctx.hasUI) {
-			const current = state.goal;
-			const shouldResume = await ctx.ui.confirm("Resume paused goal?", `Goal: ${current.objective}`);
-			if (shouldResume) {
-				setGoal({ ...current, status: "active", autoContinue: true, stopReason: undefined, pauseReason: undefined, pauseSuggestedAction: undefined }, ctx);
-			}
-		}
 		beginAccounting();
-		queueContinuation(ctx, true);
+		queueFocusedContinuationIfActionable(ctx, true);
 	});
 
 	pi.on("session_before_compact", async (_event, ctx) => {
@@ -3456,22 +3504,25 @@ promptGuidelines: [
 		if (shouldArmPostCompactReminder(state.goal)) {
 			postCompactReminderPending = true;
 		}
-		queueContinuation(ctx, true);
+		queueFocusedContinuationIfActionable(ctx, true);
 	});
 
 	pi.on("session_tree", async (_event, ctx) => {
+		advanceTurnSeq();
 		loadState(ctx);
 		syncTerminalInputPause(ctx);
 		beginAccounting();
-		queueContinuation(ctx, true);
+		queueFocusedContinuationIfActionable(ctx, true);
 	});
 
 	pi.on("before_agent_start", async (event, ctx) => {
+		advanceTurnSeq();
 		syncGoalTools();
 		const currentSystemPrompt = () => ctx.getSystemPrompt?.() || event.systemPrompt;
 		const incomingGoalId = extractGoalIdFromInjectedMessage(event.prompt ?? "");
 
 		if (confirmationIntent !== null) {
+			checkpointGoalId = null;
 			clearContinuationState();
 			clearActiveAccounting();
 			runningGoalId = null;
@@ -3479,18 +3530,24 @@ promptGuidelines: [
 		}
 
 		if (tweakDraftingFor !== null) {
+			checkpointGoalId = null;
 			clearContinuationState();
 			clearActiveAccounting();
 			runningGoalId = null;
 			return { systemPrompt: currentSystemPrompt() };
 		}
 
+		if (incomingGoalId !== null) {
+			reconcileFocusedGoalFromDisk(ctx);
+		}
+
 		// If this turn was triggered by a hidden goal checkpoint that no longer
 		// matches the active goal, abort the whole turn instead of letting the
 		// model act on a stale instruction.
 		if (incomingGoalId !== null) {
+			checkpointGoalId = incomingGoalId;
 			clearContinuationState();
-			if (!state.goal || state.goal.id !== incomingGoalId || (state.goal.status !== "active") || !state.goal.autoContinue) {
+			if (!isActionableContinuationGoal(incomingGoalId)) {
 				try {
 					ctx.abort?.();
 				} catch {}
@@ -3500,6 +3557,7 @@ promptGuidelines: [
 				};
 			}
 		} else {
+			checkpointGoalId = null;
 			// A user-driven turn — clear any queued continuation so we don't
 			// double-fire after the user's own message returns. Also reset the
 			// autoContinue nudge state so the user always gets a fresh chain.

--- a/tests/goal-extension.test.ts
+++ b/tests/goal-extension.test.ts
@@ -343,9 +343,11 @@ test("paused checkpoint reconciles from disk and aborts before work starts", asy
 		const blockedQuestion = await emit(harness, "tool_call", { toolName: "goal_question", args: { question: "Should I keep going?" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
 		assert.equal(blockedQuestion?.block, true);
 		assert.match(blockedQuestion?.reason ?? "", /goal was already stopped earlier in this turn/);
-		const blockedSubagent = await emit(harness, "tool_call", { toolName: "subagent", args: { task: "delegate stale work" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
-		assert.equal(blockedSubagent?.block, true);
-		assert.match(blockedSubagent?.reason ?? "", /goal was already stopped earlier in this turn/);
+		for (const toolName of ["subagent", "Agent", "get_subagent_result", "steer_subagent"] as const) {
+			const blockedDelegation = await emit(harness, "tool_call", { toolName, args: { task: "delegate stale work", id: "agent-1" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
+			assert.equal(blockedDelegation?.block, true, `${toolName} should block`);
+			assert.match(blockedDelegation?.reason ?? "", /goal was already stopped earlier in this turn/);
+		}
 		const blockedUnknown = await emit(harness, "tool_call", { toolName: "unknown_extension_tool", args: { payload: "delegate stale work" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
 		assert.equal(blockedUnknown?.block, true);
 		assert.match(blockedUnknown?.reason ?? "", /goal was already stopped earlier in this turn/);
@@ -416,6 +418,62 @@ test("active checkpoint prep tools do not poison same turn", async () => {
 		assert.equal(recall, undefined);
 		const grep = await emit(harness, "tool_call", { toolName: "fff_multi_grep", args: { pattern: "turnStoppedFor" } }, harness.ctx) as { block?: boolean } | undefined;
 		assert.equal(grep, undefined);
+		const read = await emit(harness, "tool_call", { toolName: "read", args: { path: "README.md" } }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(read, undefined);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("active checkpoint delegation counts as progress and queues continuation at turn_end", async () => {
+	const harness = makeHarness({ idle: true, pendingMessages: false });
+	try {
+		const goal = await createGoal(harness, "Delegation tools must count as progress", "sisyphus");
+		const checkpoint = checkpointMessage(goal.id, goal.objective);
+		harness.messages.splice(0);
+
+		const before = await emit(harness, "before_agent_start", {
+			prompt: checkpoint.content,
+			systemPrompt: "BASE",
+		}, harness.ctx) as { systemPrompt?: string } | undefined;
+		assert.equal(typeof before?.systemPrompt, "string");
+		assert.ok(before?.systemPrompt?.includes(`[PI GOAL ACTIVE goalId=${goal.id}]`));
+
+		await emit(harness, "turn_start", "", harness.ctx);
+		const delegated = await emit(harness, "tool_call", { toolName: "subagent", args: { task: "implement goal slice" } }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(delegated, undefined);
+		await emit(harness, "turn_end", { message: { role: "assistant", stopReason: "endTurn" } }, harness.ctx);
+		await sleep(80);
+
+		assert.equal(harness.messages.length, 1);
+		const queued = harness.messages[0];
+		assert.equal(queued.message.customType, GOAL_EVENT_ENTRY);
+		assert.equal(queued.options.triggerTurn, true);
+		assert.equal(queued.options.deliverAs, "followUp");
+		assert.match(String(queued.message.content ?? ""), new RegExp(`^<pi_goal_continuation goal_id="${goal.id}"`));
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("active checkpoint legacy delegation controls do not poison same turn", async () => {
+	const harness = makeHarness({ idle: true, pendingMessages: false });
+	try {
+		const goal = await createGoal(harness, "Legacy delegation controls stay active", "sisyphus");
+		const checkpoint = checkpointMessage(goal.id, goal.objective);
+
+		const before = await emit(harness, "before_agent_start", {
+			prompt: checkpoint.content,
+			systemPrompt: "BASE",
+		}, harness.ctx) as { systemPrompt?: string } | undefined;
+		assert.equal(typeof before?.systemPrompt, "string");
+		assert.ok(before?.systemPrompt?.includes(`[PI GOAL ACTIVE goalId=${goal.id}]`));
+
+		await emit(harness, "turn_start", "", harness.ctx);
+		for (const toolName of ["Agent", "get_subagent_result", "steer_subagent"] as const) {
+			const result = await emit(harness, "tool_call", { toolName, args: { task: "monitor delegated work", id: "agent-1" } }, harness.ctx) as { block?: boolean } | undefined;
+			assert.equal(result, undefined, `${toolName} should stay allowed`);
+		}
 		const read = await emit(harness, "tool_call", { toolName: "read", args: { path: "README.md" } }, harness.ctx) as { block?: boolean } | undefined;
 		assert.equal(read, undefined);
 	} finally {

--- a/tests/goal-extension.test.ts
+++ b/tests/goal-extension.test.ts
@@ -1,0 +1,600 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import goalExtension from "../extensions/goal.ts";
+
+const GOAL_EVENT_ENTRY = "pi-goal-event";
+const GOAL_STATE_ENTRY = "pi-goal-state";
+
+interface RecordedEntry {
+	customType: string;
+	data: unknown;
+}
+
+interface RecordedMessage {
+	message: {
+		customType?: string;
+		content?: unknown;
+		details?: unknown;
+		display?: boolean;
+	};
+	options: { triggerTurn?: boolean; deliverAs?: string };
+}
+
+interface GoalSnapshot {
+	id: string;
+	status: "active" | "paused" | "complete";
+	objective: string;
+	autoContinue: boolean;
+	activePath?: string;
+}
+
+interface TestContext {
+	cwd: string;
+	hasUI: boolean;
+	sessionManager: { getBranch(): RecordedEntry[] };
+	ui: {
+		notify(message: string, level: string): void;
+		setStatus(key: string, value: string | undefined): void;
+		setWidget(key: string, widget: unknown, options?: { placement?: string }): void;
+		onTerminalInput(cb: (data: string) => { consume?: boolean } | undefined): () => void;
+		confirm(prompt: string, body?: string): Promise<boolean>;
+		select(prompt: string, options: string[]): Promise<string | undefined>;
+		input(prompt: string, placeholder?: string): Promise<string | undefined>;
+	};
+	getSystemPrompt(): string;
+	abort(): void;
+	signal: AbortSignal;
+	hasPendingMessages(): boolean;
+	isIdle(): boolean;
+}
+
+interface RegisteredCommand {
+	handler(rawArgs: string, ctx: TestContext): Promise<void> | void;
+}
+
+interface Harness {
+	ctx: TestContext;
+	commands: Map<string, RegisteredCommand>;
+	handlers: Map<string, (...args: unknown[]) => unknown>;
+	entries: RecordedEntry[];
+	messages: RecordedMessage[];
+	setIdle(next: boolean): void;
+	setPendingMessages(next: boolean): void;
+	aborted(): boolean;
+	cleanup(): void;
+}
+
+function makeHarness(initial = { idle: true, pendingMessages: false }): Harness {
+	const cwd = mkdtempSync(path.join(tmpdir(), "pi-goal-x-extension-test-"));
+	const commands = new Map<string, RegisteredCommand>();
+	const handlers = new Map<string, (...args: unknown[]) => unknown>();
+	const entries: RecordedEntry[] = [];
+	const messages: RecordedMessage[] = [];
+	const activeTools: string[] = [];
+	let idle = initial.idle;
+	let pendingMessages = initial.pendingMessages;
+	let aborted = false;
+	const abortController = new AbortController();
+
+	const pi = {
+		getActiveTools: () => [...activeTools],
+		setActiveTools: (tools: string[]) => {
+			activeTools.splice(0, activeTools.length, ...tools);
+		},
+		appendEntry: (customType: string, data: unknown) => {
+			entries.push({ customType, data });
+		},
+		registerCommand: (name: string, command: unknown) => {
+			commands.set(name, command as RegisteredCommand);
+		},
+		registerTool: (_tool: unknown) => {},
+		registerMessageRenderer: (_name: string, _renderer: unknown) => {},
+		on: (eventName: string, handler: unknown) => {
+			handlers.set(eventName, handler as (...args: unknown[]) => unknown);
+		},
+		sendMessage: async (message: unknown, options: { triggerTurn?: boolean; deliverAs?: string } = {}) => {
+			messages.push({ message: message as RecordedMessage["message"], options });
+		},
+		sendUserMessage: async (message: unknown, options: { deliverAs?: string } = {}) => {
+			messages.push({
+				message: { content: message } as RecordedMessage["message"],
+				options: { deliverAs: options.deliverAs },
+			});
+		},
+	};
+
+	const extensionApi: unknown = pi;
+	goalExtension(extensionApi as Parameters<typeof goalExtension>[0]);
+
+	const ctx: TestContext = {
+		cwd,
+		hasUI: false,
+		sessionManager: {
+			getBranch: () => entries,
+		},
+		ui: {
+			notify: () => {},
+			setStatus: () => {},
+			setWidget: () => {},
+			onTerminalInput: () => () => {},
+			confirm: async () => false,
+			select: async () => undefined,
+			input: async () => undefined,
+		},
+		getSystemPrompt: () => "BASE",
+		abort: () => {
+			aborted = true;
+			abortController.abort();
+		},
+		signal: abortController.signal,
+		hasPendingMessages: () => pendingMessages,
+		isIdle: () => idle,
+	};
+
+	return {
+		ctx,
+		commands,
+		handlers,
+		entries,
+		messages,
+		setIdle: (next: boolean) => {
+			idle = next;
+		},
+		setPendingMessages: (next: boolean) => {
+			pendingMessages = next;
+		},
+		aborted: () => aborted,
+		cleanup: () => {
+			rmSync(cwd, { recursive: true, force: true });
+		},
+	};
+}
+
+async function runCommand(harness: Harness, name: string, rawArgs = ""): Promise<void> {
+	const command = harness.commands.get(name);
+	assert.ok(command, `missing command: ${name}`);
+	await command.handler(rawArgs, harness.ctx);
+}
+
+async function emit(harness: Harness, eventName: string, ...args: unknown[]): Promise<unknown> {
+	const handler = harness.handlers.get(eventName);
+	assert.ok(handler, `missing handler: ${eventName}`);
+	return await Promise.resolve(handler(...args));
+}
+
+async function sleep(ms: number): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function latestGoalSnapshot(entries: RecordedEntry[]): GoalSnapshot | null {
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
+		if (!entry || entry.customType !== GOAL_STATE_ENTRY) continue;
+		const data = entry.data as { version?: number; goal?: { id?: unknown; status?: unknown; objective?: unknown; autoContinue?: unknown; activePath?: unknown } | null };
+		const goal = data.goal;
+		if (!goal) return null;
+		if (typeof goal.id !== "string" || typeof goal.objective !== "string" || typeof goal.autoContinue !== "boolean") return null;
+		const status = goal.status === "paused" || goal.status === "complete" ? goal.status : "active";
+		return {
+			id: goal.id,
+			status,
+			objective: goal.objective,
+			autoContinue: goal.autoContinue,
+			activePath: typeof goal.activePath === "string" ? goal.activePath : undefined,
+		};
+	}
+	return null;
+}
+
+function checkpointPrompt(goalId: string): string {
+	return [
+		`<pi_goal_continuation goal_id="${goalId}" kind="checkpoint">`,
+		`[GOAL CHECKPOINT goalId=${goalId}]`,
+		"Continue working toward the active pi goal.",
+	].join("\n");
+}
+
+function checkpointMessage(goalId: string, objective: string): {
+	customType: string;
+	content: string;
+	display: boolean;
+	details: { kind: "checkpoint"; goalId: string; status: "active"; objective: string; timestamp: number };
+} {
+	return {
+		customType: GOAL_EVENT_ENTRY,
+		content: checkpointPrompt(goalId),
+		display: true,
+		details: {
+			kind: "checkpoint",
+			goalId,
+			status: "active",
+			objective,
+			timestamp: Date.now(),
+		},
+	};
+}
+
+async function createGoal(harness: Harness, objective: string, mode: "goal" | "sisyphus" = "sisyphus"): Promise<GoalSnapshot> {
+	await runCommand(harness, mode === "sisyphus" ? "sisyphus-set" : "goals-set", objective);
+	const snapshot = latestGoalSnapshot(harness.entries);
+	assert.ok(snapshot, "goal snapshot missing");
+	return snapshot;
+}
+
+function writePausedGoalFile(harness: Harness, goal: GoalSnapshot): void {
+	assert.ok(goal.activePath, "goal activePath missing");
+	const filePath = path.join(harness.ctx.cwd, goal.activePath);
+	const content = readFileSync(filePath, "utf8");
+	const splitAt = content.indexOf("\n\n# Goal Prompt");
+	assert.ok(splitAt > 0, "goal file metadata split missing");
+	const metadata = JSON.parse(content.slice(0, splitAt)) as Record<string, unknown>;
+	metadata.status = "paused";
+	metadata.autoContinue = false;
+	metadata.stopReason = "agent";
+	metadata.pauseReason = "persisted pause wins over stale memory";
+	writeFileSync(filePath, `${JSON.stringify(metadata, null, 2)}${content.slice(splitAt)}`, "utf8");
+}
+
+test("goal extension queues active auto-continue checkpoint and keeps it actionable", async () => {
+	const harness = makeHarness({ idle: true, pendingMessages: false });
+	try {
+		const goal = await createGoal(harness, "Ship active checkpoint guard regression", "sisyphus");
+		await sleep(20);
+
+		assert.equal(harness.messages.length, 1);
+		const queued = harness.messages[0];
+		assert.equal(queued.message.customType, GOAL_EVENT_ENTRY);
+		assert.equal(queued.options.triggerTurn, true);
+		assert.equal(queued.options.deliverAs, "followUp");
+		const queuedPrompt = queued.message.content;
+		if (typeof queuedPrompt !== "string") throw new Error("queued prompt missing");
+		assert.match(queuedPrompt, new RegExp(`^<pi_goal_continuation goal_id="${goal.id}"`));
+
+		const activeContext = await emit(harness, "context", { messages: [queued.message] }) as { messages?: Array<{ content?: unknown; details?: unknown; display?: boolean }> } | undefined;
+		assert.equal(activeContext, undefined);
+
+		const before = await emit(harness, "before_agent_start", {
+			prompt: queuedPrompt,
+			systemPrompt: "BASE",
+		}, harness.ctx) as { systemPrompt?: string } | undefined;
+		assert.equal(typeof before?.systemPrompt, "string");
+		assert.ok(before?.systemPrompt?.includes(`[PI GOAL ACTIVE goalId=${goal.id}]`));
+
+		await emit(harness, "turn_start", "", harness.ctx);
+		const toolResult = await emit(harness, "tool_call", { toolName: "read", args: { path: "README.md" } }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(toolResult, undefined);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("paused goal on session_start resume does not queue continuation", async () => {
+	const harness = makeHarness({ idle: true, pendingMessages: false });
+	try {
+		await createGoal(harness, "Stay paused on session resume", "sisyphus");
+		await sleep(20);
+		harness.messages.splice(0);
+
+		await runCommand(harness, "goal-pause");
+		await emit(harness, "session_start", { reason: "resume" }, harness.ctx);
+		await sleep(20);
+
+		const current = latestGoalSnapshot(harness.entries);
+		assert.equal(current?.status, "paused");
+		assert.equal(current?.autoContinue, false);
+		assert.equal(harness.messages.length, 0);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("paused goal on session_tree does not queue continuation", async () => {
+	const harness = makeHarness({ idle: true, pendingMessages: false });
+	try {
+		await createGoal(harness, "Stay paused on tree restore", "sisyphus");
+		await sleep(20);
+		harness.messages.splice(0);
+
+		await runCommand(harness, "goal-pause");
+		await emit(harness, "session_tree", {}, harness.ctx);
+		await sleep(20);
+
+		const current = latestGoalSnapshot(harness.entries);
+		assert.equal(current?.status, "paused");
+		assert.equal(current?.autoContinue, false);
+		assert.equal(harness.messages.length, 0);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("paused checkpoint reconciles from disk and aborts before work starts", async () => {
+	const harness = makeHarness({ idle: true, pendingMessages: false });
+	try {
+		const goal = await createGoal(harness, "Persisted pause beats stale memory", "sisyphus");
+		const checkpoint = checkpointMessage(goal.id, goal.objective);
+		writePausedGoalFile(harness, goal);
+
+		const before = await emit(harness, "before_agent_start", {
+			prompt: checkpoint.content,
+			systemPrompt: "BASE",
+		}, harness.ctx) as { systemPrompt?: string } | undefined;
+		assert.ok(before?.systemPrompt, "stale checkpoint prompt missing");
+		assert.ok(before?.systemPrompt.includes(`[GOAL STALE goalId=${goal.id}]`));
+		assert.equal(harness.aborted(), true);
+
+		const contextResult = await emit(harness, "context", { messages: [checkpoint] }) as { messages?: Array<{ content?: unknown; display?: boolean; details?: { kind?: string; goalId?: string; currentGoalId?: string | null; currentStatus?: string | null } }> } | undefined;
+		assert.ok(contextResult?.messages, "context result missing");
+		const stale = contextResult.messages[0];
+		assert.equal(stale?.display, false);
+		assert.equal(stale?.details?.kind, "stale");
+		assert.equal(stale?.details?.goalId, goal.id);
+		assert.equal(stale?.details?.currentGoalId, goal.id);
+		assert.equal(stale?.details?.currentStatus, "paused");
+
+		await emit(harness, "turn_start", "", harness.ctx);
+		const blockedBash = await emit(harness, "tool_call", { toolName: "bash", args: { command: "echo BAD" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
+		assert.equal(blockedBash?.block, true);
+		assert.match(blockedBash?.reason ?? "", /goal was already stopped earlier in this turn/);
+		const blockedQuestion = await emit(harness, "tool_call", { toolName: "goal_question", args: { question: "Should I keep going?" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
+		assert.equal(blockedQuestion?.block, true);
+		assert.match(blockedQuestion?.reason ?? "", /goal was already stopped earlier in this turn/);
+		const blockedSubagent = await emit(harness, "tool_call", { toolName: "subagent", args: { task: "delegate stale work" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
+		assert.equal(blockedSubagent?.block, true);
+		assert.match(blockedSubagent?.reason ?? "", /goal was already stopped earlier in this turn/);
+		const blockedUnknown = await emit(harness, "tool_call", { toolName: "unknown_extension_tool", args: { payload: "delegate stale work" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
+		assert.equal(blockedUnknown?.block, true);
+		assert.match(blockedUnknown?.reason ?? "", /goal was already stopped earlier in this turn/);
+		const allowedGetGoal = await emit(harness, "tool_call", { toolName: "get_goal", args: {} }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(allowedGetGoal, undefined);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("explicit goal-resume returns paused goal to active continuation", async () => {
+	const harness = makeHarness({ idle: true, pendingMessages: false });
+	try {
+		const goal = await createGoal(harness, "Resume only on explicit command", "sisyphus");
+		await sleep(20);
+		harness.messages.splice(0);
+
+		await runCommand(harness, "goal-pause");
+		await runCommand(harness, "goal-resume");
+		await sleep(20);
+
+		const current = latestGoalSnapshot(harness.entries);
+		assert.equal(current?.id, goal.id);
+		assert.equal(current?.status, "active");
+		assert.equal(current?.autoContinue, true);
+		assert.equal(harness.messages.length, 1);
+		const queued = harness.messages[0];
+		assert.equal(queued.message.customType, GOAL_EVENT_ENTRY);
+		assert.equal(queued.options.triggerTurn, true);
+		assert.equal(queued.options.deliverAs, "followUp");
+		const queuedPrompt = queued.message.content;
+		if (typeof queuedPrompt !== "string") throw new Error("queued prompt missing");
+		assert.match(queuedPrompt, new RegExp(`^<pi_goal_continuation goal_id="${goal.id}"`));
+
+		const before = await emit(harness, "before_agent_start", {
+			prompt: queuedPrompt,
+			systemPrompt: "BASE",
+		}, harness.ctx) as { systemPrompt?: string } | undefined;
+		assert.equal(typeof before?.systemPrompt, "string");
+		assert.ok(before?.systemPrompt?.includes(`[PI GOAL ACTIVE goalId=${goal.id}]`));
+
+		const toolResultBeforeTurnStart = await emit(harness, "tool_call", { toolName: "read", args: { path: "README.md" } }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(toolResultBeforeTurnStart, undefined);
+
+		await emit(harness, "turn_start", "", harness.ctx);
+		const toolResultAfterTurnStart = await emit(harness, "tool_call", { toolName: "read", args: { path: "README.md" } }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(toolResultAfterTurnStart, undefined);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("active checkpoint prep tools do not poison same turn", async () => {
+	const harness = makeHarness({ idle: true, pendingMessages: false });
+	try {
+		const goal = await createGoal(harness, "Prep tools must not stop active checkpoint", "sisyphus");
+		const checkpoint = checkpointMessage(goal.id, goal.objective);
+
+		const before = await emit(harness, "before_agent_start", {
+			prompt: checkpoint.content,
+			systemPrompt: "BASE",
+		}, harness.ctx) as { systemPrompt?: string } | undefined;
+		assert.equal(typeof before?.systemPrompt, "string");
+		assert.ok(before?.systemPrompt?.includes(`[PI GOAL ACTIVE goalId=${goal.id}]`));
+
+		await emit(harness, "turn_start", "", harness.ctx);
+		const recall = await emit(harness, "tool_call", { toolName: "session_recall", args: { query: "active goal" } }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(recall, undefined);
+		const grep = await emit(harness, "tool_call", { toolName: "fff_multi_grep", args: { pattern: "turnStoppedFor" } }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(grep, undefined);
+		const read = await emit(harness, "tool_call", { toolName: "read", args: { path: "README.md" } }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(read, undefined);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test("post-stop marker from prior agent generation does not block active goal tools", async () => {
+	const harness = makeHarness({ idle: true, pendingMessages: false });
+	try {
+		const oldGoal = await createGoal(harness, "Prior turn marker must self-heal", "sisyphus");
+		await runCommand(harness, "sisyphus-set", "Replacement active goal after stop marker");
+		const goal = latestGoalSnapshot(harness.entries);
+		assert.ok(goal, "replacement goal missing");
+		assert.notEqual(goal.id, oldGoal.id);
+
+		const before = await emit(harness, "before_agent_start", {
+			prompt: "User resumed normal work",
+			systemPrompt: "BASE",
+		}, harness.ctx) as { systemPrompt?: string } | undefined;
+		assert.equal(typeof before?.systemPrompt, "string");
+		assert.ok(before?.systemPrompt?.includes(`[PI GOAL ACTIVE goalId=${goal.id}]`));
+
+		const allowedFff = await emit(harness, "tool_call", { toolName: "fff_multi_grep", args: { pattern: "turnStoppedFor" } }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(allowedFff, undefined);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+for (const scenario of [
+	{ name: "pause", stop: async (h: Harness) => runCommand(h, "goal-pause") },
+	{ name: "clear", stop: async (h: Harness) => runCommand(h, "goal-clear") },
+	{ name: "replace", stop: async (h: Harness) => runCommand(h, "sisyphus-set", "Replacement objective") },
+] as const) {
+	test(`goal extension stales queued checkpoint after ${scenario.name} before turn start`, async () => {
+		const harness = makeHarness({ idle: true, pendingMessages: false });
+		try {
+			const goal = await createGoal(harness, `Queued checkpoint ${scenario.name}`, "sisyphus");
+			const checkpoint = checkpointMessage(goal.id, goal.objective);
+
+			await scenario.stop(harness);
+			await sleep(20);
+
+			const current = latestGoalSnapshot(harness.entries);
+			if (scenario.name === "replace") {
+				assert.ok(current, "replacement goal missing");
+				assert.ok(harness.messages.length > 0, "replacement should queue new checkpoint");
+				for (const queued of harness.messages) {
+					const details = queued.message.details as { goalId?: unknown } | undefined;
+					assert.equal(details?.goalId, current.id);
+				}
+			} else {
+				assert.equal(harness.messages.length, 0);
+			}
+
+			const contextResult = await emit(harness, "context", { messages: [checkpoint] }) as { messages?: Array<{ content?: unknown; display?: boolean; details?: { kind?: string; goalId?: string; currentGoalId?: string | null; currentStatus?: string | null } }> } | undefined;
+			assert.ok(contextResult && contextResult.messages, "context result missing");
+			const stale = contextResult.messages[0];
+			assert.ok(stale, "stale message missing");
+			assert.equal(stale.display, false);
+			assert.equal(stale.details?.kind, "stale");
+			assert.equal(stale.details?.goalId, goal.id);
+			assert.equal(stale.details?.currentGoalId, latestGoalSnapshot(harness.entries)?.id ?? null);
+			assert.equal(stale.details?.currentStatus, latestGoalSnapshot(harness.entries)?.status ?? null);
+			assert.ok(String(stale.content ?? "").startsWith(`[GOAL STALE goalId=${goal.id}]`));
+
+			const before = await emit(harness, "before_agent_start", {
+				prompt: checkpoint.content,
+				systemPrompt: "BASE",
+			}, harness.ctx) as { systemPrompt?: string } | undefined;
+			assert.ok(before?.systemPrompt, "stale checkpoint prompt missing");
+			assert.ok(before?.systemPrompt.includes(`[GOAL STALE goalId=${goal.id}]`));
+			assert.equal(harness.aborted(), true);
+		} finally {
+			harness.cleanup();
+		}
+	});
+}
+
+for (const scenario of ["pause", "clear", "replace"] as const) {
+	test(`goal extension blocks work tools if ${scenario} happens after checkpoint turn starts`, async () => {
+		const harness = makeHarness({ idle: false, pendingMessages: false });
+		try {
+			const goal = await createGoal(harness, `Mid-turn checkpoint ${scenario}`, "sisyphus");
+			const checkpoint = checkpointMessage(goal.id, goal.objective);
+
+			const before = await emit(harness, "before_agent_start", {
+				prompt: checkpoint.content,
+				systemPrompt: "BASE",
+			}, harness.ctx) as { systemPrompt?: string } | undefined;
+			assert.equal(typeof before?.systemPrompt, "string");
+			assert.ok(before?.systemPrompt?.includes(`[PI GOAL ACTIVE goalId=${goal.id}]`));
+
+			await emit(harness, "turn_start", "", harness.ctx);
+
+			if (scenario === "pause") {
+				await runCommand(harness, "goal-pause");
+			} else if (scenario === "clear") {
+				await runCommand(harness, "goal-clear");
+			} else {
+				await runCommand(harness, "sisyphus-set", "Replacement objective");
+			}
+
+			const contextResult = await emit(harness, "context", { messages: [checkpoint] }) as { messages?: Array<{ content?: unknown; display?: boolean; details?: { kind?: string; goalId?: string; currentGoalId?: string | null; currentStatus?: string | null } }> } | undefined;
+			assert.ok(contextResult && contextResult.messages, "context result missing");
+			const stale = contextResult.messages[0];
+			assert.ok(stale, "stale message missing");
+			assert.equal(stale.details?.kind, "stale");
+			assert.equal(stale.details?.goalId, goal.id);
+			assert.equal(stale.details?.currentGoalId, latestGoalSnapshot(harness.entries)?.id ?? null);
+			assert.equal(stale.details?.currentStatus, latestGoalSnapshot(harness.entries)?.status ?? null);
+
+			const blockedQuestion = await emit(harness, "tool_call", { toolName: "goal_question", args: { question: "Should I keep going?" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
+			assert.equal(blockedQuestion?.block, true);
+			assert.match(blockedQuestion?.reason ?? "", /goal was already stopped earlier in this turn/);
+			assert.match(blockedQuestion?.reason ?? "", new RegExp(`goalId=${goal.id}`));
+
+			const blockedSubagent = await emit(harness, "tool_call", { toolName: "subagent", args: { task: "delegate stale work" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
+			assert.equal(blockedSubagent?.block, true);
+			assert.match(blockedSubagent?.reason ?? "", /goal was already stopped earlier in this turn/);
+			assert.match(blockedSubagent?.reason ?? "", new RegExp(`goalId=${goal.id}`));
+
+			const blockedUnknown = await emit(harness, "tool_call", { toolName: "unknown_extension_tool", args: { payload: "delegate stale work" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
+			assert.equal(blockedUnknown?.block, true);
+			assert.match(blockedUnknown?.reason ?? "", /goal was already stopped earlier in this turn/);
+			assert.match(blockedUnknown?.reason ?? "", new RegExp(`goalId=${goal.id}`));
+
+			const allowedGetGoal = await emit(harness, "tool_call", { toolName: "get_goal", args: {} }, harness.ctx) as { block?: boolean } | undefined;
+			assert.equal(allowedGetGoal, undefined);
+
+			const blocked = await emit(harness, "tool_call", { toolName: "read", args: { path: "README.md" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
+			assert.equal(blocked?.block, true);
+			assert.match(blocked?.reason ?? "", /goal was already stopped earlier in this turn/);
+			assert.match(blocked?.reason ?? "", new RegExp(`goalId=${goal.id}`));
+		} finally {
+			harness.cleanup();
+		}
+	});
+}
+
+test("goal extension stales queued checkpoint after unfocus before turn start", async () => {
+	const harness = makeHarness({ idle: true, pendingMessages: false });
+	try {
+		const goal = await createGoal(harness, "Queued checkpoint unfocus", "sisyphus");
+		const checkpoint = checkpointMessage(goal.id, goal.objective);
+		await sleep(20);
+
+		rmSync(path.join(harness.ctx.cwd, ".pi", "goals"), { recursive: true, force: true });
+		await emit(harness, "session_tree", {}, harness.ctx);
+
+		const contextResult = await emit(harness, "context", { messages: [checkpoint] }) as { messages?: Array<{ content?: unknown; display?: boolean; details?: { kind?: string; goalId?: string; currentGoalId?: string | null; currentStatus?: string | null } }> } | undefined;
+		assert.ok(contextResult && contextResult.messages, "context result missing");
+		const stale = contextResult.messages[0];
+		assert.ok(stale, "stale message missing");
+		assert.equal(stale.display, false);
+		assert.equal(stale.details?.kind, "stale");
+		assert.equal(stale.details?.goalId, goal.id);
+		assert.equal(stale.details?.currentGoalId, null);
+		assert.equal(stale.details?.currentStatus, null);
+		assert.ok(String(stale.content ?? "").startsWith(`[GOAL STALE goalId=${goal.id}]`));
+
+		const before = await emit(harness, "before_agent_start", {
+			prompt: checkpoint.content,
+			systemPrompt: "BASE",
+		}, harness.ctx) as { systemPrompt?: string } | undefined;
+		assert.ok(before?.systemPrompt, "stale checkpoint prompt missing");
+		assert.ok(before?.systemPrompt.includes(`[GOAL STALE goalId=${goal.id}]`));
+		assert.equal(harness.aborted(), true);
+
+		await emit(harness, "turn_start", "", harness.ctx);
+		const blockedQuestion = await emit(harness, "tool_call", { toolName: "goal_question", args: { question: "Should I keep going?" } }, harness.ctx) as { block?: boolean; reason?: string } | undefined;
+		assert.equal(blockedQuestion?.block, true);
+		assert.match(blockedQuestion?.reason ?? "", /goal was already stopped earlier in this turn/);
+		assert.match(blockedQuestion?.reason ?? "", new RegExp(`goalId=${goal.id}`));
+
+		const allowedGetGoal = await emit(harness, "tool_call", { toolName: "get_goal", args: {} }, harness.ctx) as { block?: boolean } | undefined;
+		assert.equal(allowedGetGoal, undefined);
+	} finally {
+		harness.cleanup();
+	}
+});


### PR DESCRIPTION
## Summary

Fix Goal-x active continuation checkpoint handling in two reviewable commits:

1. Guard stale/resumed checkpoints so paused/cleared/replaced/unfocused goals do not keep executing queued work, while active resumed goals remain actionable.
2. Treat delegated agent work as meaningful progress during active auto-continue checkpoints.

## Why

Goal-x can run long autonomous goals where real progress happens through tool calls and delegated agent work. Two edge cases could interrupt or misclassify that flow:

- stale checkpoints from paused/cleared/replaced goals could still be around later in the turn/session and needed stricter default-deny behavior
- delegated agent/control tools could be productive work but still leave the turn looking empty/no-progress to continuation logic

## Implementation

- Adds active checkpoint runtime state checks around queued continuation handling.
- Keeps stale/post-stop safeguards default-deny for work tools.
- Adds delegation/control tools to the progress tool set:
  - `subagent`
  - legacy `Agent`
  - `get_subagent_result`
  - `steer_subagent`
- Adds focused regression coverage in `tests/goal-extension.test.ts`.

## Verification

- `node --experimental-strip-types --test tests/goal-extension.test.ts`
- `npm run check`
