### PR TITLE
fix(auditor): reuse parent ModelRuntime for nested completion audits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ with the `0.x` prefix indicating pre-1.0 development.
 
 ---
 
+## [0.18.9] — 2026-07-25
+
+### Fixed
+
+- **Completion auditor lost Cursor / extension-provider auth on pi 0.81+:** Nested
+  `createAgentSession` for the independent auditor still passed `modelRegistry`, but
+  pi 0.81+ only accepts `modelRuntime`. Combined with the auditor's empty resource
+  loader (no `pi-cursor-sdk`), that built a fresh runtime without the registered
+  `cursor` provider and failed with `No API key found for cursor` even when
+  `auth.json` had a Cursor API key. The auditor now reuses the parent session's
+  ModelRuntime (via `modelRegistry.runtime`) while still passing `modelRegistry`
+  for older SDKs.
+
 ## [0.18.8] — 2026-06-10
 
 ### Changed

--- a/extensions/goal-auditor.ts
+++ b/extensions/goal-auditor.ts
@@ -242,6 +242,30 @@ function resolveAuditorModel(ctx: ExtensionContext, config: GoalSettings): { mod
 	return { model: undefined, error: `Configured auditor model is ambiguous or unavailable: ${config.model}` };
 }
 
+/**
+ * Options that reuse the parent session's auth + registered providers for the nested auditor.
+ *
+ * Pi 0.81+ `createAgentSession` accepts `modelRuntime` (and ignores `modelRegistry`).
+ * ExtensionContext still exposes `modelRegistry`, which wraps the live ModelRuntime.
+ * Sharing that runtime keeps extension providers such as `pi-cursor-sdk`'s `cursor`
+ * provider (and its auth) available. Without this, the auditor builds a fresh runtime
+ * with an empty resource loader, so Cursor models fail with "No API key found for cursor"
+ * even when `~/.pi/agent/auth.json` has a Cursor key.
+ *
+ * Older SDKs still accept `modelRegistry`; pass both for compatibility.
+ */
+export function resolveAuditorSessionModelOptions(ctx: ExtensionContext): {
+	modelRegistry: ExtensionContext["modelRegistry"];
+	modelRuntime?: unknown;
+} {
+	const registry = ctx.modelRegistry as ExtensionContext["modelRegistry"] & { runtime?: unknown };
+	const runtime = registry?.runtime;
+	if (runtime) {
+		return { modelRegistry: ctx.modelRegistry, modelRuntime: runtime };
+	}
+	return { modelRegistry: ctx.modelRegistry };
+}
+
 function modelLabel(model: Model<any> | undefined): string | undefined {
 	return model ? `${model.provider}/${model.id}` : undefined;
 }
@@ -318,13 +342,13 @@ export async function runGoalCompletionAuditor(args: {
 			cwd: args.ctx.cwd,
 			model,
 			thinkingLevel,
-			modelRegistry: args.ctx.modelRegistry,
+			...resolveAuditorSessionModelOptions(args.ctx),
 			resourceLoader: makeAuditorResourceLoader(),
 			sessionManager: SessionManager.inMemory(args.ctx.cwd),
 			settingsManager: SettingsManager.inMemory({ compaction: { enabled: false } }),
 			tools: ["read", "grep", "find", "ls", "bash", REPORT_AUDITOR_PROGRESS_TOOL_NAME],
 			customTools: [reportProgressTool],
-		});
+		} as Parameters<typeof createAgentSession>[0]);
 		const unsubscribe = session.subscribe((event) => {
 			if (event.type === "tool_execution_start") {
 				progress.currentTool = event.toolName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-goal-x",
-  "version": "0.18.8",
+  "version": "0.18.9",
   "description": "Goal mode extension for pi: persistent long-running objectives, /goal-set drafting, Sisyphus prompt style, autoContinue, and an above-editor status overlay. Fork of @capyup/pi-goal.",
   "license": "MIT",
   "author": "pi-goal-x contributors",

--- a/tests/goal-auditor.test.ts
+++ b/tests/goal-auditor.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
 	buildGoalAuditorPrompt,
 	parseAuditorDecision,
+	resolveAuditorSessionModelOptions,
 	runGoalCompletionAuditor,
 } from "../extensions/goal-auditor.ts";
 import {
@@ -37,6 +38,48 @@ test("parseAuditorDecision requires explicit approval and lets disapproval win",
 	assert.deepEqual(parseAuditorDecision("Nope\n<disapproved/>"), { approved: false, disapproved: true });
 	assert.deepEqual(parseAuditorDecision("confused <approved/> <disapproved/>"), { approved: false, disapproved: true });
 	assert.deepEqual(parseAuditorDecision("no marker"), { approved: false, disapproved: false });
+});
+
+test("resolveAuditorSessionModelOptions shares parent ModelRuntime when available", () => {
+	const runtime = { id: "parent-runtime" };
+	const modelRegistry = { runtime, find: () => undefined };
+	const withRuntime = resolveAuditorSessionModelOptions({ modelRegistry } as any);
+	assert.equal(withRuntime.modelRuntime, runtime);
+	assert.equal(withRuntime.modelRegistry, modelRegistry);
+
+	const legacyRegistry = { find: () => undefined };
+	const legacy = resolveAuditorSessionModelOptions({ modelRegistry: legacyRegistry } as any);
+	assert.equal(legacy.modelRuntime, undefined);
+	assert.equal(legacy.modelRegistry, legacyRegistry);
+});
+
+test("runGoalCompletionAuditor passes parent modelRuntime into createSession", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-goal-auditor-test-"));
+	try {
+		const runtime = { id: "parent-runtime" };
+		const modelRegistry = { runtime, find: () => undefined, getAvailable: () => [] };
+		let captured: Record<string, unknown> | undefined;
+		const mockSession = {
+			abort: () => {},
+			subscribe: () => () => {},
+			prompt: async () => {},
+		};
+
+		await runGoalCompletionAuditor({
+			ctx: { cwd, model: undefined, modelRegistry } as any,
+			goal: goal(),
+			detailedSummary: "test",
+			createSession: async (opts: any) => {
+				captured = opts;
+				return { session: mockSession } as any;
+			},
+		});
+
+		assert.equal(captured?.modelRuntime, runtime);
+		assert.equal(captured?.modelRegistry, modelRegistry);
+	} finally {
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
 });
 
 test("parseGoalSettings supports provider/model and thinking_level aliases", () => {


### PR DESCRIPTION
## Summary
- Nested completion audits on pi 0.81+ were passing `modelRegistry` into `createAgentSession`, but that option was replaced by `modelRuntime`, so the auditor built a fresh runtime.
- Combined with the auditor's empty resource loader (no `pi-cursor-sdk`), Cursor models failed with `No API key found for cursor` even when `~/.pi/agent/auth.json` had a Cursor API key.
- Reuse the parent session's `ModelRuntime` via `modelRegistry.runtime`, while still passing `modelRegistry` for older SDKs.

## Test plan
- [x] `npm test` — new auditor tests pass (`resolveAuditorSessionModelOptions`, createSession handoff)
- [ ] On pi 0.81+ with `pi-cursor-sdk` and a Cursor key in `auth.json`, set auditor to `cursor/<model>` and run `complete_goal` — audit should authenticate instead of failing with missing Cursor API key
- [ ] Confirm non-Cursor auditors (e.g. anthropic/openai) still work