### PR TITLE
feat: add autoSelectSingleGoal setting (default: false)

### DIFF
--- a/extensions/goal-pool.ts
+++ b/extensions/goal-pool.ts
@@ -38,6 +38,7 @@ export function resolveSessionFocus(args: {
 	pool: Map<string, GoalRecord>;
 	focusEntry?: GoalFocusEntry | null;
 	legacyGoal?: GoalRecord | null;
+	autoSelectSingleGoal?: boolean;
 }): string | null {
 	const focusedGoalId = args.focusEntry?.focusedGoalId ?? null;
 	const focused = focusedGoalId ? focusedGoalFromPool(args.pool, focusedGoalId) : null;
@@ -52,8 +53,14 @@ export function resolveSessionFocus(args: {
 		args.pool.set(args.legacyGoal.id, cloneGoal(args.legacyGoal));
 		return args.legacyGoal.id;
 	}
-	const open = openGoalsFromPool(args.pool);
-	return open.length === 1 ? open[0]?.id ?? null : null;
+	// Auto-select single open goal only when explicitly enabled.
+	// Default (false): sessions start unfocused to prevent goals from
+	// bleeding across sessions that share the same .pi/goals/ directory.
+	if (args.autoSelectSingleGoal) {
+		const open = openGoalsFromPool(args.pool);
+		return open.length === 1 ? open[0]?.id ?? null : null;
+	}
+	return null;
 }
 
 export function goalSelectorLabel(goal: GoalRecord, focusedGoalId: string | null): string {

--- a/extensions/goal-settings.ts
+++ b/extensions/goal-settings.ts
@@ -26,6 +26,7 @@ export interface GoalSettings {
 	model?: string;
 	thinkingLevel?: ThinkingLevel;
 	disabled?: boolean;
+	autoSelectSingleGoal?: boolean;
 }
 
 export const PI_GOAL_SETTINGS_FILE_ENV = "PI_GOAL_SETTINGS_FILE";
@@ -41,6 +42,7 @@ const ALLOWED_SETTINGS_KEYS = new Set([
 	"thinkingLevel",
 	"thinking_level",
 	"disabled",
+	"autoSelectSingleGoal",
 ]);
 
 /**
@@ -105,6 +107,7 @@ export function parseGoalSettings(raw: unknown): GoalSettings {
 	if (model !== undefined) settings.model = model;
 	if (thinkingLevel !== undefined) settings.thinkingLevel = thinkingLevel;
 	if (record.disabled === true || record.disabled === "true") settings.disabled = true;
+	if (record.autoSelectSingleGoal === true || record.autoSelectSingleGoal === "true") settings.autoSelectSingleGoal = true;
 	return settings;
 }
 
@@ -136,6 +139,7 @@ export function loadGoalSettings(cwd: string, env: NodeJS.ProcessEnv = process.e
 		model: fileConfig.model,
 		thinkingLevel: fileConfig.thinkingLevel,
 		disabled: fileConfig.disabled,
+		autoSelectSingleGoal: fileConfig.autoSelectSingleGoal ?? false,
 	};
 }
 
@@ -176,6 +180,7 @@ export function saveGoalSettingsFileConfig(cwd: string, settings: GoalSettings):
 	if (clean.disableTasks) persisted.disableTasks = true;
 	if (clean.disableContracts) persisted.disableContracts = true;
 	if (clean.subtaskDepth !== undefined) persisted.subtaskDepth = clean.subtaskDepth;
+	if (settings.autoSelectSingleGoal === true) persisted.autoSelectSingleGoal = true;
 	fs.writeFileSync(configPath, `${JSON.stringify(persisted, null, 2)}\n`, "utf8");
 	return clean;
 }

--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -890,7 +890,8 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		if (legacyGoal && legacyGoal.status !== "complete") {
 			legacyGoal = sanitizeGoalPaths(ctx, mergeGoalPromptFromDisk(ctx, legacyGoal));
 		}
-		focusedGoalId = resolveSessionFocus({ pool: goalsById, focusEntry, legacyGoal });
+		const settings = loadGoalSettings(ctx.cwd);
+		focusedGoalId = resolveSessionFocus({ pool: goalsById, focusEntry, legacyGoal, autoSelectSingleGoal: settings.autoSelectSingleGoal });
 		if (!focusEntry && focusedGoalId) {
 			try {
 				appendFocusEntry(focusedGoalId, legacyGoal?.id === focusedGoalId ? "migrated" : "selected");


### PR DESCRIPTION
## Context

The README documents single-open auto-focus as intentional:

> "single-open auto-focus only happens when no focus entry exists at all"

This is a good default for single-session-per-folder workflows: you pause a goal, come back later, and it's ready.

It doesn't work for **multi-session-per-folder** workflows (e.g. an Obsidian vault where different sessions handle different tasks). In that case, every new session silently picks up stale goals from prior sessions with no way to opt out.

## What this PR does

Adds a new setting to `pi-goal-x-settings.json`:

```json
{
  "autoSelectSingleGoal": false
}
```

| Value | Behavior |
|-------|----------|
| `false` (default) | Sessions start unfocused. Goals are session-scoped. Use `/goal-focus` to choose. |
| `true` | Current behavior: auto-focus the single open goal when no focus entry exists. |

## Changes

- `goal-settings.ts`: add `autoSelectSingleGoal` to interface, parser, loader, saver
- `goal-pool.ts`: `resolveSessionFocus` checks the flag before auto-selecting
- `goal.ts`: `loadState` passes the flag from settings

## Default value rationale

Default is `false` because:
- The README's design principle is "user owns intent" — the user decides what to work on
- Defaulting to session-scoped respects this: the system doesn't assume you want an old goal
- Users who prefer per-folder behavior can opt in with one line in settings

This is a breaking change for users who rely on auto-select. If a non-breaking default is preferred, changing the default to `true` preserves current behavior while giving users an opt-out.

## Alternative considered

A `/goal-unfocus` command that writes a "no focus" entry. This would work within the existing architecture without a new setting, but requires the user to explicitly unfocus every new session. A setting is more ergonomic for users who always want session-scoped goals.
