### PR TITLE
fix(widget): convert ms to seconds before passing to formatDuration for tool timing

### DIFF
--- a/extensions/widgets/goal-widget.ts
+++ b/extensions/widgets/goal-widget.ts
@@ -179,7 +179,7 @@ export function renderAuditorWidgetLines(progress: AuditorWidgetProgress, theme:
 			? truncateText(progress.currentToolArgs, Math.max(10, safeWidth - 24))
 			: "";
 		const toolDuration = progress.currentToolStartedAt
-			? ` ${theme.fg("dim", formatDuration(Date.now() - progress.currentToolStartedAt))}`
+			? ` ${theme.fg("dim", formatDuration(Math.floor((Date.now() - progress.currentToolStartedAt) / 1000)))}`
 			: "";
 		lines.push(branchLine(
 			theme,


### PR DESCRIPTION
## Bug Description

When the completion auditor sub-agent executes a tool (e.g. `bash`, `read`, `grep`), the **per-tool execution time** displayed in the auditor widget is roughly 1000x larger than the real duration.

For example, a `bash` command that actually took ~3 seconds is shown as `50m00s` instead of `3s`.

## Root Cause

In `extensions/widgets/goal-widget.ts` line ~170:

```typescript
const toolDuration = progress.currentToolStartedAt
    ? ` ${theme.fg("dim", formatDuration(Date.now() - progress.currentToolStartedAt))}`
    : "";
```

- `currentToolStartedAt` is set from `Date.now()` (milliseconds)
- `Date.now() - progress.currentToolStartedAt` is therefore a **millisecond delta** (e.g., 3000 for 3 seconds)
- But `formatDuration()` expects its argument in **seconds** (see `goal-core.ts: export function formatDuration(seconds: number)`)

The overall audit duration display on the same line intentionally does `/ 1000` before passing to `formatDuration`, confirming this is a unit mismatch:

```typescript
// formatDuration expects seconds, progress.elapsedMs is in milliseconds
const duration = formatDuration(Math.floor(progress.elapsedMs / 1000));  // correct
```

## Fix

Divide the millisecond delta by 1000 before passing to `formatDuration`, matching the pattern used by the overall duration display.

```diff
- formatDuration(Date.now() - progress.currentToolStartedAt)
+ formatDuration(Math.floor((Date.now() - progress.currentToolStartedAt) / 1000))
```

## Impact

Only the auditor widget's per-tool timing label is affected. The overall audit elapsed time and the goal's accumulated `activeSeconds` are calculated correctly.
