### PR TITLE
fix(widget): preserve terminal scrollback while goals are active

### DIFF
--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -146,7 +146,6 @@ const GOAL_EVENT_ENTRY = "pi-goal-event";
 const GOAL_AUDIT_ENTRY = "pi-goal-audit-event";
 const COMPLETE_STATUS = "complete";
 const CONTINUATION_IDLE_RETRY_MS = 50;
-const STATUS_REFRESH_MS = 1000;
 /**
  * Tools that count as "real work" toward the active goal. If a non-tool-use
  * turn ends without any of these having been called, we DO NOT queue the next
@@ -410,8 +409,6 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	let continuationTimer: ReturnType<typeof setTimeout> | null = null;
 	let runningGoalId: string | null = null;
 	let terminalInputUnsubscribe: (() => void) | null = null;
-	let statusRefreshTimer: ReturnType<typeof setInterval> | null = null;
-	let statusRefreshCtx: ExtensionContext | null = null;
 	let auditProgress: AuditorWidgetProgress | null = null;
 	let auditAnimationTimer: ReturnType<typeof setInterval> | null = null;
 	let auditAbortController: AbortController | null = null;
@@ -525,37 +522,6 @@ export default function goalExtension(pi: ExtensionAPI): void {
 				// Ledger append failure should not block skip
 			}
 		}
-	}
-
-	function stopStatusRefresh(): void {
-		if (statusRefreshTimer) {
-			clearInterval(statusRefreshTimer);
-			statusRefreshTimer = null;
-		}
-		statusRefreshCtx = null;
-	}
-
-	function syncStatusRefresh(ctx: ExtensionContext): void {
-		if (!ctx.hasUI || state.goal?.status !== "active") {
-			stopStatusRefresh();
-			return;
-		}
-		statusRefreshCtx = ctx;
-		if (statusRefreshTimer) return;
-		statusRefreshTimer = setInterval(() => {
-			if (!statusRefreshCtx || state.goal?.status !== "active") {
-				stopStatusRefresh();
-				return;
-			}
-			const displayGoal = goalForDisplay();
-			if (displayGoal) {
-				const otherCount = otherOpenGoalCount(goalsById, focusedGoalId);
-				statusRefreshCtx.ui.setStatus("goal", `${footerStatus(displayGoal)}${otherCount > 0 ? ` (+${otherCount} open)` : ""}`);
-			}
-			// Live-tick the above-editor widget so duration/tokens update.
-			goalWidgetComponent?.update();
-		}, STATUS_REFRESH_MS);
-		statusRefreshTimer.unref?.();
 	}
 
 	function clearContinuationTimer(): void {
@@ -774,7 +740,10 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	 * Live above-editor widget for the active goal. Inspired by rpiv-todo's
 	 * TodoOverlay: register the widget once with a factory, read live state
 	 * via the closure at render time, and call `tui.requestRender()` on every
-	 * state change so the overlay refreshes without re-registration.
+	 * state change so the overlay refreshes without re-registration. Normal pi
+	 * renders still read current values through the closure; do not request
+	 * periodic renders just to tick elapsed time because terminal redraws pull
+	 * users out of scrollback while they review long goals and earlier context.
 	 *
 	 * Layout (sisyphus, running):
 	 *   ◆ Sisyphus  [▰▰▰▱▱] 3/5
@@ -805,7 +774,6 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		const totalOpen = openGoals().length;
 		if (!state.goal && totalOpen === 0) {
 			clearGoalWidget(ctx);
-			stopStatusRefresh();
 			return;
 		}
 		if (!state.goal) {
@@ -831,7 +799,6 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			} else {
 				goalWidgetComponent?.update();
 			}
-			stopStatusRefresh();
 			return;
 		}
 
@@ -859,12 +826,6 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			widgetRegistered = true;
 		} else {
 			goalWidgetComponent?.update();
-		}
-
-		if (state.goal.status === "complete") {
-			stopStatusRefresh();
-		} else {
-			syncStatusRefresh(ctx);
 		}
 	}
 
@@ -3585,7 +3546,6 @@ promptGuidelines: [
 	pi.on("session_shutdown", async (_event, ctx) => {
 		accountProgress(ctx);
 		clearContinuationTimer();
-		stopStatusRefresh();
 		terminalInputUnsubscribe?.();
 		terminalInputUnsubscribe = null;
 		if (state.goal) persist(ctx);


### PR DESCRIPTION
## Problem

An active goal starts a one-second status refresh that calls both `ui.setStatus()` and `goalWidgetComponent.update()`. Those forced TUI redraws pull the terminal viewport back to the bottom while the user is reading scrollback.

This is particularly disruptive when the confirmed goal itself is taller than the terminal: scrolling is required to review the full objective, but the viewport snaps away before it can be read. Pausing the goal stops the timer and makes scrollback usable, but users should not have to pause execution to inspect their goal or earlier context.

## Change

Remove the private periodic refresh and continue requesting goal-display renders on existing state-change paths.

The goal widget reads current values through closures, so it still recalculates elapsed time whenever pi naturally renders—for example during model streaming, tool activity, input, notifications, or resize. The change only stops `pi-goal-x` from forcing a redraw every second while the interface would otherwise be still. After an idle interval, the widget catches up on the next natural render. The footer status string catches up on the next goal UI update.

Throttling the timer would only make the interruption less frequent; any unsolicited redraw can still disrupt required reading. A comment records this constraint while clarifying that normal pi renders remain dynamic.

## Why this belongs in the extension today

Pi's TUI tracks its own rendered working viewport, but it cannot observe the terminal emulator's user-selected scrollback position. There is therefore no extension API that can safely update a bottom status line while guaranteeing that native terminal scrollback remains fixed. Preserving the timer would require a larger pi/TUI capability such as application-owned history scrolling or exposed viewport-follow state.

## Verification

- `npm test`: 379 passing, 0 failing
- `npm pack --dry-run`: passes
- `git diff --check`: passes
- `npm run check`: the changed extension typechecks, but the repository's full check remains blocked by two pre-existing test errors:
  - `tests/goal-tool-visibility.test.ts:258`: `completedAt` is absent from `GoalRecord`
  - `tests/goal-widget.test.ts:513`: `undefined` is not assignable to `GoalWidgetRecord | null`

## Environment reproduced

- `pi-goal-x` 0.19.0
- pi coding agent 0.80.6