### PR TITLE
fix: show full pause and abort reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ with the `0.x` prefix indicating pre-1.0 development.
 - **Agent lifecycle reasons remain readable in tool-call headings:** `pause_goal` and
   `abort_goal` no longer pass their reason through `truncateText(..., 80)`, so Pi's
   `Text` component wraps the complete reason instead of replacing text after 77
-  characters with `...`. Potentially large draft objectives and proposal summaries
-  retain their compact 80-character previews.
+  characters with `...`. Rendered reasons are trimmed to match the validated/stored
+  execution value and avoid whitespace-only wrapping artifacts. Potentially large
+  draft objectives and proposal summaries retain their compact 80-character previews.
 
 ## [0.21.0] — 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ with the `0.x` prefix indicating pre-1.0 development.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Agent lifecycle reasons remain readable in tool-call headings:** `pause_goal` and
+  `abort_goal` no longer pass their reason through `truncateText(..., 80)`, so Pi's
+  `Text` component wraps the complete reason instead of replacing text after 77
+  characters with `...`. Potentially large draft objectives and proposal summaries
+  retain their compact 80-character previews.
+
 ## [0.21.0] — 2026-08-03
 
 ### Added

--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -2934,7 +2934,7 @@ ${objective}` : objective,
 			};
 		},
 		renderCall(args, theme) {
-			return new Text(theme.fg("toolTitle", "pause_goal ") + theme.fg("warning", truncateText(args?.reason ?? "", 80)), 0, 0);
+			return new Text(theme.fg("toolTitle", "pause_goal ") + theme.fg("warning", args?.reason ?? ""), 0, 0);
 		},
 		renderResult(result, _options, theme) {
 			return renderGoalResult(result, theme);
@@ -3006,7 +3006,7 @@ ${objective}` : objective,
 			};
 		},
 		renderCall(args, theme) {
-			return new Text(theme.fg("toolTitle", "abort_goal ") + theme.fg("warning", truncateText(args?.reason ?? "", 80)), 0, 0);
+			return new Text(theme.fg("toolTitle", "abort_goal ") + theme.fg("warning", args?.reason ?? ""), 0, 0);
 		},
 		renderResult(result, _options, theme) {
 			return renderGoalResult(result, theme);

--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -2934,7 +2934,7 @@ ${objective}` : objective,
 			};
 		},
 		renderCall(args, theme) {
-			return new Text(theme.fg("toolTitle", "pause_goal ") + theme.fg("warning", args?.reason ?? ""), 0, 0);
+			return new Text(theme.fg("toolTitle", "pause_goal ") + theme.fg("warning", (args?.reason ?? "").trim()), 0, 0);
 		},
 		renderResult(result, _options, theme) {
 			return renderGoalResult(result, theme);
@@ -3006,7 +3006,7 @@ ${objective}` : objective,
 			};
 		},
 		renderCall(args, theme) {
-			return new Text(theme.fg("toolTitle", "abort_goal ") + theme.fg("warning", args?.reason ?? ""), 0, 0);
+			return new Text(theme.fg("toolTitle", "abort_goal ") + theme.fg("warning", (args?.reason ?? "").trim()), 0, 0);
 		},
 		renderResult(result, _options, theme) {
 			return renderGoalResult(result, theme);

--- a/tests/goal-lifecycle-rendering.test.ts
+++ b/tests/goal-lifecycle-rendering.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import piGoalExtension from "../extensions/goal.ts";
+
+const tools: ToolDefinition[] = [];
+
+piGoalExtension({
+	registerTool: (tool: ToolDefinition) => tools.push(tool),
+	registerCommand: () => {},
+	on: () => {},
+	appendEntry: () => {},
+	registerMessageRenderer: () => {},
+	sendMessage: () => {},
+	getActiveTools: () => [],
+	setActiveTools: () => {},
+	hasUI: false,
+} as any);
+
+const theme = {
+	fg: (_color: string, text: string) => text,
+};
+
+function renderCall(name: string, args: Record<string, unknown>): string {
+	const tool = tools.find((candidate) => candidate.name === name);
+	assert.ok(tool, `Tool ${name} should be registered`);
+	assert.ok(tool.renderCall, `Tool ${name} should define renderCall`);
+	return tool.renderCall(args as any, theme as any, {} as any).render(1_000).map((line) => line.trimEnd()).join("\n");
+}
+
+describe("lifecycle tool call rendering", () => {
+	it("shows full pause and abort reasons even when they exceed 80 characters", () => {
+		const reason = "The agent cannot continue because the required deployment credential is unavailable in the current environment.";
+		assert.ok(reason.length > 80);
+
+		assert.equal(renderCall("pause_goal", { reason }), `pause_goal ${reason}`);
+		assert.equal(renderCall("abort_goal", { reason }), `abort_goal ${reason}`);
+	});
+
+	it("keeps potentially large proposal previews truncated", () => {
+		const longText = "A deliberately long preview value ".repeat(10).trim();
+		assert.ok(longText.length > 80);
+
+		for (const [name, args] of [
+			["propose_goal_draft", { objective: longText, sisyphus: false }],
+			["propose_goal_tweak", { changeSummary: longText }],
+			["propose_task_list", { changeSummary: longText, tasks: [] }],
+		] as const) {
+			const rendered = renderCall(name, args);
+			assert.ok(rendered.endsWith("..."), `${name} should retain its compact preview`);
+			assert.equal(rendered.includes(longText), false, `${name} should not render the full preview`);
+		}
+	});
+});

--- a/tests/goal-lifecycle-rendering.test.ts
+++ b/tests/goal-lifecycle-rendering.test.ts
@@ -38,6 +38,13 @@ describe("lifecycle tool call rendering", () => {
 		assert.equal(renderCall("abort_goal", { reason }), `abort_goal ${reason}`);
 	});
 
+	it("trims pause and abort reasons to match validated execution input", () => {
+		const reason = "  Waiting for the user to provide credentials.  ";
+
+		assert.equal(renderCall("pause_goal", { reason }), "pause_goal Waiting for the user to provide credentials.");
+		assert.equal(renderCall("abort_goal", { reason }), "abort_goal Waiting for the user to provide credentials.");
+	});
+
 	it("keeps potentially large proposal previews truncated", () => {
 		const longText = "A deliberately long preview value ".repeat(10).trim();
 		assert.ok(longText.length > 80);


### PR DESCRIPTION
## Summary

- show the full agent-provided `pause_goal` reason in its tool-call heading
- apply the same behavior to the equivalent `abort_goal` lifecycle reason
- let Pi's `Text` component wrap long reasons to the terminal width
- add rendering regression coverage and document the change

## Why it happened

The `pause_goal` call renderer passed the agent's `reason` parameter through `truncateText(reason, 80)`. That helper first collapsed whitespace and then, when the reason exceeded 80 characters, kept the first 77 characters and appended `...`. Reasons of 80 characters or fewer remained complete, which made the behavior appear intermittent.

`abort_goal` used the same rendering pattern, so it had the same issue.

## Before

Long agent-authored lifecycle reasons appeared as a permanently shortened heading:

```text
pause_goal The agent cannot continue because the required deployment credential is...
```

The complete reason was still stored in goal state and returned in the tool result; this was a display-only truncation in the call heading.

## Now

`pause_goal` and `abort_goal` pass their complete reason directly to Pi's `Text` component. Long reasons word-wrap according to the available terminal width instead of being replaced after 77 characters with `...`.

## Intentionally unchanged

The compact 80-character call previews remain for content that can be much larger:

- `propose_goal_draft` objective
- `propose_goal_tweak` change summary
- `propose_task_list` change summary

The lifecycle schemas, persistence, pause/abort execution, and existing bounded notification previews are unchanged.

## Validation

- `npm test` — 410 passing, 0 failing
- `npm run check` — passing
- regression tests verify full pause/abort reasons and retained proposal truncation

Fixes #10
