### PR TITLE
feat: add session-local /goal-unfocus command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ with the `0.x` prefix indicating pre-1.0 development.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`/goal-unfocus` command:** Detaches the current session from its focused goal,
+  stops that session's continuation state, and records a session-local cleared focus
+  without pausing, modifying, or archiving the shared goal in `.pi/goals/`.
+
+### Documentation
+
+- Clarified that `autoSelectSingleGoal: false` keeps focus—not the shared project goal
+  files—session-scoped.
+
 ## [0.20.1] — 2026-08-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ with the `0.x` prefix indicating pre-1.0 development.
 ### Added
 
 - **`/goal-unfocus` command:** Detaches the current session from its focused goal,
-  stops that session's continuation state, and records a session-local cleared focus
-  without pausing, modifying, or archiving the shared goal in `.pi/goals/`.
+  stops that session's continuation state, and records a session-local null focus entry
+  with reason `unfocused` without pausing, modifying, or archiving the shared goal in
+  `.pi/goals/`.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ with the `0.x` prefix indicating pre-1.0 development.
 ### Added
 
 - **`/goal-unfocus` command:** Detaches the current session from its focused goal,
-  stops that session's continuation state, and records a session-local null focus entry
-  with reason `unfocused` without pausing, modifying, or archiving the shared goal in
-  `.pi/goals/`.
+  stops or aborts that session's continuation and in-flight goal work, and records a
+  session-local null focus entry with reason `unfocused` without pausing, modifying,
+  archiving, or writing a focus event for the shared goal in `.pi/goals/`. Pending
+  audits and confirmation flows revalidate session focus before applying results.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ If the objective is already final and should start immediately, use:
 /goal-status            Show focused goal state
 /goal-list              List all open goals in .pi/goals/
 /goal-focus             Choose this session's focused goal
+/goal-unfocus           Unfocus this session without modifying the shared goal
 /goal-tweak <change>    Draft a revision to the focused active/paused goal
 /goal-pause             Pause the focused active goal
 /goal-resume            Resume a paused goal
@@ -104,7 +105,7 @@ Pressing `Esc` or aborting an active run pauses the goal so it does not remain f
 - **Branch-local focus**: because focus is reconstructed from the current session branch, `/tree` navigation can restore a different focus for a different branch.
 - **One continuation chain**: auto-continue only schedules work for the focused goal in the current session.
 
-Creating a goal with `/goals`, `/sisyphus`, `/goals-set`, or `/sisyphus-set` no longer clears other open goals. It creates a new active goal file and focuses it. Use `/goal-list` to inspect open goals and `/goal-focus` to switch the session focus. If the latest focus entry explicitly clears focus, or points at a missing/stale goal, a remaining single open goal is not auto-focused. By default (`autoSelectSingleGoal: false`) sessions start unfocused so goals stay session-scoped — useful when multiple sessions share the same `.pi/goals/` directory. Set `autoSelectSingleGoal: true` to restore the old behavior where a single open goal is auto-focused when no focus entry exists at all. If multiple open goals exist and the session has no valid focus, `/goal-resume`, `/goal-clear`, `/goal-abort`, `/goal-pause`, and `/goal-tweak` ask the user to choose a goal instead of acting on all of them.
+Creating a goal with `/goals`, `/sisyphus`, `/goals-set`, or `/sisyphus-set` no longer clears other open goals. It creates a new active goal file and focuses it. Use `/goal-list` to inspect open goals, `/goal-focus` to switch the session focus, and `/goal-unfocus` to detach the current session without pausing, modifying, or archiving the shared goal. If the latest focus entry explicitly clears focus, or points at a missing/stale goal, a remaining single open goal is not auto-focused. By default (`autoSelectSingleGoal: false`) sessions start unfocused so focus stays session-scoped — useful when multiple sessions share the same `.pi/goals/` directory. Set `autoSelectSingleGoal: true` to restore the old behavior where a single open goal is auto-focused when no focus entry exists at all. If multiple open goals exist and the session has no valid focus, `/goal-resume`, `/goal-clear`, `/goal-abort`, `/goal-pause`, and `/goal-tweak` ask the user to choose a goal instead of acting on all of them.
 
 ## Agent tools
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If the objective is already final and should start immediately, use:
 /goal-status            Show focused goal state
 /goal-list              List all open goals in .pi/goals/
 /goal-focus             Choose this session's focused goal
-/goal-unfocus           Unfocus this session without modifying the shared goal
+/goal-unfocus           Stop this session's goal work without modifying the shared goal
 /goal-tweak <change>    Draft a revision to the focused active/paused goal
 /goal-pause             Pause the focused active goal
 /goal-resume            Resume a paused goal
@@ -105,7 +105,7 @@ Pressing `Esc` or aborting an active run pauses the goal so it does not remain f
 - **Branch-local focus**: because focus is reconstructed from the current session branch, `/tree` navigation can restore a different focus for a different branch.
 - **One continuation chain**: auto-continue only schedules work for the focused goal in the current session.
 
-Creating a goal with `/goals`, `/sisyphus`, `/goals-set`, or `/sisyphus-set` no longer clears other open goals. It creates a new active goal file and focuses it. Use `/goal-list` to inspect open goals, `/goal-focus` to switch the session focus, and `/goal-unfocus` to detach the current session without pausing, modifying, or archiving the shared goal. If the latest focus entry explicitly clears focus, or points at a missing/stale goal, a remaining single open goal is not auto-focused. By default (`autoSelectSingleGoal: false`) sessions start unfocused so focus stays session-scoped — useful when multiple sessions share the same `.pi/goals/` directory. Set `autoSelectSingleGoal: true` to restore the old behavior where a single open goal is auto-focused when no focus entry exists at all. If multiple open goals exist and the session has no valid focus, `/goal-resume`, `/goal-clear`, `/goal-abort`, `/goal-pause`, and `/goal-tweak` ask the user to choose a goal instead of acting on all of them.
+Creating a goal with `/goals`, `/sisyphus`, `/goals-set`, or `/sisyphus-set` no longer clears other open goals. It creates a new active goal file and focuses it. Use `/goal-list` to inspect open goals, `/goal-focus` to switch the session focus, and `/goal-unfocus` to detach the current session without pausing, modifying, archiving, or recording a project-ledger focus change for the shared goal. Unfocus also aborts in-flight work and audits owned by that session; asynchronous lifecycle results are discarded if focus changed while they were pending. If the latest focus entry explicitly clears focus, or points at a missing/stale goal, a remaining single open goal is not auto-focused and resume does not prompt to replace that explicit choice. By default (`autoSelectSingleGoal: false`) sessions start unfocused so focus stays session-scoped — useful when multiple sessions share the same `.pi/goals/` directory. Set `autoSelectSingleGoal: true` to restore the old behavior where a single open goal is auto-focused when no focus entry exists at all. If multiple open goals exist and the session has no valid focus, `/goal-resume`, `/goal-clear`, `/goal-abort`, `/goal-pause`, and `/goal-tweak` ask the user to choose a goal instead of acting on all of them.
 
 ## Agent tools
 

--- a/docs/agent-flow-design.md
+++ b/docs/agent-flow-design.md
@@ -140,6 +140,7 @@ ledger append 是 best-effort：写入失败不应该让用户的生命周期动
 | `/sisyphus-set <objective>` | 直接创建并启动 Sisyphus goal，不进入 draft discussion。 |
 | `/goal-list` | 列出 `.pi/goals/` 下所有 open goals。 |
 | `/goal-focus` | 让用户选择当前 session focus。 |
+| `/goal-unfocus` | 只清除当前 session focus 和 continuation state，不暂停、修改或归档共享 goal。 |
 | `/goal-status` / `/goal` | 显示 focused goal 状态和其他 open goals 提示。 |
 | `/goal-tweak <change>` | 修改 focused goal，但也要先走 tweak drafting。 |
 | `/goal-pause` | 用户暂停 focused active goal。 |

--- a/docs/agent-flow-design.md
+++ b/docs/agent-flow-design.md
@@ -77,6 +77,8 @@ let focusedGoalId: string | null = null;
 | `goalWorkToolCalledThisTurn` | empty-turn guard：只有本 turn 做了有意义工作才继续 auto-continue。 |
 | `turnStoppedFor` | pause/abort/complete/tweak 后阻止同一 turn 继续乱调用工具。 |
 | `postCompactReminderPending` | session compact 后给下一轮 agent 注入 deterministic resync prompt。 |
+| `focusRevision` | session focus 改变时递增；异步 completion/tweak/task proposal 在写入前必须验证 revision，避免 unfocus 后迟到结果修改共享 goal。 |
+| `hasExplicitSessionFocus` | 区分“从未选择 focus”和显式 null focus，保证 resume/tree 不覆盖 `/goal-unfocus`。 |
 | `activeGetGoalTurnsByGoalId` | 统计重复 `get_goal`，用于 soft nudge，不是 hard block。 |
 
 ## 4. 持久化：Goal 文件与 Ledger
@@ -140,7 +142,7 @@ ledger append 是 best-effort：写入失败不应该让用户的生命周期动
 | `/sisyphus-set <objective>` | 直接创建并启动 Sisyphus goal，不进入 draft discussion。 |
 | `/goal-list` | 列出 `.pi/goals/` 下所有 open goals。 |
 | `/goal-focus` | 让用户选择当前 session focus。 |
-| `/goal-unfocus` | 只清除当前 session focus 和 continuation state，不暂停、修改或归档共享 goal。 |
+| `/goal-unfocus` | 清除当前 session focus，终止该 session 的 continuation/in-flight work/audit，并用 revision gate 丢弃迟到异步结果；不暂停、修改、归档共享 goal，也不写 project-global focus event。 |
 | `/goal-status` / `/goal` | 显示 focused goal 状态和其他 open goals 提示。 |
 | `/goal-tweak <change>` | 修改 focused goal，但也要先走 tweak drafting。 |
 | `/goal-pause` | 用户暂停 focused active goal。 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ Because this is stored with `pi.appendEntry("pi-goal-focus", ...)`, it is sessio
 2. If the latest focus entry explicitly has `focusedGoalId: null`, or points at a missing/stale goal, remain unfocused.
 3. If no focus entry exists, merge a compatible legacy `pi-goal-state { version: 3, goal }` goal and focus it. If disk already has the same id, the disk record wins and the legacy session record only supplies focus.
 4. If no focus entry exists and `autoSelectSingleGoal` is enabled, auto-focus the sole open goal for compatibility. The default is disabled.
-5. Otherwise remain unfocused until the user explicitly selects a goal. `/goal-unfocus` appends a null focus entry so the current session stays detached without modifying the shared goal.
+5. Otherwise remain unfocused until the user explicitly selects a goal. `/goal-unfocus` appends a null focus entry so the current session stays detached without modifying the shared goal or appending a project-global focus event. Resume and tree reconstruction preserve that explicit null focus.
 
 Focus is human-owned. No agent tool can switch focus. Lifecycle tools operate only on the focused goal.
 
@@ -138,7 +138,7 @@ A deprecated optional `draftId` parameter is accepted for compatibility but igno
 - `/goals-set` and `/sisyphus-set` directly create and focus a new open goal from the supplied objective.
 - `/goal-list` prints all open goals with id, status, mode, usage, objective title, path, and a focus marker.
 - `/goal-focus` uses `ctx.ui.select` when multiple goals are open and updates only session focus.
-- `/goal-unfocus` writes a null session focus entry, clears that session's continuation/runtime state, and leaves the shared active goal file unchanged.
+- `/goal-unfocus` writes a null session focus entry, clears continuation/runtime state, aborts in-flight work and audits for that session, and leaves the shared active goal file and project-global focus ledger unchanged. Focus revision tokens prevent pending completion, tweak, and task-list confirmation results from mutating a goal after detachment.
 - `/goal-status` and `/goal` show the focused goal plus an `other open goals` hint.
 - `/goal-resume` resumes the focused paused goal; when unfocused with multiple open goals, it asks the user to choose. Choosing an already active goal only focuses it.
 - `/goal-clear` and `/goal-abort` archive only the focused/selected goal and never clear the whole pool at once.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,6 +68,7 @@ Reusable logic is split into smaller modules:
   ├─ multiple open goals
   │    ├─ /goal-list shows the project goal pool
   │    ├─ /goal-focus chooses the session focus
+  │    ├─ /goal-unfocus clears only the session focus and leaves the shared goal open
   │    └─ unfocused sessions guide the user to choose instead of letting the agent decide
   │
   └─ /goal-clear or /goal-abort archives the focused goal or cancels drafting
@@ -89,7 +90,7 @@ Session focus is separate. Focus changes append a custom session entry:
 {
   version: 1,
   focusedGoalId: string | null,
-  reason: "created" | "selected" | "resumed" | "completed" | "cleared" | "aborted" | "migrated"
+  reason: "created" | "selected" | "unfocused" | "resumed" | "completed" | "cleared" | "aborted" | "migrated"
 }
 ```
 
@@ -98,8 +99,8 @@ Because this is stored with `pi.appendEntry("pi-goal-focus", ...)`, it is sessio
 1. Use a valid focused id from the latest focus entry.
 2. If the latest focus entry explicitly has `focusedGoalId: null`, or points at a missing/stale goal, remain unfocused.
 3. If no focus entry exists, merge a compatible legacy `pi-goal-state { version: 3, goal }` goal and focus it. If disk already has the same id, the disk record wins and the legacy session record only supplies focus.
-4. If no focus entry exists and exactly one open goal exists, auto-focus it for compatibility.
-5. If multiple open goals exist and no valid focus exists, remain unfocused until `/goal-focus`, `/goal-resume`, `/goal-clear`, `/goal-abort`, `/goal-pause`, or `/goal-tweak` asks the user to choose.
+4. If no focus entry exists and `autoSelectSingleGoal` is enabled, auto-focus the sole open goal for compatibility. The default is disabled.
+5. Otherwise remain unfocused until the user explicitly selects a goal. `/goal-unfocus` appends a null focus entry so the current session stays detached without modifying the shared goal.
 
 Focus is human-owned. No agent tool can switch focus. Lifecycle tools operate only on the focused goal.
 
@@ -137,6 +138,7 @@ A deprecated optional `draftId` parameter is accepted for compatibility but igno
 - `/goals-set` and `/sisyphus-set` directly create and focus a new open goal from the supplied objective.
 - `/goal-list` prints all open goals with id, status, mode, usage, objective title, path, and a focus marker.
 - `/goal-focus` uses `ctx.ui.select` when multiple goals are open and updates only session focus.
+- `/goal-unfocus` writes a null session focus entry, clears that session's continuation/runtime state, and leaves the shared active goal file unchanged.
 - `/goal-status` and `/goal` show the focused goal plus an `other open goals` hint.
 - `/goal-resume` resumes the focused paused goal; when unfocused with multiple open goals, it asks the user to choose. Choosing an already active goal only focuses it.
 - `/goal-clear` and `/goal-abort` archive only the focused/selected goal and never clear the whole pool at once.

--- a/extensions/goal-record.ts
+++ b/extensions/goal-record.ts
@@ -2,7 +2,7 @@ export type GoalStatus = "active" | "paused" | "complete";
 export type StopReason = "user" | "agent";
 export type GoalEventKind = "checkpoint" | "stale" | "drafting";
 export type DraftingFocus = "goal" | "sisyphus";
-export type GoalFocusReason = "created" | "selected" | "resumed" | "completed" | "cleared" | "aborted" | "migrated";
+export type GoalFocusReason = "created" | "selected" | "unfocused" | "resumed" | "completed" | "cleared" | "aborted" | "migrated";
 
 export type TaskStatus = "pending" | "complete" | "skipped";
 
@@ -146,7 +146,7 @@ export function normalizeGoalFocusEntry(value: unknown): GoalFocusEntry | null {
 		? safeIdPart(raw.focusedGoalId)
 		: null;
 	const reason: GoalFocusReason =
-		raw.reason === "created" || raw.reason === "selected" || raw.reason === "resumed" || raw.reason === "completed" || raw.reason === "cleared" || raw.reason === "aborted" || raw.reason === "migrated"
+		raw.reason === "created" || raw.reason === "selected" || raw.reason === "unfocused" || raw.reason === "resumed" || raw.reason === "completed" || raw.reason === "cleared" || raw.reason === "aborted" || raw.reason === "migrated"
 			? raw.reason
 			: "selected";
 	return { version: 1, focusedGoalId, reason };

--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -388,9 +388,39 @@ function isMeaningfulProgressToolCall(toolName: string, args: unknown): boolean 
 
 // ---------- extension entry point ----------
 
-export default function goalExtension(pi: ExtensionAPI): void {
+export default function goalExtension(
+	pi: ExtensionAPI,
+	dependencies: { runCompletionAuditor?: typeof runGoalCompletionAuditor } = {},
+): void {
 	let goalsById = new Map<string, GoalRecord>();
 	let focusedGoalId: string | null = null;
+	let focusRevision = 0;
+	let hasExplicitSessionFocus = false;
+
+	function assignFocusedGoalId(next: string | null): void {
+		if (focusedGoalId !== next) focusRevision += 1;
+		focusedGoalId = next;
+	}
+
+	function focusedOperationToken(goalId: string): { goalId: string; revision: number } {
+		return { goalId, revision: focusRevision };
+	}
+
+	function isFocusedOperationCurrent(token: { goalId: string; revision: number }): boolean {
+		return focusedGoalId === token.goalId && focusRevision === token.revision;
+	}
+
+	function focusedOperationCancelledResult(action: string, token: { goalId: string; revision: number }) {
+		return {
+			content: [{
+				type: "text" as const,
+				text: `${action} cancelled because goal ${token.goalId} is no longer focused in this session. The shared goal was not modified.`,
+			}],
+			details: goalDetails(state.goal),
+			terminate: true,
+		};
+	}
+
 	const state = {
 		get goal(): GoalRecord | null {
 			return focusedGoalFromPool(goalsById, focusedGoalId);
@@ -398,11 +428,11 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		set goal(next: GoalRecord | null) {
 			if (next) {
 				goalsById.set(next.id, next);
-				focusedGoalId = next.id;
+				assignFocusedGoalId(next.id);
 				return;
 			}
 			if (focusedGoalId) goalsById.delete(focusedGoalId);
-			focusedGoalId = null;
+			assignFocusedGoalId(null);
 		},
 	};
 	let continuationQueuedFor: string | null = null;
@@ -602,11 +632,11 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			if (current && !current.activePath) {
 				goalsById = fresh;
 				goalsById.set(current.id, current);
-				focusedGoalId = current.id;
+				assignFocusedGoalId(current.id);
 				return true;
 			}
 			goalsById = fresh;
-			focusedGoalId = null;
+			assignFocusedGoalId(null);
 			clearStoppedRuntimeState();
 			if (current) resetGetGoalNudgeState(current.id);
 			if (tweakDraftingFor !== null) tweakDraftingFor = null;
@@ -619,19 +649,25 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			: diskGoal;
 		goalsById = fresh;
 		goalsById.set(reconciled.id, reconciled);
-		focusedGoalId = reconciled.id;
+		assignFocusedGoalId(reconciled.id);
 		if (reconciled.status !== "active" || !reconciled.autoContinue) clearContinuationState();
 		if (reconciled.status !== "active") clearActiveAccounting();
 		return true;
 	}
 
 	function appendFocusEntry(goalId: string | null, reason: GoalFocusReason): void {
+		hasExplicitSessionFocus = true;
 		pi.appendEntry(FOCUS_ENTRY, goalFocusDetails(goalId, reason));
 	}
 
-	function setFocusedGoalId(goalId: string | null, ctx: ExtensionContext, reason: GoalFocusReason): void {
+	function setFocusedGoalId(
+		goalId: string | null,
+		ctx: ExtensionContext,
+		reason: GoalFocusReason,
+		opts: { recordLedger?: boolean } = {},
+	): void {
 		const previousGoalId = focusedGoalId;
-		focusedGoalId = goalId && goalsById.has(goalId) ? goalId : null;
+		assignFocusedGoalId(goalId && goalsById.has(goalId) ? goalId : null);
 		if (previousGoalId !== focusedGoalId) {
 			clearContinuationState();
 			clearActiveAccounting();
@@ -642,9 +678,9 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		appendFocusEntry(focusedGoalId, reason);
 		// Append ledger event for focus changes
 		try {
-			if (focusedGoalId) {
+			if (opts.recordLedger !== false && focusedGoalId) {
 				appendGoalEvent(ctx, { type: "goal_focused", goalId: focusedGoalId, reason, at: nowIso() });
-			} else if (previousGoalId) {
+			} else if (opts.recordLedger !== false && previousGoalId) {
 				appendGoalEvent(ctx, { type: "goal_unfocused", reason, at: nowIso() });
 			}
 		} catch {
@@ -657,7 +693,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	function updateFocusedGoal(next: GoalRecord, ctx: ExtensionContext, shouldPersist = true): void {
 		const previousGoalId = focusedGoalId;
 		goalsById.set(next.id, next);
-		focusedGoalId = next.id;
+		assignFocusedGoalId(next.id);
 		if (previousGoalId !== focusedGoalId) {
 			resetGetGoalNudgeState(previousGoalId);
 			resetGetGoalNudgeState(focusedGoalId);
@@ -675,7 +711,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	function removeFocusedGoal(ctx: ExtensionContext, reason: GoalFocusReason): void {
 		const previousGoalId = focusedGoalId;
 		if (focusedGoalId) goalsById.delete(focusedGoalId);
-		focusedGoalId = null;
+		assignFocusedGoalId(null);
 		clearStoppedRuntimeState();
 		resetGetGoalNudgeState(previousGoalId);
 		appendFocusEntry(null, reason);
@@ -859,7 +895,9 @@ export default function goalExtension(pi: ExtensionAPI): void {
 
 	function loadState(ctx: ExtensionContext): void {
 		goalsById = readActiveGoalPool(ctx);
-		focusedGoalId = null;
+		focusRevision += 1; // Session reload/tree navigation invalidates pending async focus operations.
+		assignFocusedGoalId(null);
+		hasExplicitSessionFocus = false;
 		let focusEntry: GoalFocusEntry | null = null;
 		let legacyGoal: GoalRecord | null = null;
 		let legacyStateSeen = false;
@@ -880,7 +918,8 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			legacyGoal = sanitizeGoalPaths(ctx, mergeGoalPromptFromDisk(ctx, legacyGoal));
 		}
 		const settings = loadGoalSettings(ctx.cwd);
-		focusedGoalId = resolveSessionFocus({ pool: goalsById, focusEntry, legacyGoal, autoSelectSingleGoal: settings.autoSelectSingleGoal });
+		hasExplicitSessionFocus = focusEntry !== null;
+		assignFocusedGoalId(resolveSessionFocus({ pool: goalsById, focusEntry, legacyGoal, autoSelectSingleGoal: settings.autoSelectSingleGoal }));
 		if (!focusEntry && focusedGoalId) {
 			try {
 				appendFocusEntry(focusedGoalId, legacyGoal?.id === focusedGoalId ? "migrated" : "selected");
@@ -1038,7 +1077,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 				state.goal = null;
 				if (focusedGoalId === prevId) {
 					goalsById.delete(prevId);
-					focusedGoalId = null;
+					assignFocusedGoalId(null);
 				}
 				clearStoppedRuntimeState();
 				syncGoalTools();
@@ -1504,12 +1543,25 @@ Verification contract:
 	}
 
 	function unfocusGoalCommand(ctx: ExtensionContext): void {
+		const runtimeGoalId = state.goal?.id ?? runningGoalId ?? checkpointGoalId;
 		reconcileFocusedGoalFromDisk(ctx);
 		const current = state.goal;
-		setFocusedGoalId(null, ctx, "unfocused");
+		const detachedGoalId = current?.id ?? runtimeGoalId;
+		let wasBusy = false;
+		try {
+			wasBusy = !ctx.isIdle();
+		} catch {}
+		if (detachedGoalId && wasBusy) turnStoppedFor = { goalId: detachedGoalId, turnSeq };
+		setFocusedGoalId(null, ctx, "unfocused", { recordLedger: false });
 		runningGoalId = null;
 		checkpointGoalId = null;
 		postCompactReminderPending = false;
+		if (auditAbortController) auditAbortController.abort();
+		if (detachedGoalId && wasBusy) {
+			try {
+				ctx.abort?.();
+			} catch {}
+		}
 		if (!current) {
 			const openCount = openGoals().length;
 			ctx.ui.notify(openCount > 0 ? buildUnfocusedOpenGoalsSummary(openCount) : detailedSummary(null), "info");
@@ -2261,6 +2313,7 @@ ${objective}` : objective,
 			});
 
 			const headless = shouldAutoConfirmProposal({ hasUI: ctx.hasUI, autoConfirmEnv: process.env.PI_GOAL_AUTO_CONFIRM });
+			const tweakFocus = focusedOperationToken(state.goal.id);
 
 			let decision: { decision: "confirm" | "continue"; auditorEnabled: boolean };
 			if (headless) {
@@ -2276,6 +2329,9 @@ ${objective}` : objective,
 						details: goalDetails(state.goal),
 					};
 				}
+			}
+			if (!isFocusedOperationCurrent(tweakFocus)) {
+				return focusedOperationCancelledResult("Goal tweak", tweakFocus);
 			}
 
 			if (decision.decision === "confirm") {
@@ -2439,6 +2495,7 @@ ${objective}` : objective,
 			}
 
 			const auditTarget = mergeGoalPromptFromDisk(ctx, state.goal);
+			const completionFocus = focusedOperationToken(auditTarget.id);
 			// Append ledger: completion requested
 			try {
 				appendGoalEvent(ctx, {
@@ -2583,6 +2640,9 @@ ${objective}` : objective,
 				display: true,
 				details: { phase: "started", goalId: auditTarget.id, auditor: auditorLabel },
 			}, { triggerTurn: true });
+			if (!isFocusedOperationCurrent(completionFocus)) {
+				return focusedOperationCancelledResult("Goal completion", completionFocus);
+			}
 			// Append ledger: audit started
 			try {
 				appendGoalEvent(ctx, {
@@ -2617,16 +2677,17 @@ ${objective}` : objective,
 
 			// Create a dedicated AbortController for the audit so it can be interrupted via Escape
 			auditAbortController?.abort(); // Clean up any stale controller
-			auditAbortController = new AbortController();
+			const completionAuditController = new AbortController();
+			auditAbortController = completionAuditController;
 
-			const auditor = await runGoalCompletionAuditor({
+			const auditor = await (dependencies.runCompletionAuditor ?? runGoalCompletionAuditor)({
 				ctx,
 				goal: auditTarget,
 				completionSummary: params.completionSummary,
 				detailedSummary: detailedSummary(auditTarget),
 				verificationSummary: params.verificationSummary,
 				settings: loadGoalSettings(ctx.cwd),
-				signal: auditAbortController.signal,
+				signal: completionAuditController.signal,
 				onProgress: (progress) => {
 					auditProgress = {
 						...progress,
@@ -2636,9 +2697,14 @@ ${objective}` : objective,
 				},
 			});
 			// Clear abort controller — audit finished on its own
-			auditAbortController = null;
+			if (auditAbortController === completionAuditController) auditAbortController = null;
 			// Clear auditor progress display
 			stopAuditAnimation();
+			if (!isFocusedOperationCurrent(completionFocus)) {
+				auditProgress = null;
+				goalWidgetComponent?.invalidate();
+				return focusedOperationCancelledResult("Goal completion", completionFocus);
+			}
 
 			// If the audit was aborted by the user (Esc), show a TUI dialog letting
 			// the user choose: mark complete without audit, or continue working.
@@ -2650,6 +2716,9 @@ ${objective}` : objective,
 				showingEscapeDialog = true;
 				const userChoice: EscapeDialogResult = await showEscapeDialog(ctx, auditTarget.objective);
 				showingEscapeDialog = false;
+				if (!isFocusedOperationCurrent(completionFocus)) {
+					return focusedOperationCancelledResult("Goal completion", completionFocus);
+				}
 
 				if (userChoice === "complete_without_audit") {
 					// ── Mark complete without audit ────────────────────────────
@@ -3074,8 +3143,12 @@ ${objective}` : objective,
 			const taskLines = renderTaskLines(taskList.tasks);
 			const gateLabel = blockCompletion ? " (blockCompletion enabled)" : "";
 			const proposalText = [`Proposed task list${gateLabel}:`, "", ...taskLines].join("\n");
+			const taskListFocus = focusedOperationToken(state.goal.id);
 
 			const dialogResult = await showProposalDialog(ctx, proposalText, "goal", !state.goal?.skipAuditor);
+			if (!isFocusedOperationCurrent(taskListFocus)) {
+				return focusedOperationCancelledResult("Task list proposal", taskListFocus);
+			}
 			if (dialogResult.decision !== "confirm") {
 				return {
 					content: [{ type: "text", text: "Task list proposal declined." }],
@@ -3448,7 +3521,7 @@ promptGuidelines: [
 			const archived = archiveGoalFile(ctx, completedGoal);
 			resetGetGoalNudgeState(completedGoal.id);
 			goalsById.delete(completedGoal.id);
-			focusedGoalId = null;
+			assignFocusedGoalId(null);
 			appendFocusEntry(null, "completed");
 			syncGoalTools();
 			updateUI(ctx);
@@ -3490,7 +3563,7 @@ promptGuidelines: [
 		loadState(ctx);
 		syncGoalTools();
 		syncTerminalInputPause(ctx);
-		if (event.reason === "resume" && !state.goal && openGoals().length > 1 && ctx.hasUI) {
+		if (event.reason === "resume" && !state.goal && !hasExplicitSessionFocus && openGoals().length > 1 && ctx.hasUI) {
 			await focusGoalCommand(ctx);
 		}
 		// Codex behavior: prompt before reactivating a paused goal on resume.

--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -1506,15 +1506,15 @@ Verification contract:
 	function unfocusGoalCommand(ctx: ExtensionContext): void {
 		reconcileFocusedGoalFromDisk(ctx);
 		const current = state.goal;
+		setFocusedGoalId(null, ctx, "unfocused");
+		runningGoalId = null;
+		checkpointGoalId = null;
+		postCompactReminderPending = false;
 		if (!current) {
 			const openCount = openGoals().length;
 			ctx.ui.notify(openCount > 0 ? buildUnfocusedOpenGoalsSummary(openCount) : detailedSummary(null), "info");
 			return;
 		}
-		setFocusedGoalId(null, ctx, "unfocused");
-		runningGoalId = null;
-		checkpointGoalId = null;
-		postCompactReminderPending = false;
 		ctx.ui.notify(`Goal unfocused for this session. It remains open in .pi/goals: ${current.id}`, "info");
 	}
 

--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -1503,6 +1503,21 @@ Verification contract:
 		ctx.ui.notify(`Focused goal: ${oneLineSummary(state.goal)}`, "info");
 	}
 
+	function unfocusGoalCommand(ctx: ExtensionContext): void {
+		reconcileFocusedGoalFromDisk(ctx);
+		const current = state.goal;
+		if (!current) {
+			const openCount = openGoals().length;
+			ctx.ui.notify(openCount > 0 ? buildUnfocusedOpenGoalsSummary(openCount) : detailedSummary(null), "info");
+			return;
+		}
+		setFocusedGoalId(null, ctx, "unfocused");
+		runningGoalId = null;
+		checkpointGoalId = null;
+		postCompactReminderPending = false;
+		ctx.ui.notify(`Goal unfocused for this session. It remains open in .pi/goals: ${current.id}`, "info");
+	}
+
 	async function handleGoalCommandTopic(rawTopic: string, ctx: ExtensionContext, focus: DraftingFocus, opts: { replace: boolean }): Promise<void> {
 		const topic = rawTopic.trim();
 		if (opts.replace) {
@@ -1761,7 +1776,7 @@ Verification contract:
 		},
 	};
 	pi.registerCommand("goal", {
-		description: "Show focused goal status. Discuss with /goals or /sisyphus; direct-start with /goals-set or /sisyphus-set; manage with /goal-list, /goal-focus, /goal-settings, /goal-tweak, /goal-clear, /goal-abort, /goal-pause, /goal-resume.",
+		description: "Show focused goal status. Discuss with /goals or /sisyphus; direct-start with /goals-set or /sisyphus-set; manage with /goal-list, /goal-focus, /goal-unfocus, /goal-settings, /goal-tweak, /goal-clear, /goal-abort, /goal-pause, /goal-resume.",
 		handler: statusCommand.handler,
 	});
 	pi.registerCommand("goal-status", statusCommand);
@@ -1777,6 +1792,12 @@ Verification contract:
 		description: "Choose which open goal this session should focus on.",
 		handler: async (_rawArgs, ctx) => {
 			await focusGoalCommand(ctx);
+		},
+	});
+	pi.registerCommand("goal-unfocus", {
+		description: "Stop focusing the current goal in this session without modifying or archiving the shared goal.",
+		handler: async (_rawArgs, ctx) => {
+			unfocusGoalCommand(ctx);
 		},
 	});
 	pi.registerCommand("goal-settings", {

--- a/tests/goal-record.test.ts
+++ b/tests/goal-record.test.ts
@@ -168,11 +168,21 @@ test("goal focus entries persist only session focus metadata", () => {
 		focusedGoalId: null,
 		reason: "cleared",
 	});
+	assert.deepEqual(goalFocusDetails(null, "unfocused"), {
+		version: 1,
+		focusedGoalId: null,
+		reason: "unfocused",
+	});
 
 	assert.deepEqual(normalizeGoalFocusEntry({ version: 1, focusedGoalId: "abc/def", reason: "resumed" }), {
 		version: 1,
 		focusedGoalId: "abc_def",
 		reason: "resumed",
+	});
+	assert.deepEqual(normalizeGoalFocusEntry({ version: 1, focusedGoalId: null, reason: "unfocused" }), {
+		version: 1,
+		focusedGoalId: null,
+		reason: "unfocused",
 	});
 	assert.deepEqual(normalizeGoalFocusEntry({ version: 1, focusedGoalId: "", reason: "unknown" }), {
 		version: 1,

--- a/tests/goal-unfocus.test.ts
+++ b/tests/goal-unfocus.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -19,6 +19,8 @@ test("/goal-unfocus clears only session focus and leaves the shared goal open", 
 
 	const goal = createGoal({ objective: "Keep this shared goal open", autoContinue: true, sisyphus: false });
 	const written = writeActiveGoalFile({ cwd } as ExtensionContext, goal);
+	const activePath = path.join(cwd, written.activePath!);
+	const originalGoalFile = readFileSync(activePath);
 	const sessionEntries = [
 		{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(goal.id, "created") },
 	];
@@ -74,8 +76,20 @@ test("/goal-unfocus clears only session focus and leaves the shared goal open", 
 			focusedGoalId: null,
 			reason: "unfocused",
 		});
-		assert.equal(existsSync(path.join(cwd, written.activePath!)), true, "shared active goal file must remain");
+		assert.equal(existsSync(activePath), true, "shared active goal file must remain");
+		assert.deepEqual(readFileSync(activePath), originalGoalFile, "shared active goal file must remain unchanged");
 		assert.match(notifications.at(-1) ?? "", /remains open in \.pi\/goals/);
+
+		const focusEntryCount = appendedEntries.filter((entry) => entry.customType === "pi-goal-focus").length;
+		await command.handler("", ctx);
+		const repeatedFocusEntries = appendedEntries.filter((entry) => entry.customType === "pi-goal-focus");
+		assert.equal(repeatedFocusEntries.length, focusEntryCount + 1, "repeated unfocus must persist explicit null focus");
+		assert.deepEqual(repeatedFocusEntries.at(-1)?.data, {
+			version: 1,
+			focusedGoalId: null,
+			reason: "unfocused",
+		});
+		assert.deepEqual(readFileSync(activePath), originalGoalFile, "repeated unfocus must not modify the shared goal");
 
 		const promptResult = await handlers.get("before_agent_start")?.(
 			{ systemPrompt: "base prompt", prompt: "ordinary user request" },

--- a/tests/goal-unfocus.test.ts
+++ b/tests/goal-unfocus.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import goalExtension from "../extensions/goal.ts";
+import { createGoal, goalFocusDetails } from "../extensions/goal-record.ts";
+import { writeActiveGoalFile } from "../extensions/storage/goal-files.ts";
+
+test("/goal-unfocus clears only session focus and leaves the shared goal open", async () => {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-unfocus-"));
+	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
+	writeFileSync(
+		path.join(cwd, ".pi", "pi-goal-x-settings.json"),
+		JSON.stringify({ autoSelectSingleGoal: false, disabled: true }),
+	);
+
+	const goal = createGoal({ objective: "Keep this shared goal open", autoContinue: true, sisyphus: false });
+	const written = writeActiveGoalFile({ cwd } as ExtensionContext, goal);
+	const sessionEntries = [
+		{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(goal.id, "created") },
+	];
+	const appendedEntries: Array<{ customType: string; data: unknown }> = [];
+	const notifications: string[] = [];
+	const commands = new Map<string, { handler: (args: string, ctx: ExtensionContext) => Promise<void> | void }>();
+	const handlers = new Map<string, Function>();
+	let activeTools = ["read", "bash", "edit", "write"];
+
+	const pi = {
+		registerTool: () => {},
+		registerCommand: (name: string, definition: { handler: (args: string, ctx: ExtensionContext) => Promise<void> | void }) => {
+			commands.set(name, definition);
+		},
+		on: (event: string, handler: Function) => { handlers.set(event, handler); },
+		appendEntry: (customType: string, data: unknown) => { appendedEntries.push({ customType, data }); },
+		registerMessageRenderer: () => {},
+		sendMessage: () => {},
+		getActiveTools: () => [...activeTools],
+		setActiveTools: (names: string[]) => { activeTools = [...names]; },
+		hasUI: false,
+	};
+
+	const ctx = {
+		cwd,
+		hasUI: false,
+		sessionManager: {
+			getBranch: () => sessionEntries,
+			getCwd: () => cwd,
+			getSessionId: () => "unfocus-test-session",
+			getRoot: () => cwd,
+		},
+		ui: {
+			notify: (message: string) => { notifications.push(message); },
+		},
+		getSystemPrompt: () => "base prompt",
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		abort: () => {},
+	} as unknown as ExtensionContext;
+
+	try {
+		goalExtension(pi as any);
+		await handlers.get("session_start")?.({ reason: "start" }, ctx);
+
+		const command = commands.get("goal-unfocus");
+		assert.ok(command, "/goal-unfocus must be registered");
+		await command.handler("", ctx);
+
+		const focusEntry = [...appendedEntries].reverse().find((entry) => entry.customType === "pi-goal-focus");
+		assert.deepEqual(focusEntry?.data, {
+			version: 1,
+			focusedGoalId: null,
+			reason: "unfocused",
+		});
+		assert.equal(existsSync(path.join(cwd, written.activePath!)), true, "shared active goal file must remain");
+		assert.match(notifications.at(-1) ?? "", /remains open in \.pi\/goals/);
+
+		const promptResult = await handlers.get("before_agent_start")?.(
+			{ systemPrompt: "base prompt", prompt: "ordinary user request" },
+			ctx,
+		);
+		assert.match(promptResult?.systemPrompt ?? "", /\[PI GOAL UNFOCUSED\]/);
+		assert.doesNotMatch(promptResult?.systemPrompt ?? "", /\[PI GOAL ACTIVE/);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});

--- a/tests/goal-unfocus.test.ts
+++ b/tests/goal-unfocus.test.ts
@@ -1,37 +1,35 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import goalExtension from "../extensions/goal.ts";
-import { createGoal, goalFocusDetails } from "../extensions/goal-record.ts";
+import { createGoal, goalFocusDetails, type GoalRecord } from "../extensions/goal-record.ts";
 import { writeActiveGoalFile } from "../extensions/storage/goal-files.ts";
 
-test("/goal-unfocus clears only session focus and leaves the shared goal open", async () => {
-	const cwd = mkdtempSync(path.join(tmpdir(), "goal-unfocus-"));
-	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
-	writeFileSync(
-		path.join(cwd, ".pi", "pi-goal-x-settings.json"),
-		JSON.stringify({ autoSelectSingleGoal: false, disabled: true }),
-	);
+interface HarnessOptions {
+	cwd: string;
+	sessionEntries: unknown[];
+	hasUI?: boolean;
+	idle?: boolean;
+	custom?: () => Promise<unknown>;
+	runCompletionAuditor?: (...args: any[]) => Promise<any>;
+}
 
-	const goal = createGoal({ objective: "Keep this shared goal open", autoContinue: true, sisyphus: false });
-	const written = writeActiveGoalFile({ cwd } as ExtensionContext, goal);
-	const activePath = path.join(cwd, written.activePath!);
-	const originalGoalFile = readFileSync(activePath);
-	const sessionEntries = [
-		{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(goal.id, "created") },
-	];
+function createHarness(options: HarnessOptions) {
 	const appendedEntries: Array<{ customType: string; data: unknown }> = [];
 	const notifications: string[] = [];
 	const commands = new Map<string, { handler: (args: string, ctx: ExtensionContext) => Promise<void> | void }>();
 	const handlers = new Map<string, Function>();
+	const tools = new Map<string, any>();
 	let activeTools = ["read", "bash", "edit", "write"];
+	let abortCount = 0;
+	let selectCount = 0;
 
 	const pi = {
-		registerTool: () => {},
+		registerTool: (definition: any) => { tools.set(definition.name, definition); },
 		registerCommand: (name: string, definition: { handler: (args: string, ctx: ExtensionContext) => Promise<void> | void }) => {
 			commands.set(name, definition);
 		},
@@ -41,63 +39,420 @@ test("/goal-unfocus clears only session focus and leaves the shared goal open", 
 		sendMessage: () => {},
 		getActiveTools: () => [...activeTools],
 		setActiveTools: (names: string[]) => { activeTools = [...names]; },
-		hasUI: false,
+		hasUI: options.hasUI ?? false,
 	};
 
 	const ctx = {
-		cwd,
-		hasUI: false,
+		cwd: options.cwd,
+		hasUI: options.hasUI ?? false,
 		sessionManager: {
-			getBranch: () => sessionEntries,
-			getCwd: () => cwd,
+			getBranch: () => options.sessionEntries,
+			getCwd: () => options.cwd,
 			getSessionId: () => "unfocus-test-session",
-			getRoot: () => cwd,
+			getRoot: () => options.cwd,
 		},
 		ui: {
 			notify: (message: string) => { notifications.push(message); },
+			setStatus: () => {},
+			setWidget: () => {},
+			onTerminalInput: () => () => {},
+			select: async () => { selectCount += 1; return undefined; },
+			confirm: async () => false,
+			custom: async () => options.custom ? options.custom() : undefined,
 		},
 		getSystemPrompt: () => "base prompt",
-		isIdle: () => true,
+		isIdle: () => options.idle ?? true,
 		hasPendingMessages: () => false,
-		abort: () => {},
+		abort: () => { abortCount += 1; },
 	} as unknown as ExtensionContext;
 
+	goalExtension(pi as any, { runCompletionAuditor: options.runCompletionAuditor });
+	return {
+		ctx,
+		commands,
+		handlers,
+		tools,
+		appendedEntries,
+		notifications,
+		get abortCount() { return abortCount; },
+		get selectCount() { return selectCount; },
+	};
+}
+
+function createFixture(overrides: Partial<GoalRecord> = {}, settings: Record<string, unknown> = { autoSelectSingleGoal: false, disabled: true }) {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-unfocus-"));
+	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
+	writeFileSync(path.join(cwd, ".pi", "pi-goal-x-settings.json"), JSON.stringify(settings));
+	const goal = createGoal({ objective: "Keep this shared goal open", autoContinue: true, sisyphus: false });
+	Object.assign(goal, overrides);
+	const written = writeActiveGoalFile({ cwd } as ExtensionContext, goal);
+	return {
+		cwd,
+		goal: written,
+		activePath: path.join(cwd, written.activePath!),
+		cleanup: () => rmSync(cwd, { recursive: true, force: true }),
+	};
+}
+
+function latestFocusEntry(entries: Array<{ customType: string; data: unknown }>) {
+	return [...entries].reverse().find((entry) => entry.customType === "pi-goal-focus");
+}
+
+test("/goal-unfocus is idempotent, session-local, and leaves the active goal byte-for-byte unchanged", async () => {
+	const fixture = createFixture();
+	const originalGoalFile = readFileSync(fixture.activePath);
+	const harness = createHarness({
+		cwd: fixture.cwd,
+		sessionEntries: [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(fixture.goal.id, "created") }],
+	});
+
 	try {
-		goalExtension(pi as any);
-		await handlers.get("session_start")?.({ reason: "start" }, ctx);
-
-		const command = commands.get("goal-unfocus");
+		await harness.handlers.get("session_start")?.({ reason: "startup" }, harness.ctx);
+		const command = harness.commands.get("goal-unfocus");
 		assert.ok(command, "/goal-unfocus must be registered");
-		await command.handler("", ctx);
+		await command.handler("", harness.ctx);
 
-		const focusEntry = [...appendedEntries].reverse().find((entry) => entry.customType === "pi-goal-focus");
-		assert.deepEqual(focusEntry?.data, {
+		assert.deepEqual(latestFocusEntry(harness.appendedEntries)?.data, {
 			version: 1,
 			focusedGoalId: null,
 			reason: "unfocused",
 		});
-		assert.equal(existsSync(activePath), true, "shared active goal file must remain");
-		assert.deepEqual(readFileSync(activePath), originalGoalFile, "shared active goal file must remain unchanged");
-		assert.match(notifications.at(-1) ?? "", /remains open in \.pi\/goals/);
+		assert.equal(existsSync(fixture.activePath), true);
+		assert.deepEqual(readFileSync(fixture.activePath), originalGoalFile);
+		assert.equal(existsSync(path.join(fixture.cwd, ".pi", "goals", "goal_events.jsonl")), false, "unfocus must not write the shared ledger");
+		assert.equal(readdirSync(path.join(fixture.cwd, ".pi", "goals", "archived")).length, 0);
+		assert.match(harness.notifications.at(-1) ?? "", /remains open in \.pi\/goals/);
 
-		const focusEntryCount = appendedEntries.filter((entry) => entry.customType === "pi-goal-focus").length;
-		await command.handler("", ctx);
-		const repeatedFocusEntries = appendedEntries.filter((entry) => entry.customType === "pi-goal-focus");
-		assert.equal(repeatedFocusEntries.length, focusEntryCount + 1, "repeated unfocus must persist explicit null focus");
+		const focusEntryCount = harness.appendedEntries.filter((entry) => entry.customType === "pi-goal-focus").length;
+		await command.handler("", harness.ctx);
+		const repeatedFocusEntries = harness.appendedEntries.filter((entry) => entry.customType === "pi-goal-focus");
+		assert.equal(repeatedFocusEntries.length, focusEntryCount + 1);
 		assert.deepEqual(repeatedFocusEntries.at(-1)?.data, {
 			version: 1,
 			focusedGoalId: null,
 			reason: "unfocused",
 		});
-		assert.deepEqual(readFileSync(activePath), originalGoalFile, "repeated unfocus must not modify the shared goal");
+		assert.deepEqual(readFileSync(fixture.activePath), originalGoalFile);
 
-		const promptResult = await handlers.get("before_agent_start")?.(
+		const promptResult = await harness.handlers.get("before_agent_start")?.(
 			{ systemPrompt: "base prompt", prompt: "ordinary user request" },
-			ctx,
+			harness.ctx,
 		);
 		assert.match(promptResult?.systemPrompt ?? "", /\[PI GOAL UNFOCUSED\]/);
 		assert.doesNotMatch(promptResult?.systemPrompt ?? "", /\[PI GOAL ACTIVE/);
 	} finally {
-		rmSync(cwd, { recursive: true, force: true });
+		fixture.cleanup();
+	}
+});
+
+test("/goal-unfocus aborts a busy goal turn, blocks later tools, and prevents abort handlers from pausing it", async () => {
+	const fixture = createFixture();
+	const originalGoalFile = readFileSync(fixture.activePath);
+	const harness = createHarness({
+		cwd: fixture.cwd,
+		idle: false,
+		sessionEntries: [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(fixture.goal.id, "created") }],
+	});
+	try {
+		await harness.handlers.get("session_start")?.({ reason: "startup" }, harness.ctx);
+		await harness.commands.get("goal-unfocus")!.handler("", harness.ctx);
+		assert.equal(harness.abortCount, 1);
+		const gate = await harness.handlers.get("tool_call")?.({ toolName: "write", input: { path: "late.txt", content: "late" } }, harness.ctx);
+		assert.equal(gate?.block, true);
+		assert.match(gate?.reason ?? "", /already stopped earlier in this turn/);
+		const abortedMessage = { role: "assistant", stopReason: "aborted", usage: { input: 0, output: 0 } };
+		await harness.handlers.get("message_end")?.({ message: abortedMessage }, harness.ctx);
+		await harness.handlers.get("turn_end")?.({ message: abortedMessage }, harness.ctx);
+		await harness.handlers.get("agent_end")?.({ messages: [abortedMessage] }, harness.ctx);
+		assert.deepEqual(readFileSync(fixture.activePath), originalGoalFile);
+		assert.equal(readdirSync(path.join(fixture.cwd, ".pi", "goals", "archived")).length, 0);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test("/goal-unfocus preserves a paused goal and does not archive it", async () => {
+	const fixture = createFixture({ status: "paused", autoContinue: false, pauseReason: "waiting" });
+	const originalGoalFile = readFileSync(fixture.activePath);
+	const harness = createHarness({
+		cwd: fixture.cwd,
+		sessionEntries: [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(fixture.goal.id, "created") }],
+	});
+	try {
+		await harness.handlers.get("session_start")?.({ reason: "startup" }, harness.ctx);
+		await harness.commands.get("goal-unfocus")!.handler("", harness.ctx);
+		assert.deepEqual(readFileSync(fixture.activePath), originalGoalFile);
+		assert.equal(readdirSync(path.join(fixture.cwd, ".pi", "goals", "archived")).length, 0);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test("/goal-unfocus records explicit null focus when the active goal file disappeared", async () => {
+	const fixture = createFixture();
+	const harness = createHarness({
+		cwd: fixture.cwd,
+		sessionEntries: [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(fixture.goal.id, "selected") }],
+	});
+	try {
+		await harness.handlers.get("session_start")?.({ reason: "startup" }, harness.ctx);
+		rmSync(fixture.activePath);
+		await harness.commands.get("goal-unfocus")!.handler("", harness.ctx);
+		assert.deepEqual(latestFocusEntry(harness.appendedEntries)?.data, {
+			version: 1,
+			focusedGoalId: null,
+			reason: "unfocused",
+		});
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test("busy missing-file detachment still aborts and blocks the former goal turn", async () => {
+	const fixture = createFixture();
+	const harness = createHarness({
+		cwd: fixture.cwd,
+		idle: false,
+		sessionEntries: [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(fixture.goal.id, "selected") }],
+	});
+	try {
+		await harness.handlers.get("session_start")?.({ reason: "startup" }, harness.ctx);
+		rmSync(fixture.activePath);
+		await harness.commands.get("goal-unfocus")!.handler("", harness.ctx);
+		assert.equal(harness.abortCount, 1);
+		const gate = await harness.handlers.get("tool_call")?.({ toolName: "bash", input: { command: "echo late" } }, harness.ctx);
+		assert.equal(gate?.block, true);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test("already-unfocused command does not abort unrelated busy work", async () => {
+	const fixture = createFixture();
+	const harness = createHarness({
+		cwd: fixture.cwd,
+		idle: false,
+		sessionEntries: [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(null, "unfocused") }],
+	});
+	try {
+		await harness.handlers.get("session_start")?.({ reason: "startup" }, harness.ctx);
+		await harness.commands.get("goal-unfocus")!.handler("", harness.ctx);
+		assert.equal(harness.abortCount, 0);
+		assert.deepEqual(latestFocusEntry(harness.appendedEntries)?.data, {
+			version: 1,
+			focusedGoalId: null,
+			reason: "unfocused",
+		});
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test("one session can unfocus while another remains focused on the shared goal", async () => {
+	const fixture = createFixture();
+	const focusEntry = { type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(fixture.goal.id, "selected") };
+	const first = createHarness({ cwd: fixture.cwd, sessionEntries: [focusEntry] });
+	const second = createHarness({ cwd: fixture.cwd, sessionEntries: [focusEntry] });
+	try {
+		await first.handlers.get("session_start")?.({ reason: "startup" }, first.ctx);
+		await second.handlers.get("session_start")?.({ reason: "startup" }, second.ctx);
+		await first.commands.get("goal-unfocus")!.handler("", first.ctx);
+
+		const firstPrompt = await first.handlers.get("before_agent_start")?.({ systemPrompt: "base", prompt: "hello" }, first.ctx);
+		const secondPrompt = await second.handlers.get("before_agent_start")?.({ systemPrompt: "base", prompt: "continue" }, second.ctx);
+		assert.match(firstPrompt?.systemPrompt ?? "", /\[PI GOAL UNFOCUSED\]/);
+		assert.match(secondPrompt?.systemPrompt ?? "", new RegExp(`\\[PI GOAL ACTIVE goalId=${fixture.goal.id}\\]`));
+		assert.equal(existsSync(path.join(fixture.cwd, ".pi", "goals", "goal_events.jsonl")), false);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test("autoSelectSingleGoal opt-in focuses one goal on resume when no focus entry exists", async () => {
+	const fixture = createFixture({}, { autoSelectSingleGoal: true, disabled: true });
+	const harness = createHarness({ cwd: fixture.cwd, hasUI: true, sessionEntries: [] });
+	try {
+		await harness.handlers.get("session_start")?.({ reason: "resume" }, harness.ctx);
+		assert.equal(harness.selectCount, 0);
+		const prompt = await harness.handlers.get("before_agent_start")?.({ systemPrompt: "base", prompt: "continue" }, harness.ctx);
+		assert.match(prompt?.systemPrompt ?? "", new RegExp(`\\[PI GOAL ACTIVE goalId=${fixture.goal.id}\\]`));
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test("the null entry produced by unfocus survives resume/tree and suppresses opt-in auto-selection", async () => {
+	const fixture = createFixture({}, { autoSelectSingleGoal: true, disabled: true });
+	const producer = createHarness({
+		cwd: fixture.cwd,
+		sessionEntries: [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(fixture.goal.id, "selected") }],
+	});
+	try {
+		await producer.handlers.get("session_start")?.({ reason: "startup" }, producer.ctx);
+		await producer.commands.get("goal-unfocus")!.handler("", producer.ctx);
+		const producedEntry = latestFocusEntry(producer.appendedEntries);
+		assert.ok(producedEntry);
+		const sessionEntries = [{ type: "custom", customType: producedEntry.customType, data: producedEntry.data }];
+
+		const resumed = createHarness({ cwd: fixture.cwd, hasUI: true, sessionEntries });
+		await resumed.handlers.get("session_start")?.({ reason: "resume" }, resumed.ctx);
+		let prompt = await resumed.handlers.get("before_agent_start")?.({ systemPrompt: "base", prompt: "hello" }, resumed.ctx);
+		assert.match(prompt?.systemPrompt ?? "", /\[PI GOAL UNFOCUSED\]/, "one open goal must not auto-select despite opt-in setting");
+
+		sessionEntries.splice(0, sessionEntries.length, {
+			type: "custom",
+			customType: "pi-goal-focus",
+			data: goalFocusDetails(fixture.goal.id, "selected"),
+		});
+		await resumed.handlers.get("session_tree")?.({ newLeafId: "focused-branch", oldLeafId: "unfocused-branch" }, resumed.ctx);
+		prompt = await resumed.handlers.get("before_agent_start")?.({ systemPrompt: "base", prompt: "focused branch" }, resumed.ctx);
+		assert.match(prompt?.systemPrompt ?? "", new RegExp(`\\[PI GOAL ACTIVE goalId=${fixture.goal.id}\\]`));
+
+		sessionEntries.splice(0, sessionEntries.length, {
+			type: "custom",
+			customType: producedEntry.customType,
+			data: producedEntry.data,
+		});
+		await resumed.handlers.get("session_tree")?.({ newLeafId: "unfocused-branch", oldLeafId: "focused-branch" }, resumed.ctx);
+		prompt = await resumed.handlers.get("before_agent_start")?.({ systemPrompt: "base", prompt: "after tree" }, resumed.ctx);
+		assert.match(prompt?.systemPrompt ?? "", /\[PI GOAL UNFOCUSED\]/);
+
+		const secondGoal = createGoal({ objective: "Second shared goal", autoContinue: true, sisyphus: false });
+		const writtenSecondGoal = writeActiveGoalFile({ cwd: fixture.cwd } as ExtensionContext, secondGoal);
+		sessionEntries.splice(0, sessionEntries.length, {
+			type: "custom",
+			customType: "pi-goal-focus",
+			data: goalFocusDetails(writtenSecondGoal.id, "selected"),
+		});
+		await resumed.handlers.get("session_tree")?.({ newLeafId: "second-goal-branch", oldLeafId: "unfocused-branch" }, resumed.ctx);
+		prompt = await resumed.handlers.get("before_agent_start")?.({ systemPrompt: "base", prompt: "second goal" }, resumed.ctx);
+		assert.match(prompt?.systemPrompt ?? "", new RegExp(`\\[PI GOAL ACTIVE goalId=${writtenSecondGoal.id}\\]`));
+
+		sessionEntries.splice(0, sessionEntries.length, {
+			type: "custom",
+			customType: producedEntry.customType,
+			data: producedEntry.data,
+		});
+		const multiGoalResume = createHarness({ cwd: fixture.cwd, hasUI: true, sessionEntries });
+		await multiGoalResume.handlers.get("session_start")?.({ reason: "resume" }, multiGoalResume.ctx);
+		assert.equal(multiGoalResume.selectCount, 0, "resume must not prompt to replace an explicit null focus");
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test("an async tweak confirmation cannot mutate the goal after unfocus", async () => {
+	const fixture = createFixture();
+	let resolveDialog!: (value: unknown) => void;
+	const dialog = new Promise<unknown>((resolve) => { resolveDialog = resolve; });
+	const harness = createHarness({
+		cwd: fixture.cwd,
+		hasUI: true,
+		idle: false,
+		custom: () => dialog,
+		sessionEntries: [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(fixture.goal.id, "created") }],
+	});
+	try {
+		await harness.handlers.get("session_start")?.({ reason: "startup" }, harness.ctx);
+		await harness.commands.get("goal-tweak")!.handler("Prepare a delayed tweak", harness.ctx);
+		const goalFileBeforeProposal = readFileSync(fixture.activePath);
+		const proposal = harness.tools.get("propose_goal_tweak");
+		const proposalPromise = proposal.execute("tweak-1", {
+			newObjective: "A stale replacement objective",
+			changeSummary: "Must not be applied",
+		}, undefined, undefined, harness.ctx);
+		await new Promise((resolve) => setImmediate(resolve));
+		await harness.commands.get("goal-unfocus")!.handler("", harness.ctx);
+		resolveDialog({
+			cancelled: false,
+			questions: [],
+			answers: [{ id: "confirm", question: "Confirm Goal Draft", answer: "Confirm — create this goal now", wasCustom: false }],
+			auditorEnabled: true,
+		});
+		const result = await proposalPromise;
+		assert.match(result.content[0]?.text ?? "", /Goal tweak cancelled because goal .* is no longer focused/);
+		assert.deepEqual(readFileSync(fixture.activePath), goalFileBeforeProposal);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test("an approved completion audit cannot complete or archive a goal after unfocus", async () => {
+	const fixture = createFixture({}, { autoSelectSingleGoal: false });
+	const originalGoalFile = readFileSync(fixture.activePath);
+	let resolveAudit!: (value: unknown) => void;
+	let auditSignal: AbortSignal | undefined;
+	let auditStarted!: () => void;
+	const started = new Promise<void>((resolve) => { auditStarted = resolve; });
+	const audit = new Promise<unknown>((resolve) => { resolveAudit = resolve; });
+	const harness = createHarness({
+		cwd: fixture.cwd,
+		idle: false,
+		runCompletionAuditor: async (args: { signal?: AbortSignal }) => {
+			auditSignal = args.signal;
+			auditStarted();
+			return audit;
+		},
+		sessionEntries: [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(fixture.goal.id, "created") }],
+	});
+	try {
+		await harness.handlers.get("session_start")?.({ reason: "startup" }, harness.ctx);
+		await harness.handlers.get("before_agent_start")?.({ systemPrompt: "base", prompt: "finish" }, harness.ctx);
+		const complete = harness.tools.get("complete_goal");
+		const completionPromise = complete.execute("complete-1", {
+			status: "complete",
+			completionSummary: "Claimed complete",
+			verificationSummary: "Tests passed",
+		}, undefined, undefined, harness.ctx);
+		await started;
+		await harness.commands.get("goal-unfocus")!.handler("", harness.ctx);
+		assert.equal(auditSignal?.aborted, true);
+		resolveAudit({ approved: true, disapproved: false, output: "Looks good\n<approved/>", model: "mock" });
+		const result = await completionPromise;
+		assert.match(result.content[0]?.text ?? "", /Goal completion cancelled because goal .* is no longer focused/);
+		await harness.handlers.get("turn_end")?.({ message: { role: "assistant", stopReason: "stop", usage: { input: 0, output: 0 } } }, harness.ctx);
+		assert.deepEqual(readFileSync(fixture.activePath), originalGoalFile);
+		assert.equal(readdirSync(path.join(fixture.cwd, ".pi", "goals", "archived")).length, 0);
+		const ledger = readFileSync(path.join(fixture.cwd, ".pi", "goals", "goal_events.jsonl"), "utf8");
+		assert.doesNotMatch(ledger, /"type":"audit_result"/);
+		assert.doesNotMatch(ledger, /"type":"goal_completed"/);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test("an async task-list confirmation cannot mutate the goal after unfocus", async () => {
+	const fixture = createFixture();
+	const originalGoalFile = readFileSync(fixture.activePath);
+	let resolveDialog!: (value: unknown) => void;
+	const dialog = new Promise<unknown>((resolve) => { resolveDialog = resolve; });
+	const harness = createHarness({
+		cwd: fixture.cwd,
+		hasUI: true,
+		idle: false,
+		custom: () => dialog,
+		sessionEntries: [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(fixture.goal.id, "created") }],
+	});
+	try {
+		await harness.handlers.get("session_start")?.({ reason: "startup" }, harness.ctx);
+		const proposal = harness.tools.get("propose_task_list");
+		assert.ok(proposal);
+		const proposalPromise = proposal.execute("call-1", {
+			tasks: [{ id: "t1", title: "Must not be applied" }],
+			blockCompletion: false,
+		}, undefined, undefined, harness.ctx);
+		await new Promise((resolve) => setImmediate(resolve));
+		await harness.commands.get("goal-unfocus")!.handler("", harness.ctx);
+		resolveDialog({
+			cancelled: false,
+			questions: [],
+			answers: [{ id: "confirm", question: "Confirm Goal Draft", answer: "Confirm — create this goal now", wasCustom: false }],
+			auditorEnabled: true,
+		});
+		const result = await proposalPromise;
+		assert.match(result.content[0]?.text ?? "", /cancelled because goal .* is no longer focused/);
+		assert.deepEqual(readFileSync(fixture.activePath), originalGoalFile);
+	} finally {
+		fixture.cleanup();
 	}
 });


### PR DESCRIPTION
## Summary

- add `/goal-unfocus` to detach only the current session from its focused goal
- persist an explicit session-local null focus entry with reason `unfocused`
- stop that session's queued/in-flight goal work and completion audit without pausing, modifying, or archiving the shared goal
- suppress project-global focus ledger writes for session-only unfocus
- reject delayed completion, tweak, and task-list confirmation results after session focus changes
- preserve explicit unfocus across resume and `/tree`, including `autoSelectSingleGoal: true`
- clarify that `autoSelectSingleGoal: false` keeps focus, rather than project goal files, session-scoped

## Why

Goals are intentionally stored in a project-level pool, but `/goal-clear` archives that shared state. Users running multiple Pi sessions in one directory need a safe way to stop one session from participating in a goal without affecting another session that is still working on it.

With `autoSelectSingleGoal: false`, fresh sessions already start unfocused. This command provides the matching transition for an existing focused session.

## Safety and race handling

- busy goal turns are aborted and subsequent same-turn work tools are blocked
- abort lifecycle handlers cannot pause the detached shared goal
- active completion audits receive cancellation and cannot complete/archive after detachment
- async tweak and task-list dialogs revalidate a focus revision before writing
- repeated unfocus and missing-file paths still persist the explicit null entry
- already-unfocused commands do not abort unrelated busy work
- unfocus does not append a project-global `goal_unfocused` ledger event

## Verification

- `npm test` — 408 tests pass
- `npm run check` — passes
- `npm pack --dry-run` — succeeds
- `git diff --check` — passes
- independent `gpt-5.6-sol` xhigh review verdict: **ready**

Integration coverage verifies active, paused, repeated, missing-file, busy-turn, two-session, resume, mutable `/tree` branch, opt-in auto-selection, delayed audit approval, delayed tweak confirmation, and delayed task-list confirmation behavior.
