### PR TITLE
fix: defer syncGoalTools() out of top-level extension load

### DIFF
--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -3267,8 +3267,6 @@ promptGuidelines: [
 		},
 	}));
 
-	syncGoalTools();
-
 	pi.on("context", async (event): Promise<{ messages: typeof event.messages } | undefined> => {
 		let changed = false;
 		const latestGoalEventIndex = new Map<string, number>();
@@ -3407,6 +3405,7 @@ promptGuidelines: [
 	});
 
 	pi.on("session_start", async (event, ctx) => {
+		syncGoalTools();
 		loadState(ctx);
 		syncTerminalInputPause(ctx);
 		if (event.reason === "resume" && !state.goal && openGoals().length > 1 && ctx.hasUI) {


### PR DESCRIPTION
Fixes a spurious error logged on every session start:

```
[pi-goal] syncGoalTools error: Extension runtime not initialized. Action methods cannot be called during extension loading.
```

`syncGoalTools()` was called at the top level of `goalExtension()`, before pi's extension runtime finishes initializing, so `pi.getActiveTools()`/`setActiveTools()` (guarded "Action methods") always threw. Harmless in practice — the internal `try/catch` swallows it, and `before_agent_start` already re-syncs correctly before every real turn — but noisy.

Moved the call into `session_start`, where the runtime is ready. No behavior change.

**Verified:** `npm test`: 379/379 passing, 0 regressions. `npm run check`: same 2 pre-existing unrelated errors as `main`.
