### PR TITLE
fix(goal): stop appending full state snapshots

### DIFF
--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -755,7 +755,6 @@ export default function goalExtension(pi: ExtensionAPI): void {
 				if (next) state.goal = next.status === "complete" ? archiveGoalFile(ctx, next) : writeActiveGoalFile(ctx, next);
 			}
 		}
-		pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
 		syncGoalTools();
 		if (ctx) updateUI(ctx);
 	}
@@ -764,7 +763,6 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		if (!state.goal || state.goal.status === "complete") return;
 		if (syncGoalPromptFromDisk(ctx)) {
 			state.goal = { ...state.goal, updatedAt: nowIso() };
-			pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
 		}
 		syncGoalTools();
 		updateUI(ctx);
@@ -2246,10 +2244,9 @@ ${objective}` : objective,
 				// minimal state update manually:
 				//   1) write the new record to disk authoritatively
 				//   2) update in-memory `goal` to the canonical post-write record
-				//   3) append the state entry and re-sync tools
+				//   3) re-sync tools
 				//   4) clear the tweak drafting gate so propose_goal_tweak can't be re-used
 				state.goal = writeActiveGoalFile(ctx, next);
-				pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
 				tweakDraftingFor = null;
 				// Reset autoContinue counter — plan changed, agent gets a fresh chain.
 				resetGetGoalNudgeState(state.goal.id);
@@ -2413,7 +2410,6 @@ ${objective}` : objective,
 					updatedAt: nowIso(),
 				};
 				state.goal = writeActiveGoalFile(ctx, state.goal);
-				pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
 				turnStoppedFor = state.goal?.id ?? null;
 				resetGetGoalNudgeState(state.goal?.id);
 				syncGoalTools();
@@ -2480,7 +2476,6 @@ ${objective}` : objective,
 					updatedAt: nowIso(),
 				};
 				state.goal = writeActiveGoalFile(ctx, state.goal);
-				pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
 				turnStoppedFor = state.goal?.id ?? null;
 				resetGetGoalNudgeState(state.goal?.id);
 				syncGoalTools();
@@ -2610,7 +2605,6 @@ ${objective}` : objective,
 						updatedAt: nowIso(),
 					};
 					state.goal = writeActiveGoalFile(ctx, state.goal);
-					pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
 					turnStoppedFor = state.goal?.id ?? null;
 					resetGetGoalNudgeState(state.goal?.id);
 					syncGoalTools();
@@ -2711,7 +2705,6 @@ ${objective}` : objective,
 				updatedAt: nowIso(),
 			};
 			state.goal = writeActiveGoalFile(ctx, state.goal);
-			pi.appendEntry(STATE_ENTRY, goalDetails(state.goal));
 			turnStoppedFor = state.goal?.id ?? null;
 			resetGetGoalNudgeState(state.goal?.id);
 			syncGoalTools();

--- a/tests/session-state-growth.test.ts
+++ b/tests/session-state-growth.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("../extensions/goal.ts", import.meta.url), "utf8");
+
+test("goal updates do not append full state snapshots to the session", () => {
+	assert.doesNotMatch(source, /appendEntry\(STATE_ENTRY/);
+	assert.match(source, /entry\.customType === STATE_ENTRY/);
+});


### PR DESCRIPTION
## Problem

`pi-goal-x` appends the complete goal record to the pi session on every persistence event. A four-day session accumulated 8,842 `pi-goal-state` entries totaling 266 MB in a 332 MB JSONL file. Retaining those duplicate objectives and task lists eventually exhausted V8's roughly 4.3 GB heap and crashed pi.

## Fix

Keep goal state in the existing authoritative goal files and stop appending full state snapshots to sessions. Legacy snapshot reads remain in place for migration, while new sessions continue to store the small branch-local focus record.

## Verification

- `npm test`: 380 passed, 0 failed
- Added a regression test that rejects new `STATE_ENTRY` append sites while preserving legacy reads
- `git diff --check`: clean

`npm run check` still reports two pre-existing type errors in `tests/goal-tool-visibility.test.ts` and `tests/goal-widget.test.ts`; this change does not touch those files.
