### PR TITLE
Unified dashboard: anchored scrollable task list, expanded view, audit, pastel one-tone palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ with the `0.x` prefix indicating pre-1.0 development.
 
 ### Added
 
+- **Scrollable, latest-completion-anchored task list**: the task list in the
+  dashboard is a window over the plan-ordered list that defaults to showing
+  the most recently completed tasks (`completedAt` anchor) instead of the
+  earliest ones, with `↑ N more` / `… +N more` indicator rows. `↑/↓` scroll a
+  row, `PgUp/PgDn` a page, and `Home/End` jump to the ends while the
+  dashboard is focused — the expanded dashboard is focused while open, and
+  `F6` engages compact scrolling so the arrow keys scroll the compact widget
+  without touching the editor (`Esc` disengages). A new completion re-anchors
+  the window. `/goal-status` renders the same anchored window as a static
+  snapshot; the window and indicators stay width-safe at 40–140 columns.
 - **Unified goal dashboard** (see `docs/unified-dashboard.md`): one dashboard
   component in compact (above-editor) and expanded modes, driven by a shared
   pure presentation model (`extensions/widgets/goal-dashboard-model.ts`) used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,78 @@ with the `0.x` prefix indicating pre-1.0 development.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Unified goal dashboard** (see `docs/unified-dashboard.md`): one dashboard
+  component in compact (above-editor) and expanded modes, driven by a shared
+  pure presentation model (`extensions/widgets/goal-dashboard-model.ts`) used
+  by the widget, `/goal-status`, and the completion flow.
+- **Expanded dashboard**: the full task tree (✓ complete, ▸ current,
+  ~ skipped, · pending), current-task block with verification contract and
+  evidence, goal-level verification, and a recent-activity feed derived from
+  the durable ledger. `Ctrl+Shift+T` toggles compact/expanded; `Esc`
+  collapses.
+- **Merged task overlay**: the separate task-list overlay registration is
+  removed; its behavior moved into the dashboard's expanded mode.
+- **Persisted current-task state**: optional `currentTaskId` on goal records
+  (execution focus, distinct from completion status), `task_started` ledger
+  event, `update_goal_task(status="start")`, normalization that accepts only
+  existing pending tasks, and focus preservation/clearing on task-list
+  restructuring. Legacy goal files load without the field and are never
+  rewritten.
+- **Improved `/goal-status`**: standard mode renders the same dashboard model
+  (compact dashboard + current-task details + recent activity + last audit
+  result, no settings noise); `/goal-status verbose` adds full diagnostic
+  detail (id, revision, objective, tree with evidence and contracts, ledger
+  history, budget, pause/blocker, paths, audit report, settings provenance).
+- **Structured audit progress**: the audit widget shows five check stages
+  (objective, verification, tasks, workspace, decision) with a progress bar
+  and auditor identity; raw tools/output appear only in expanded/debug mode
+  or on failure. Approval and changes-required result cards follow the audit.
+- **Archive-result improvements**: successful archival emits `goal_archived`
+  and reports the real archive path; failure never claims success, keeps the
+  complete record recoverable, reports the remaining path, and writes a
+  `goal_archive_failed` diagnostic ledger event.
+- **Drafting polish**: durable proposal summary (objective, plan,
+  verification, continuation, auditor state) in the transcript for every
+  proposal outcome; richer confirmation output (goal id, file, task count,
+  verification, auditor, budget); questionnaire answers are captured before
+  draft state is cleared and appear in the created-goal report.
+- **Width safety**: compact and expanded layouts adapt to wide/medium/narrow/
+  very-narrow terminals; no rendered line ever exceeds the terminal width
+  (asserted by golden tests at 40/50/60/80/100/140 columns).
+- **End-to-end lifecycle test** (`tests/e2e/goal-lifecycle-dashboard.test.ts`)
+  covering guided creation through archival (plan §19.9).
+- **Compact tracker polish**: the compact dashboard now shows the top-level
+  task list by default (colored markers, aligned id column, truncated titles,
+  `… +N more` overflow), rounded box corners, `·`-separated status bits, and
+  marker colors via the theme abstraction with a monochrome fallback —
+  consistent across the widget, the expanded dashboard, and `/goal-status`.
+- **Goal-draft proposals always show the task list exactly once**: the F2
+  derived-task preview now derives from the raw objective (boxed confirmation
+  text prefixed every line with `│`, hiding checklist/ordered markers); a
+  `/goal-tweak` confirmation renders explicit tasks once inside its box and
+  previews the retained current list when no tasks are proposed.
+- **Goal-tweak status preservation**: a `/goal-tweak` that proposes a task
+  list merges it into the existing tree by id (§7.5) — steps that persist
+  keep their status, evidence, and timestamps; new steps start pending;
+  removed steps drop; `currentTaskId` clears when its task is no longer
+  pending. A tweak without a task list retains the current list unchanged.
+- **Goal-settings menu fixes**: the settings menu renders its nine rows
+  correctly (the `stall timeout (minutes)` row edits its own key, invalid
+  `thinking_level` picks warn instead of failing silently).
+
+### Changed
+
+- The task-overlay shortcut (`Ctrl+Shift+T`) now toggles the unified
+  dashboard instead of opening a separate overlay.
+- Prompt task blocks surface the persisted current task with its contract.
+- The test runner discovers `tests/e2e/*.test.ts` (`npm run test:e2e`).
+
+---
+
 ## [0.23.0] — 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,14 +83,17 @@ with the `0.x` prefix indicating pre-1.0 development.
 
 ### Changed
 
-- **Dashboard palette (pastel)**: box borders are drawn in the theme's gray
-  (`muted`) instead of the dark `borderMuted`; task rows are pastel amber
-  (`mdHeading`) — the theme's soft markdown-heading yellow rather than the
-  bright `warning` — with colour-coded markers (✓ complete muted green,
-  ▸ current teal, ~ skipped gray, · pending amber). Blocked/budget states
-  use the soft red/amber instead of neon yellow, and the header meta and
-  footer hints are muted. Everything still follows the theme with a
-  monochrome fallback.
+- **Dashboard palette (pastel)**: the outer box frame is drawn in the theme's
+  light steel gray-blue (`mdLink`) — clearly lighter than the old dark
+  `borderMuted` and in the same hue family as pi's own borders — while the
+  interior rules stay in the theme's gray (`muted`) for hierarchy. Task rows
+  are pastel amber (`mdHeading`) with colour-coded markers *and ids* (✓
+  complete muted green, ▸ current teal, ~ skipped gray, · pending amber),
+  and the current task is fully accent (marker, id, title). The header brand,
+  progress fractions, and budget gauge are tinted; blocked/budget states use
+  soft red/amber instead of neon yellow, and the header meta and footer
+  hints are muted. Everything still follows the theme with a monochrome
+  fallback.
 - The task-overlay shortcut (`Ctrl+Shift+T`) now toggles the unified
   dashboard instead of opening a separate overlay.
 - Prompt task blocks surface the persisted current task with its contract.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ with the `0.x` prefix indicating pre-1.0 development.
 
 ### Changed
 
+- **Dashboard palette (pastel)**: box borders are drawn in the theme's gray
+  (`muted`) instead of the dark `borderMuted`; task rows are pastel amber
+  (`mdHeading`) — the theme's soft markdown-heading yellow rather than the
+  bright `warning` — with colour-coded markers (✓ complete muted green,
+  ▸ current teal, ~ skipped gray, · pending amber). Blocked/budget states
+  use the soft red/amber instead of neon yellow, and the header meta and
+  footer hints are muted. Everything still follows the theme with a
+  monochrome fallback.
 - The task-overlay shortcut (`Ctrl+Shift+T`) now toggles the unified
   dashboard instead of opening a separate overlay.
 - Prompt task blocks surface the persisted current task with its contract.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ with the `0.x` prefix indicating pre-1.0 development.
 - **Scrollable, latest-completion-anchored task list**: the task list in the
   dashboard is a window over the plan-ordered list that defaults to showing
   the most recently completed tasks (`completedAt` anchor) instead of the
-  earliest ones, with `↑ N more` / `… +N more` indicator rows. `↑/↓` scroll a
-  row, `PgUp/PgDn` a page, and `Home/End` jump to the ends while the
-  dashboard is focused — the expanded dashboard is focused while open, and
-  `F6` engages compact scrolling so the arrow keys scroll the compact widget
-  without touching the editor (`Esc` disengages). A new completion re-anchors
-  the window. `/goal-status` renders the same anchored window as a static
+  earliest ones, with `↑ N more` / `… +N more` indicator rows. The expanded
+  dashboard is modal and scrolls with `↑/↓`, `PgUp/PgDn`, and `Home/End`;
+  the compact widget never touches the editor's arrows and scrolls with the
+  free `Ctrl+Shift+↑/↓` chords (consumed only when the list overflows, with a
+  `Ctrl+Shift+↑↓: scroll` footer hint). A new completion re-anchors the
+  window. `/goal-status` renders the same anchored window as a static
   snapshot; the window and indicators stay width-safe at 40–140 columns.
 - **Unified goal dashboard** (see `docs/unified-dashboard.md`): one dashboard
   component in compact (above-editor) and expanded modes, driven by a shared

--- a/README.md
+++ b/README.md
@@ -290,7 +290,9 @@ Always visible above the editor while a goal is focused:
 
 Every rendered line is width-aware: the dashboard adapts to wide, medium, narrow, and very-narrow terminals and never overflows the available width.
 
-See [`docs/unified-dashboard.md`](docs/unified-dashboard.md) for the full layout specification, status states, and migration behavior.
+The task list is a scrollable **window** that by default is anchored to the most recently completed task — recent completions stay visible instead of the earliest tasks. `F6` engages compact scrolling; while the dashboard is focused (expanded, or compact after `F6`), `↑/↓` scroll a row, `PgUp/PgDn` scroll a page, and `Home/End` jump to the ends; `Esc` returns the keys to the editor. A new completion re-anchors the window.
+
+See [`docs/unified-dashboard.md`](docs/unified-dashboard.md) for the full layout specification, status states, scrolling behavior, and migration behavior.
 
 ## Completion review
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Always visible above the editor while a goal is focused:
 └─ Esc/Ctrl+Shift+T: collapse ────────────────────────────────────────┘
 ```
 
-Every rendered line is width-aware: the dashboard adapts to wide, medium, narrow, and very-narrow terminals and never overflows the available width. It follows a pastel theme palette with a monochrome fallback: gray borders, pastel-amber task rows with colour-coded markers (✓ complete green, ▸ current teal, ~ skipped gray, · pending amber), and status symbols in their state color.
+Every rendered line is width-aware: the dashboard adapts to wide, medium, narrow, and very-narrow terminals and never overflows the available width. It follows a pastel theme palette with a monochrome fallback: a light steel-gray-blue outer frame (`mdLink`) with gray interior rules, pastel-amber task rows with colour-coded markers and ids (✓ complete green, ▸ current teal, ~ skipped gray, · pending amber), accent-tinted progress and brand, and status symbols in their state color.
 
 The task list is a scrollable **window** that by default is anchored to the most recently completed task — recent completions stay visible instead of the earliest tasks. The expanded dashboard is modal and scrolls with the plain `↑/↓`, `PgUp/PgDn`, and `Home/End` keys; the compact widget keeps the editor's arrows untouched and scrolls with the free `Ctrl+Shift+↑/↓` chords (pi leaves those unbound). A new completion re-anchors the window.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Sisyphus goals work well for migrations, staged refactors, release procedures, d
 
 The `/goal` and `/sisyphus` commands start a guided drafting process. The agent can ask focused questions, clarify the objective, and propose a task plan for confirmation.
 
+The proposal is written to the conversation as a durable summary (objective, plan, verification, automatic continuation, auditor state); confirming it creates and focuses the goal and starts working automatically.
+
 ### Direct goal creation
 
 The `/goal-direct` and `/sisyphus-direct` commands create a goal immediately from a complete objective.
@@ -56,7 +58,11 @@ Approved goals are archived as complete. Goals requiring additional work remain 
 
 ### Visible status
 
-An above-editor widget shows the focused goal, its status, file path, and progress.
+An above-editor widget shows the focused goal: its status, focus state, other open goals, time and token usage, task progress, the current task, and the goal file path.
+
+Press `Ctrl+Shift+T` to expand the widget into the full unified dashboard — the complete task tree with the current task highlighted, the current task's verification contract and evidence, the goal-level verification contract, and a recent-activity feed derived from the durable goal ledger. Press `Esc` or `Ctrl+Shift+T` again to collapse it.
+
+During an independent completion audit the widget shows a structured audit dashboard (five review stages and a progress bar); after the audit it shows the approval or changes-required result, then returns to the normal view.
 
 ### Goal controls
 
@@ -216,7 +222,7 @@ Pressing `Esc` during active work pauses the goal.
 
 ## Tasks and verification
 
-The agent can divide a goal into tasks and subtasks and update them as work progresses.
+The agent can divide a goal into tasks and subtasks and update them as work progresses. The current task is tracked explicitly (persisted as the goal's execution focus) and highlighted in the dashboard; starting a task with `update_goal_task(status="start")` sets it, and completing or skipping it clears it.
 
 Verification contracts describe the evidence required for completion. They can apply to the entire goal or to an individual task.
 
@@ -234,6 +240,58 @@ Confirm the new command appears in the help menu.
 Verify that the generated report contains every required section.
 ```
 
+## Unified dashboard
+
+`pi-goal-x` renders one dashboard component in two modes; the above-editor widget, `/goal-status`, and the completion flow all derive from the same presentation model, so they can never disagree about the data.
+
+### Compact mode
+
+Always visible above the editor while a goal is focused:
+
+```text
+╭─ pi-goal-x ─ Add CSV export to reports ─────── 12m47s · 18.2K tok ─╮
+│ ● In progress · Focused: yes · Other goals: 2                      │
+│ Tasks  [██████░░░░] 3/5 · 60%                                      │
+├─ Tasks ────────────────────────────────────────────────────────────┤
+│ ✓ t1  Review reports page and data source                          │
+│ ✓ t2  Implement filtered CSV export                                │
+│ ▸ t3  Add the download button                                      │
+│ · t4  Add documentation                                            │
+│ … +1 more task                                                     │
+│ Current  t3 · Add the download button                              │
+│ Subtasks [███████░░░] 2/3 · 67%                                    │
+│ Verify   Run npm test with zero failures.                          │
+│ File     .pi/goals/active_goal_...                                 │
+╰─ Ctrl+Shift+T: expand tasks ───────────────────────────────────────╯
+```
+
+### Expanded mode
+
+`Ctrl+Shift+T` expands the same component: full task tree (✓ complete, ▸ current, ~ skipped, · pending), the current-task block with its contract and evidence, goal-level verification, and recent activity.
+
+```text
+├─ Progress ──────────────────────────────────────────────────────────┤
+│ [██████░░░░] 3/5 tasks · 60%                                       │
+├─ Tasks ─────────────────────────────────────────────────────────────┤
+│ ✓ t1  Review reports page and data source                          │
+│ ✓ t2  Implement filtered CSV export                                │
+│ ▸ t3  Add the download button                                      │
+│   ✓ t3.1  Add loading state                                         │
+│   · t3.3  Add error handling                                        │
+│ · t4  Add documentation                                             │
+├─ Current task ──────────────────────────────────────────────────────┤
+│ t3 · Add the download button                                        │
+│ Subtasks [███████░░░] 2/3 · 67%                                     │
+│ Contract: The button downloads a CSV using the active filters.      │
+├─ Verification ──────────────────────────────────────────────────────┤
+│ Run npm test with zero failures.                                    │
+└─ Esc/Ctrl+Shift+T: collapse ────────────────────────────────────────┘
+```
+
+Every rendered line is width-aware: the dashboard adapts to wide, medium, narrow, and very-narrow terminals and never overflows the available width.
+
+See [`docs/unified-dashboard.md`](docs/unified-dashboard.md) for the full layout specification, status states, and migration behavior.
+
 ## Completion review
 
 When the agent reports a goal as complete, `pi-goal-x` starts an independent completion review.
@@ -245,9 +303,9 @@ The auditor examines:
 * Verification contracts
 * The current workspace
 
-An approved goal is archived as complete. Review feedback is added to any goal that requires further work.
+An approved goal is archived as complete, and the archive path is reported. Review feedback is added to any goal that requires further work, and the dashboard shows the changes-required result before returning to the normal view.
 
-Press `Esc` to stop an active audit.
+Press `Esc` to stop an active audit (completing without audit is recorded explicitly and never presented as independently approved).
 
 ## Goal storage
 
@@ -273,7 +331,8 @@ Each session can focus on one goal while the project keeps other goals open.
 /goal-direct <objective>     Create a regular goal immediately
 /sisyphus-direct <objective> Create an ordered goal immediately
 /goal-list                   List open goals
-/goal-status                 Show the focused goal
+/goal-status                 Show the focused goal (unified dashboard)
+/goal-status verbose         Show the focused goal with full diagnostic detail
 /goal-focus                  Select an open goal
 /goal-unfocus                Remove the session’s focus
 /goal-tweak <change>         Revise the focused goal

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Always visible above the editor while a goal is focused:
 └─ Esc/Ctrl+Shift+T: collapse ────────────────────────────────────────┘
 ```
 
-Every rendered line is width-aware: the dashboard adapts to wide, medium, narrow, and very-narrow terminals and never overflows the available width.
+Every rendered line is width-aware: the dashboard adapts to wide, medium, narrow, and very-narrow terminals and never overflows the available width. It follows a pastel theme palette with a monochrome fallback: gray borders, pastel-amber task rows with colour-coded markers (✓ complete green, ▸ current teal, ~ skipped gray, · pending amber), and status symbols in their state color.
 
 The task list is a scrollable **window** that by default is anchored to the most recently completed task — recent completions stay visible instead of the earliest tasks. The expanded dashboard is modal and scrolls with the plain `↑/↓`, `PgUp/PgDn`, and `Home/End` keys; the compact widget keeps the editor's arrows untouched and scrolls with the free `Ctrl+Shift+↑/↓` chords (pi leaves those unbound). A new completion re-anchors the window.
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Always visible above the editor while a goal is focused:
 
 Every rendered line is width-aware: the dashboard adapts to wide, medium, narrow, and very-narrow terminals and never overflows the available width.
 
-The task list is a scrollable **window** that by default is anchored to the most recently completed task — recent completions stay visible instead of the earliest tasks. `F6` engages compact scrolling; while the dashboard is focused (expanded, or compact after `F6`), `↑/↓` scroll a row, `PgUp/PgDn` scroll a page, and `Home/End` jump to the ends; `Esc` returns the keys to the editor. A new completion re-anchors the window.
+The task list is a scrollable **window** that by default is anchored to the most recently completed task — recent completions stay visible instead of the earliest tasks. The expanded dashboard is modal and scrolls with the plain `↑/↓`, `PgUp/PgDn`, and `Home/End` keys; the compact widget keeps the editor's arrows untouched and scrolls with the free `Ctrl+Shift+↑/↓` chords (pi leaves those unbound). A new completion re-anchors the window.
 
 See [`docs/unified-dashboard.md`](docs/unified-dashboard.md) for the full layout specification, status states, scrolling behavior, and migration behavior.
 

--- a/docs/pi-goal-x-unified-dashboard-plan.md
+++ b/docs/pi-goal-x-unified-dashboard-plan.md
@@ -1,0 +1,1667 @@
+# pi-goal-x Unified Dashboard and Goal Lifecycle Implementation Plan
+
+## Delivery model
+
+All work described in this document will be delivered in **one pull request**.
+
+The pull request will include the data-model changes, runtime changes, unified dashboard, merged task view, goal-status redesign, audit presentation, migration handling, tests, documentation, and changelog updates. The work should be committed in reviewable internal commits, but it must land as a single coherent feature.
+
+---
+
+## 1. Objective
+
+Upgrade `pi-goal-x` into a polished, complete goal-execution experience for long-running work.
+
+The finished system must support the full lifecycle:
+
+1. Guided goal creation.
+2. Explicit confirmation.
+3. Immediate automatic execution.
+4. Persistent progress visibility.
+5. Structured task and subtask tracking.
+6. A clearly identified current task.
+7. Visible verification requirements.
+8. Human-readable recent activity.
+9. Independent completion auditing.
+10. Clear approval or rejection.
+11. Reliable archival with a permanent record.
+
+At any point, the user should be able to understand:
+
+- What goal is focused.
+- What state the goal is in.
+- What the agent is doing now.
+- What has already been completed.
+- What remains.
+- Which task and subtask are current.
+- What evidence is required.
+- How much active time and token usage has accumulated.
+- Whether other goals remain open.
+- Whether completion is being audited.
+- Whether the audit passed or failed.
+- Where the durable goal record is stored.
+
+The design must work well in narrow and wide terminals, preserve compatibility with existing goal files, and avoid unnecessary terminal redraws that disrupt scrollback.
+
+---
+
+## 2. Design principles
+
+### 2.1 One source of truth
+
+The dashboard, `/goal-status`, completion summaries, and tests must all derive from the same presentation model.
+
+There must not be separate formatting logic that gradually diverges between:
+
+- The above-editor widget.
+- The goal-status command.
+- The task overlay.
+- Audit progress.
+- Completion messages.
+
+### 2.2 Persist meaningful execution state
+
+Anything important enough to show as factual progress must be derived from persisted state or the durable ledger.
+
+Do not fabricate display-only state for:
+
+- Current task.
+- Task completion.
+- Verification status.
+- Audit result.
+- Archive location.
+- Recent activity.
+
+### 2.3 Progressive disclosure
+
+The default dashboard should be visually rich but compact.
+
+More detail should be available by expanding the same dashboard rather than opening an unrelated interface.
+
+The dashboard should have two presentation modes:
+
+- **Compact mode:** persistent summary above the editor.
+- **Expanded mode:** integrated task tree, current-task details, verification, evidence, and recent activity.
+
+### 2.4 Terminal-first visual quality
+
+The UI should be as polished as the host TUI permits:
+
+- Balanced spacing.
+- Clear visual hierarchy.
+- Semantic color.
+- Consistent borders.
+- Stable alignment.
+- Width-aware truncation.
+- Useful progress bars.
+- No line overflow.
+- No dependence on color alone.
+
+### 2.5 Minimal redraw churn
+
+Normal goal rendering must not introduce a once-per-second redraw loop.
+
+Elapsed time should refresh on meaningful events such as:
+
+- Turn start.
+- Turn end.
+- Tool progress.
+- Task updates.
+- Goal updates.
+- Focus changes.
+- Explicit status requests.
+- Audit progress.
+
+The audit may retain a short-lived animation timer because it is a temporary foreground process.
+
+---
+
+## 3. Required user experience
+
+## 3.1 Guided goal creation
+
+Running:
+
+```text
+/goal <initial request>
+```
+
+must begin a guided drafting session.
+
+The agent should:
+
+- Identify material ambiguity.
+- Ask only the questions required to make the goal executable.
+- Offer recommended answers where appropriate.
+- Allow custom answers.
+- Build a complete objective.
+- Propose a useful task plan when the work naturally decomposes.
+- Define or extract a verification contract.
+- Present the complete proposal for confirmation.
+
+The confirmation experience must show:
+
+- Goal type.
+- Normalized objective.
+- Constraints and boundaries.
+- Automatic-continuation state.
+- Auditor state.
+- Proposed task hierarchy.
+- Verification requirements.
+- Token budget when configured.
+
+The user must be able to:
+
+- Confirm and begin.
+- Continue refining.
+- Cancel without creating a goal.
+
+No persistent goal may be created before confirmation succeeds.
+
+## 3.2 Direct creation
+
+The direct commands must continue to work:
+
+```text
+/goal-direct <complete objective>
+/sisyphus-direct <ordered objective>
+```
+
+Direct creation should:
+
+- Validate the objective.
+- Extract verification requirements.
+- Create the goal.
+- Focus it for the current session.
+- Persist it.
+- Start accounting.
+- Begin automatic continuation when enabled.
+
+## 3.3 Immediate automatic execution
+
+After confirmation or direct creation:
+
+- The goal becomes focused.
+- The active goal file is written.
+- Accounting begins.
+- The agent starts the first execution turn automatically.
+- Productive turns continue until the goal pauses, blocks, reaches a budget, or enters completion review.
+
+Automatic continuation must stop when:
+
+- The user pauses the goal.
+- The agent reports a blocker.
+- The goal is unfocused.
+- The goal reaches its token budget.
+- A stale continuation is detected.
+- The current turn performed no meaningful work.
+- The user interrupts execution.
+- Completion review begins.
+- The goal is completed.
+
+---
+
+## 4. Unified dashboard
+
+The current goal widget and task overlay will be merged into one unified dashboard component.
+
+The separate task overlay should no longer be a parallel UI with separate formatting and navigation logic. Its useful behavior should move into the dashboard's expanded mode.
+
+The existing task shortcut may be retained, but it should toggle the dashboard between compact and expanded task views.
+
+Suggested behavior:
+
+```text
+Ctrl+Shift+T  Toggle expanded goal dashboard
+```
+
+If the host keybinding system supports a clearer default, use that instead, but keep the action discoverable in help and the dashboard footer.
+
+## 4.1 Compact mode
+
+Compact mode is always visible above the editor while a goal is focused.
+
+Wide-terminal example:
+
+```text
+┌─ pi-goal-x ─ Add CSV export to reports ─────────────── 12m47s · 18.2K tok ─┐
+│ ● In progress          Focused: yes        Other goals: 2                  │
+│ Tasks  [██████░░░░] 3/5 · 60%                                              │
+│ Current  t3 · Add the download button                                      │
+│ Subtasks [███████░░░] 2/3 · 67%                                            │
+│ Verify   Run npm test with zero failures.                                  │
+│ File     .pi/goals/active_goal_...                                          │
+└─ Enter/Ctrl+Shift+T: expand tasks ──────────────────────────────────────────┘
+```
+
+The exact shortcut hint should match the implemented interaction.
+
+## 4.2 Expanded mode
+
+Expanded mode replaces the separate task overlay and uses the same dashboard component.
+
+It should show:
+
+- Goal header.
+- Goal status.
+- Focus state.
+- Time and token usage.
+- Active or archived path.
+- Overall task progress.
+- Full task tree.
+- Current task highlight.
+- Current task verification contract.
+- Current task evidence.
+- Current task subtasks.
+- Recent completed tasks.
+- Recent activity.
+- Goal-level verification contract.
+- Other open goals.
+- Useful keyboard hints.
+
+Example:
+
+```text
+┌─ pi-goal-x ─ Add CSV export to reports ─────────────── 12m47s · 18.2K tok ─┐
+│ Status: ● In progress   Focused: yes   Other goals: 2                      │
+│ File: .pi/goals/active_goal_...                                             │
+├─ Progress ──────────────────────────────────────────────────────────────────┤
+│ [██████░░░░] 3/5 tasks · 60%                                               │
+├─ Tasks ─────────────────────────────────────────────────────────────────────┤
+│ ✓ t1  Review reports page and data source                                  │
+│ ✓ t2  Implement filtered CSV export                                        │
+│ ▸ t3  Add the download button                                              │
+│   ✓ t3.1  Add loading state                                                 │
+│   ✓ t3.2  Generate timestamped filename                                    │
+│   ▸ t3.3  Add error handling                                                │
+│ · t4  Add documentation                                                    │
+│ · t5  Add and run tests                                                    │
+├─ Current task ──────────────────────────────────────────────────────────────┤
+│ t3 · Add the download button                                               │
+│ Subtasks: [███████░░░] 2/3 · 67%                                           │
+│ Contract: The button downloads a CSV using the active filters.              │
+│ Evidence: Loading state and filename behavior implemented.                  │
+├─ Verification ──────────────────────────────────────────────────────────────┤
+│ Run npm test with zero failures.                                            │
+├─ Recent activity ───────────────────────────────────────────────────────────┤
+│ ✓ Completed filtered CSV serialization                                     │
+│ ✓ Added loading and filename behavior                                      │
+│ ▸ Started download error handling                                          │
+└─ Esc/Ctrl+Shift+T: collapse ────────────────────────────────────────────────┘
+```
+
+## 4.3 Unfocused state
+
+When open goals exist but none is focused:
+
+```text
+┌─ pi-goal-x ─ Goal focus required ───────────────────────────────────────────┐
+│ 3 open goals are available.                                                │
+│ Run /goal-focus to choose the goal for this session.                       │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## 4.4 Paused state
+
+Paused goals should clearly show:
+
+- Paused status.
+- Who paused the goal.
+- Pause reason.
+- Suggested next action.
+- Resume command.
+
+## 4.5 Blocked state
+
+Blocked goals should prominently show:
+
+- Blocker.
+- Suggested user action.
+- Current task.
+- Last useful progress.
+- Resume or tweak command.
+
+## 4.6 Budget-limited state
+
+Budget-limited goals should show:
+
+- Used and configured token budget.
+- Percentage used.
+- Goal status.
+- Current task.
+- Suggested next action.
+
+## 4.7 Complete state
+
+Before archival completes:
+
+```text
+┌─ pi-goal-x ─ Goal complete ─────────────────────────────────────────────────┐
+│ ✓ All required work is complete.                                           │
+│ Waiting for final archival.                                                │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+After archival, the persistent dashboard should clear or focus the next goal according to existing settings.
+
+---
+
+## 5. Visual design specification
+
+## 5.1 Border system
+
+Use a consistent box-drawing system:
+
+- `┌ ┐ └ ┘` for outer borders.
+- `├ ┤` for section separators.
+- `─` for horizontal rules.
+- `│` for vertical edges.
+
+The renderer must be capable of falling back to a simpler ASCII border if the host or environment cannot render box-drawing characters reliably.
+
+## 5.2 Status symbols
+
+Use symbols consistently:
+
+- `●` running.
+- `○` idle.
+- `◐` paused.
+- `⊘` blocked.
+- `⛽` budget limited.
+- `✓` complete.
+- `◌` active audit stage.
+- `·` pending.
+- `✗` failed.
+- `▸` current task or current subtask.
+
+Status labels must remain explicit so the interface is understandable without symbols.
+
+## 5.3 Progress bars
+
+Use a fixed logical scale with width selected by available terminal space.
+
+Examples:
+
+```text
+[██████░░░░] 3/5 · 60%
+[███████░░░] 2/3 · 67%
+```
+
+Progress bars must:
+
+- Clamp values to valid bounds.
+- Handle zero tasks.
+- Handle all-complete state.
+- Avoid misleading percentages.
+- Use semantic color where available.
+- Remain readable without color.
+
+## 5.4 Spacing and hierarchy
+
+The dashboard should use:
+
+- One-line title/header.
+- Clear section separators.
+- Consistent label widths where practical.
+- One blank line only where it materially improves readability.
+- Indentation for task hierarchy.
+- Strong emphasis on the current task.
+- Muted treatment for paths and secondary metadata.
+
+## 5.5 Responsive layouts
+
+Define explicit rendering modes.
+
+### Wide: 100 columns and above
+
+- Full border.
+- Multiple fields on one line.
+- Full task titles.
+- Wider progress bars.
+- Current-task details.
+- Rich footer hints.
+
+### Medium: 70–99 columns
+
+- Full border.
+- Mostly one field per line.
+- Shorter progress bars.
+- Truncated paths and contracts.
+- Compact current-task block.
+
+### Narrow: 50–69 columns
+
+- Compact border.
+- Short labels.
+- Reduced metadata.
+- One task line at a time.
+- Current task and progress remain visible.
+
+### Very narrow: below 50 columns
+
+Render only the essential summary:
+
+```text
+┌ Goal · In progress ───────┐
+│ CSV export                │
+│ Tasks 3/5 · 60%           │
+│ ▸ Add download button     │
+│ Verify: npm test passes   │
+└───────────────────────────┘
+```
+
+The renderer must never emit a line wider than the available terminal width.
+
+## 5.6 ANSI and Unicode safety
+
+All truncation and alignment must use visible-width-aware helpers.
+
+Test with:
+
+- ANSI colors.
+- Unicode task titles.
+- Double-width characters.
+- Long paths.
+- Long contracts.
+- Long evidence.
+- Long auditor names.
+
+---
+
+## 6. Shared dashboard view model
+
+Create:
+
+```text
+extensions/widgets/goal-dashboard-model.ts
+```
+
+This module must contain pure data derivation only. It should not import TUI rendering components.
+
+Suggested model:
+
+```ts
+export interface GoalDashboardModel {
+  goalId: string;
+  title: string;
+
+  status: {
+    code:
+      | "running"
+      | "idle"
+      | "paused"
+      | "blocked"
+      | "budget_limited"
+      | "complete";
+    label: string;
+    reason?: string;
+    suggestedAction?: string;
+  };
+
+  focused: boolean;
+  filePath?: string;
+
+  usage: {
+    activeSeconds: number;
+    elapsedLabel: string;
+    tokens: number;
+    tokenLabel: string;
+  };
+
+  budget?: {
+    used: number;
+    total: number;
+    percentage: number;
+    remaining: number;
+  };
+
+  taskProgress?: {
+    completed: number;
+    total: number;
+    percentage: number;
+  };
+
+  taskTree: DashboardTaskNode[];
+
+  currentTask?: {
+    id: string;
+    title: string;
+    depth: number;
+    completedSubtasks: number;
+    totalSubtasks: number;
+    subtaskPercentage: number;
+    verificationContract?: string;
+    evidence?: string;
+  };
+
+  goalVerificationContract?: string;
+  otherOpenGoals: number;
+  recentActivity: GoalActivityItem[];
+}
+
+export interface DashboardTaskNode {
+  id: string;
+  title: string;
+  status: "pending" | "complete" | "skipped";
+  depth: number;
+  isCurrent: boolean;
+  verificationContract?: string;
+  evidence?: string;
+}
+```
+
+Add pure helpers:
+
+```ts
+deriveGoalDashboardModel(...)
+deriveGoalStatus(...)
+deriveTopLevelTaskProgress(...)
+flattenTaskTree(...)
+deriveCurrentTask(...)
+deriveCurrentTaskSubtaskProgress(...)
+deriveGoalActivity(...)
+formatDashboardDuration(...)
+formatCompactTokens(...)
+formatBudget(...)
+```
+
+Use this model for:
+
+- Persistent compact dashboard.
+- Expanded dashboard.
+- `/goal-status`.
+- Audit transition back to normal display.
+- Golden tests.
+- Documentation examples.
+
+---
+
+## 7. Data model changes
+
+## 7.1 Persist current task
+
+Extend `GoalRecord`:
+
+```ts
+export interface GoalRecord {
+  // Existing fields...
+  currentTaskId?: string;
+}
+```
+
+Keep it optional for compatibility.
+
+Do not add `in_progress` to `TaskStatus`.
+
+Task status should remain:
+
+```ts
+type TaskStatus = "pending" | "complete" | "skipped";
+```
+
+`currentTaskId` describes execution focus, while task status describes completion state.
+
+## 7.2 Persist current subtask
+
+A separate `currentSubtaskId` is not required if every task and subtask already has a globally unique ID.
+
+`currentTaskId` may point to any node in the task tree.
+
+The dashboard should derive:
+
+- The current node.
+- Its parent task when applicable.
+- Its sibling/subtask progress.
+- Its depth.
+
+## 7.3 Add task-start ledger event
+
+Add:
+
+```ts
+interface TaskStartedEvent {
+  type: "task_started";
+  goalId: string;
+  taskId: string;
+  at: string;
+}
+```
+
+Use existing completion and skip events for terminal states.
+
+## 7.4 Normalization rules
+
+When loading a goal:
+
+- Accept `currentTaskId` only when it references an existing pending task.
+- Clear it when the task is complete.
+- Clear it when the task is skipped.
+- Clear it when the task no longer exists.
+- Leave it absent for historical files.
+- Do not rewrite old files solely because the field is absent.
+
+For display only, if no persisted current task exists, the dashboard may fall back to the first pending task. The fallback must be visually or internally marked as inferred so it is not persisted accidentally.
+
+## 7.5 Task-list replacement rules
+
+When a task list is replaced or restructured:
+
+- Preserve matching task statuses and evidence.
+- Preserve `currentTaskId` only if the same ID remains pending.
+- Otherwise clear it.
+- Recompute dashboard state immediately.
+
+---
+
+## 8. Task tool changes
+
+Extend `update_goal_task` to support explicit task execution focus.
+
+Suggested input:
+
+```ts
+{
+  task_id: string;
+  action: "start" | "complete" | "skip";
+  evidence?: string;
+  reason?: string;
+}
+```
+
+## 8.1 Start
+
+Validation:
+
+- A focused goal exists.
+- The goal is active or valid for task editing.
+- The task exists.
+- The task is pending.
+
+Effect:
+
+- Set `currentTaskId`.
+- Append `task_started`.
+- Persist the goal.
+- Refresh the dashboard.
+- Include the task contract in the next continuation prompt.
+
+## 8.2 Complete
+
+Validation:
+
+- The task exists.
+- Required subtasks are complete unless lightweight rules permit otherwise.
+- Required evidence is present.
+- The task is not already complete or skipped.
+
+Effect:
+
+- Set status to complete.
+- Save completion timestamp.
+- Save evidence.
+- Clear `currentTaskId` if it matches.
+- Append `task_completed`.
+- Optionally infer the next pending task for display.
+- Refresh the dashboard.
+
+## 8.3 Skip
+
+Validation:
+
+- The task exists.
+- A reason is supplied when required.
+- The task is not already terminal.
+
+Effect:
+
+- Set status to skipped.
+- Save timestamp and reason.
+- Clear `currentTaskId` if it matches.
+- Append `task_skipped`.
+- Refresh the dashboard.
+
+---
+
+## 9. Task progress semantics
+
+## 9.1 Overall task progress
+
+The main dashboard progress should count top-level tasks.
+
+This keeps the main percentage aligned with major milestones.
+
+A top-level task counts as done when it is:
+
+- Complete.
+- Skipped.
+
+## 9.2 Expanded task tree
+
+Expanded mode should show every task and subtask recursively.
+
+Each task row should show:
+
+- Completion marker.
+- Current-task marker.
+- ID.
+- Title.
+- Optional verification indicator.
+- Optional evidence indicator.
+
+Suggested markers:
+
+```text
+✓ complete
+~ skipped
+▸ current
+· pending
+```
+
+## 9.3 Current-task subtask progress
+
+For the current task:
+
+- If it has direct children, show progress across those children.
+- If the current task is itself a subtask, show progress among its siblings or omit the ratio if that would be confusing.
+- Use one documented rule consistently.
+
+Preferred rule:
+
+- For a parent task, show direct-child completion.
+- For a leaf task, omit subtask progress.
+
+## 9.4 All tasks complete
+
+When all top-level tasks are done:
+
+```text
+Tasks [██████████] 5/5 · 100%
+Current: All tasks complete
+```
+
+The expanded dashboard should retain the completed task tree until audit or archival begins.
+
+## 9.5 Tasks disabled
+
+When tasks are disabled:
+
+- Omit task sections.
+- Keep goal status, verification, usage, path, and focus.
+- Do not show empty separators.
+
+---
+
+## 10. Merging the existing task overlay
+
+The useful behavior currently associated with the task overlay should be moved into the dashboard.
+
+This includes:
+
+- Recursive task rendering.
+- Current selection.
+- Task detail.
+- Evidence.
+- Verification contracts.
+- Keyboard navigation where useful.
+- Width-safe rendering.
+- Task counts.
+- Nested indentation.
+
+Implementation direction:
+
+1. Move reusable tree derivation into `goal-dashboard-model.ts`.
+2. Move reusable task-row rendering into the dashboard renderer.
+3. Add a dashboard expansion state to `GoalWidgetComponent`.
+4. Route the task-overlay shortcut to `toggleExpanded()`.
+5. Remove separate overlay registration after parity is achieved.
+6. Retain compatibility helpers only where tests or external imports require them.
+7. Update documentation and help text to describe one dashboard, not two interfaces.
+
+The expanded dashboard should remain a passive status surface unless the current overlay already provides safe, well-tested navigation. Do not add task mutation directly to the dashboard in this change unless it can be done without confusing focus or input behavior.
+
+---
+
+## 11. Verification visibility
+
+## 11.1 Goal-level verification
+
+Show the goal-level verification contract in:
+
+- Compact dashboard.
+- Expanded dashboard.
+- `/goal-status`.
+- Completion review.
+- Archive record.
+
+Compact mode may show a truncated first line.
+
+Expanded mode should show the complete contract, wrapped safely.
+
+## 11.2 Task-level verification
+
+Show the current task's verification contract in the current-task section.
+
+The full task tree may show a small indicator for tasks with contracts, with the full contract shown when the task is current or selected.
+
+## 11.3 Detailed summary
+
+Update `detailedSummary` to include:
+
+```text
+Verification: <contract>
+```
+
+where a contract exists.
+
+---
+
+## 12. Human-readable activity feed
+
+Create:
+
+```text
+extensions/goal-activity.ts
+```
+
+Suggested model:
+
+```ts
+export interface GoalActivityItem {
+  at: string;
+  kind:
+    | "goal"
+    | "task"
+    | "verification"
+    | "audit"
+    | "archive";
+  text: string;
+}
+```
+
+Map durable events to readable activity:
+
+```text
+goal_created
+→ Created and focused the goal.
+
+task_started
+→ Started “Add download button.”
+
+task_completed
+→ Completed “Implement CSV export.”
+
+task_skipped
+→ Skipped “Legacy fallback” — out of scope.
+
+goal_tweaked
+→ Updated the goal objective and task plan.
+
+audit_started
+→ Started independent completion review.
+
+audit_approved
+→ Independent auditor approved completion.
+
+audit_rejected
+→ Completion review requested additional work.
+
+goal_archived
+→ Archived the completed goal.
+```
+
+Rules:
+
+- Prefer task title over task ID.
+- Include evidence only when concise.
+- Exclude low-value checkpoint noise.
+- Deduplicate repeated lifecycle events.
+- Default to the latest three to five useful entries.
+- Preserve full history for verbose status and archived records.
+
+---
+
+## 13. `/goal-status` redesign
+
+`/goal-status` should render the same unified dashboard model as the above-editor widget.
+
+It should be visually polished, not a plain diagnostic dump.
+
+## 13.1 Standard mode
+
+Standard output should contain:
+
+1. A static text rendering of the compact dashboard.
+2. Current-task details.
+3. Recent activity.
+4. Last audit result when available.
+
+Example:
+
+```text
+┌─ pi-goal-x ─ Add CSV export to reports ─────────────── 12m47s · 18.2K tok ─┐
+│ ● In progress          Focused: yes        Other goals: 2                  │
+│ Tasks  [██████░░░░] 3/5 · 60%                                              │
+│ Current  t3 · Add the download button                                      │
+│ Subtasks [███████░░░] 2/3 · 67%                                            │
+│ Verify   Run npm test with zero failures.                                  │
+│ File     .pi/goals/active_goal_...                                          │
+├─ Recent activity ───────────────────────────────────────────────────────────┤
+│ ✓ Completed filtered CSV serialization                                     │
+│ ✓ Added loading and filename behavior                                      │
+│ ▸ Started download error handling                                          │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+The command output should not include effective settings by default.
+
+## 13.2 Verbose mode
+
+Add:
+
+```text
+/goal-status verbose
+```
+
+Verbose output may include:
+
+- Goal ID.
+- Revision.
+- Full objective.
+- Complete task tree.
+- Full task evidence.
+- Full verification contracts.
+- Recent ledger history.
+- Effective settings and provenance.
+- Token budget detail.
+- Pause or blocker detail.
+- Active and archived paths.
+- Last audit report.
+
+## 13.3 Expanded dashboard parity
+
+The standard `/goal-status` output should closely match the expanded dashboard's information hierarchy.
+
+The two surfaces may differ in interaction, but not in data or terminology.
+
+---
+
+## 14. Guided drafting improvements
+
+Preserve the existing questionnaire capabilities:
+
+- Single or multiple questions.
+- Recommended answers.
+- Custom answers.
+- Tab navigation.
+- Auditor toggle.
+- Continue refining.
+- Cancel.
+- Terminal-height safety.
+
+Add a durable proposal summary to the terminal transcript:
+
+```text
+Proposed objective:
+Add CSV export to the reports page using active filters and visible-column
+order, with documentation and passing tests.
+
+Proposed plan:
+1. Review the reports page and data source.
+2. Implement filtered CSV export.
+3. Add the download control.
+4. Add documentation.
+5. Add and run tests.
+
+Verification:
+Run npm test with zero failures.
+
+Automatic continuation: enabled
+Independent auditor: enabled
+```
+
+After confirmation:
+
+```text
+✓ Goal created and focused.
+Continuing automatically with the confirmed plan.
+```
+
+Expanded detail may include:
+
+- Goal ID.
+- Active file path.
+- Task count.
+- Verification contract.
+- Auditor configuration.
+- Token budget.
+
+Capture questionnaire answers before clearing draft state so the confirmed goal report can include them reliably.
+
+---
+
+## 15. Structured audit dashboard
+
+The audit view should use the same visual system as the goal dashboard.
+
+## 15.1 Audit model
+
+Extend auditor progress with structured checks:
+
+```ts
+export type AuditCheckState =
+  | "pending"
+  | "running"
+  | "passed"
+  | "failed";
+
+export interface AuditCheck {
+  id:
+    | "objective"
+    | "verification"
+    | "tasks"
+    | "workspace"
+    | "decision";
+  label: string;
+  state: AuditCheckState;
+  detail?: string;
+}
+
+export interface AuditorDashboardModel {
+  auditorLabel: string;
+  elapsedMs: number;
+  percentage?: number;
+  checks: AuditCheck[];
+  currentTool?: string;
+  currentToolArgs?: string;
+  recentOutput: string[];
+}
+```
+
+## 15.2 Audit stages
+
+The auditor should report:
+
+1. Objective and success criteria.
+2. Verification contracts.
+3. Tasks and evidence.
+4. Workspace inspection.
+5. Final decision.
+
+## 15.3 Audit rendering
+
+Example:
+
+```text
+┌─ Independent completion audit ─ provider/model ─────────────────── 2m18s ─┐
+│ ✓ Objective and success criteria                                           │
+│ ✓ Verification contracts                                                   │
+│ ✓ Tasks and recorded evidence                                              │
+│ ◌ Workspace inspection                                                     │
+│ · Final decision                                                           │
+│ [███████░░░] 72%                                                           │
+└─ Esc: stop audit ───────────────────────────────────────────────────────────┘
+```
+
+Raw tools and recent output should appear only:
+
+- In expanded audit mode.
+- In debug mode.
+- When an unexpected audit failure needs diagnostic detail.
+
+## 15.4 Audit result
+
+Approval:
+
+```text
+┌─ Audit result ─ APPROVED ───────────────────────────────────────────────────┐
+│ ✓ Objective satisfied.                                                     │
+│ ✓ Verification requirements satisfied.                                     │
+│ ✓ Required tasks and evidence accepted.                                    │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+Rejection:
+
+```text
+┌─ Audit result ─ CHANGES REQUIRED ───────────────────────────────────────────┐
+│ ✗ Tests were not run after the final implementation change.                │
+│ ✗ Task “Update documentation” has no completion evidence.                  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+On rejection:
+
+- Keep the goal open.
+- Persist the report.
+- Add findings to the next continuation.
+- Restore the normal dashboard.
+- Show the required next work clearly.
+
+---
+
+## 16. Completion and archival flow
+
+## 16.1 Completion request
+
+When the agent requests completion:
+
+- Reconcile the goal from disk.
+- Validate lifecycle state.
+- Validate task-completion rules.
+- Account remaining usage.
+- Append `completion_requested`.
+- Launch the auditor.
+
+## 16.2 Auditor disabled
+
+When auditing is disabled:
+
+- Record `audit_skipped`.
+- State why it was skipped.
+- Use the same completion transaction.
+- Do not present the result as independently approved.
+
+## 16.3 User abort during audit
+
+Preserve the existing Escape flow.
+
+The user should be able to:
+
+- Continue working.
+- Complete without audit.
+
+Completing without audit must:
+
+- Record the bypass explicitly.
+- Never be labeled approved.
+- Continue through normal archival.
+
+## 16.4 Approval
+
+On approval:
+
+- Persist the audit report.
+- Mark the goal complete.
+- Stop continuation.
+- Allow the final executor summary.
+- Archive at the correct deferred lifecycle point.
+
+## 16.5 Rejection
+
+On rejection:
+
+- Persist the audit report.
+- Keep the goal open.
+- Surface actionable findings.
+- Resume normal work state.
+- Allow the agent to continue correcting the implementation.
+
+## 16.6 Archive transaction
+
+The archive operation should:
+
+1. Acquire the goal lock.
+2. Confirm the expected revision.
+3. Write the completed archived record.
+4. Retire the active record.
+5. Append `goal_archived`.
+6. Update memory.
+7. Clear or change focus according to settings.
+8. Emit the actual archive path.
+
+Success message:
+
+```text
+Goal archived.
+File: .pi/goals/archived/goal_...
+```
+
+Failure behavior:
+
+- Do not claim success.
+- Keep the complete record recoverable.
+- Report the remaining active or temporary path.
+- Write a diagnostic ledger event when possible.
+
+---
+
+## 17. Repository changes
+
+## 17.1 New files
+
+```text
+extensions/widgets/goal-dashboard-model.ts
+extensions/widgets/goal-dashboard-renderer.ts
+extensions/goal-activity.ts
+tests/goal-dashboard-model.test.ts
+tests/goal-activity.test.ts
+tests/goal-dashboard-golden.test.ts
+tests/e2e/goal-lifecycle-dashboard.test.ts
+docs/unified-dashboard.md
+```
+
+`goal-dashboard-renderer.ts` may be folded into `goal-widget.ts` if keeping a separate renderer does not improve clarity. The important requirement is to keep pure model derivation separate from TUI integration.
+
+## 17.2 Primary modified files
+
+```text
+extensions/goal-record.ts
+extensions/goal-ledger.ts
+extensions/goal-task-tools.ts
+extensions/goal-format.ts
+extensions/goal-state.ts
+extensions/goal-drafting.ts
+extensions/goal-questionnaire.ts
+extensions/goal-completion.ts
+extensions/goal-auditor.ts
+extensions/goal-commands.ts
+extensions/widgets/goal-widget.ts
+extensions/widgets/task-list-overlay.ts
+extensions/storage/goal-files.ts
+README.md
+CHANGELOG.md
+tests/.test-manifest.json
+```
+
+## 17.3 Supporting changes as required
+
+```text
+extensions/goal-policy.ts
+extensions/goal-prompts.ts
+extensions/goal-core-tools.ts
+extensions/goal-service.ts
+extensions/goal-events.ts
+tests/tui-test-utils.ts
+```
+
+---
+
+## 18. Implementation sequence inside the single PR
+
+The pull request should be developed in this order to keep the branch continuously testable.
+
+### 18.1 Presentation foundation
+
+- Add the dashboard model.
+- Add task-tree flattening.
+- Add progress derivation.
+- Add status derivation.
+- Add activity derivation.
+- Add model tests.
+
+### 18.2 Current-task persistence
+
+- Add `currentTaskId`.
+- Add normalization.
+- Add task-start events.
+- Extend task tools.
+- Add migration and lifecycle tests.
+
+### 18.3 Unified dashboard component
+
+- Add compact rendering.
+- Add expanded rendering.
+- Merge task-overlay behavior.
+- Add expansion state.
+- Add responsive layouts.
+- Add width and golden tests.
+
+### 18.4 Goal-status integration
+
+- Render from the same dashboard model.
+- Add standard and verbose modes.
+- Remove default settings noise.
+- Add activity and last-audit sections.
+
+### 18.5 Drafting polish
+
+- Add durable proposal summaries.
+- Improve confirmation output.
+- Preserve questionnaire answer summaries.
+
+### 18.6 Audit integration
+
+- Add structured audit stages.
+- Add audit dashboard rendering.
+- Add approval and rejection result cards.
+- Preserve Escape and bypass behavior.
+
+### 18.7 Completion and archival polish
+
+- Add explicit archive-success output.
+- Add archive-failure handling.
+- Add the complete end-to-end lifecycle test.
+
+### 18.8 Documentation and final verification
+
+- Update README.
+- Add unified dashboard documentation.
+- Update command help.
+- Add migration notes.
+- Update changelog.
+- Run all checks.
+
+---
+
+## 19. Testing strategy
+
+## 19.1 Dashboard model tests
+
+Cover:
+
+- Active goal without tasks.
+- Active goal with partial tasks.
+- All tasks complete.
+- Current top-level task.
+- Current nested task.
+- Current parent with subtasks.
+- Current leaf task.
+- Invalid `currentTaskId`.
+- Removed current task.
+- Skipped tasks.
+- Disabled tasks.
+- Goal verification.
+- Task verification.
+- Multiple open goals.
+- Token budget.
+- Paused state.
+- Blocked state.
+- Budget-limited state.
+- Complete state.
+
+## 19.2 Task lifecycle tests
+
+Verify:
+
+- `start` sets `currentTaskId`.
+- Starting another task replaces it.
+- Completing the current task clears it.
+- Skipping the current task clears it.
+- Structural task changes preserve a valid current ID.
+- Structural task changes clear an invalid ID.
+- Existing status, timestamps, and evidence remain intact.
+
+## 19.3 Activity tests
+
+Verify:
+
+- Ledger events map to readable text.
+- Task titles replace IDs.
+- Checkpoint noise is excluded.
+- Evidence is truncated safely.
+- Events are correctly ordered.
+- Duplicate events are merged.
+- Default output is capped.
+- Full history remains available.
+
+## 19.4 Dashboard golden tests
+
+Render compact and expanded dashboards at:
+
+```text
+40 columns
+50 columns
+60 columns
+80 columns
+100 columns
+140 columns
+```
+
+Cover:
+
+- Running goal.
+- Running goal with tasks.
+- Current task with subtasks.
+- Long objective.
+- Long file path.
+- Long verification contract.
+- Unicode content.
+- Paused goal.
+- Blocked goal.
+- Budget-limited goal.
+- Complete goal.
+- Unfocused state.
+- Audit running.
+- Audit approved.
+- Audit rejected.
+
+For every rendered line:
+
+```ts
+assert.ok(visibleWidth(line) <= width);
+```
+
+## 19.5 Dashboard interaction tests
+
+Verify:
+
+- Compact mode is the default.
+- Task shortcut expands the dashboard.
+- The same shortcut or Escape collapses it.
+- Expanded mode does not corrupt editor input.
+- Goal state updates are visible in both modes.
+- Audit mode temporarily replaces the normal view.
+- Normal mode returns after rejection or audit completion.
+- Separate task-overlay registration is removed.
+
+## 19.6 Drafting tests
+
+Verify:
+
+- Questions precede proposals when needed.
+- Recommended answers work.
+- Custom answers work.
+- Proposal includes objective, tasks, verification, continuation, and auditor state.
+- Continue refining does not create a goal.
+- Cancel does not create a goal.
+- Confirm creates exactly one goal.
+- The goal is focused.
+- Questionnaire answers appear in the creation report.
+- Draft state survives compaction.
+- Stale tweak drafts are safely discarded.
+
+## 19.7 Audit tests
+
+Verify each transition:
+
+```text
+objective: pending → running → passed
+verification: pending → running → passed
+tasks: pending → running → passed
+workspace: pending → running → passed
+decision: pending → running → passed or failed
+```
+
+Also verify:
+
+- Auditor identity is shown.
+- Percentage is clamped.
+- Expanded diagnostics retain tool details.
+- Escape behavior works.
+- Rejection keeps the goal open.
+- Approval enters deferred completion.
+- The normal dashboard returns correctly.
+
+## 19.8 Persistence and migration tests
+
+Legacy goal files must:
+
+- Load without `currentTaskId`.
+- Preserve task state.
+- Preserve usage.
+- Preserve verification.
+- Preserve lifecycle status.
+- Archive correctly.
+
+New goal files must:
+
+- Persist `currentTaskId`.
+- Remove stale IDs during normalization.
+- Survive restart.
+- Survive session refocus.
+- Preserve revision safety.
+
+## 19.9 End-to-end lifecycle test
+
+Create a deterministic lifecycle scenario:
+
+1. Start a guided goal.
+2. Answer clarification questions.
+3. Confirm a five-task plan.
+4. Verify goal creation, focus, persistence, and automatic continuation.
+5. Start the first task.
+6. Complete three of five top-level tasks.
+7. Verify the compact dashboard shows:
+   - `3/5`.
+   - `60%`.
+   - Current task.
+   - Subtask progress.
+   - Verification contract.
+8. Expand the dashboard.
+9. Verify the complete task tree and current-task block.
+10. Complete all tasks.
+11. Request completion.
+12. Simulate all audit stages.
+13. Approve.
+14. Verify deferred completion.
+15. Verify archive creation.
+16. Verify the final archive path.
+17. Reload and verify the goal is no longer active.
+
+## 19.10 Full regression suite
+
+All existing tests must remain green, including coverage for:
+
+- Accounting.
+- Automatic continuation.
+- Auditor selection.
+- Drafting.
+- Escape handling.
+- Goal focus.
+- Mutation boundaries.
+- Overflow.
+- Task rendering.
+- Deferred archival.
+- Session growth.
+- Tool visibility.
+- Width safety.
+
+Required commands:
+
+```text
+npm run check
+npm test
+npm run test:integration
+npm run test:all
+```
+
+Run any project benchmark or self-check commands required by the repository before merge.
+
+---
+
+## 20. Backward compatibility
+
+The change must preserve:
+
+- Existing goal-file formats.
+- Existing archived goals.
+- Existing settings.
+- Existing slash commands.
+- Existing direct-goal behavior.
+- Existing Sisyphus behavior.
+- Existing auditor configuration.
+- Existing task evidence.
+- Existing focus behavior.
+
+Compatibility rules:
+
+- New persisted fields are optional.
+- Historical records normalize safely.
+- Existing task IDs remain authoritative.
+- Existing command names do not change.
+- Existing task-overlay shortcut may be retained, but it now expands the unified dashboard.
+- Headless behavior remains functional without TUI rendering.
+- Audit-disabled behavior remains explicit and distinguishable from approval.
+
+---
+
+## 21. Documentation updates
+
+Update the README to explain:
+
+- Guided goal creation.
+- Immediate automatic continuation.
+- The unified dashboard.
+- Compact and expanded modes.
+- Current-task tracking.
+- Task-tree integration.
+- Verification visibility.
+- Recent activity.
+- Independent auditing.
+- Approval, rejection, and archival.
+- Keyboard shortcuts.
+- Standard and verbose goal-status modes.
+
+Add:
+
+```text
+docs/unified-dashboard.md
+```
+
+The document should include:
+
+- Layout examples for wide and narrow terminals.
+- Status-state examples.
+- Expanded task view.
+- Audit view.
+- Keybindings.
+- Accessibility and width behavior.
+- Migration behavior.
+
+Update `CHANGELOG.md` with:
+
+- Unified dashboard.
+- Merged task overlay.
+- Persisted current-task state.
+- Improved goal-status.
+- Structured audit progress.
+- Archive-result improvements.
+
+---
+
+## 22. Acceptance criteria
+
+The single pull request is complete when all of the following are true:
+
+- `/goal` supports clarification and explicit confirmation.
+- No guided goal is created before confirmation.
+- Confirmed goals are immediately focused and started.
+- Automatic continuation works without repetitive user prompts.
+- A polished dashboard is visible for focused goals.
+- The dashboard has compact and expanded modes.
+- The existing task overlay is merged into the dashboard.
+- The expanded dashboard shows the complete task tree.
+- The current task is persisted and clearly highlighted.
+- Current-task subtask progress is visible.
+- Task and goal verification contracts are visible.
+- Time, token usage, focus, path, and other open goals are visible.
+- Progress is derived from persisted goal state.
+- Recent activity is derived from the durable ledger.
+- `/goal-status` uses the same presentation model.
+- `/goal-status` is visually polished.
+- `/goal-status verbose` contains diagnostic detail.
+- Completion launches an independent auditor.
+- Audit progress uses a structured checklist.
+- Auditor identity and elapsed time are visible.
+- Audit rejection leaves the goal open with actionable feedback.
+- Audit approval proceeds through deferred archival.
+- Successful archival reports the real archive path.
+- Failed archival is never reported as successful.
+- Legacy goal files continue to work.
+- Compact and expanded layouts fit narrow and wide terminals.
+- No rendered line exceeds terminal width.
+- Normal goal rendering does not disrupt scrollback with continuous redraws.
+- Separate task-overlay registration is removed after feature parity.
+- All existing tests pass.
+- New model, lifecycle, rendering, migration, audit, interaction, and end-to-end tests pass.
+- README, dashboard documentation, and changelog are updated.

--- a/docs/unified-dashboard.md
+++ b/docs/unified-dashboard.md
@@ -44,7 +44,8 @@ Compact rows, in order:
    (`·`-separated). Colors come from the theme with a monochrome fallback.
 3. Token budget (when configured): `⛽ Budget 18.2K / 50K · 36%`.
 4. Top-level task progress (`3/5 · 60%`); a skipped top-level task counts as
-   done (§9.1).
+   done (§9.1). The fraction and percent are muted; only the progress bar is
+   colourful (accent fill, dim empty cells).
 5. Task list section: the top-level tasks shown by default in **pastel
    amber** (`mdHeading`) with colour-coded markers and ids (✓ complete muted
    green, ▸ current teal, ~ skipped gray, · pending amber), an aligned id
@@ -61,7 +62,10 @@ Compact rows, in order:
 8. Goal-level verification contract (first line, truncated).
 9. Blocked or paused detail (reason, suggested action).
 10. Active (or archived) goal file path.
-11. Footer with the expansion shortcut.
+11. Footer with the expansion shortcut. The whole footer line — leading dash,
+    shortcut hint and trailing fill — is drawn in one frame tone (`mdLink`),
+    so the blue-gray spans the full width with no two-tone split; the header
+    line is likewise one tone with only the `pi-goal-x` brand in accent.
 
 When every top-level task is done, the current line reads
 `Current  All tasks complete`. With `disableTasks` enabled the task rows are

--- a/docs/unified-dashboard.md
+++ b/docs/unified-dashboard.md
@@ -44,8 +44,8 @@ Compact rows, in order:
    (`·`-separated). Colors come from the theme with a monochrome fallback.
 3. Token budget (when configured): `⛽ Budget 18.2K / 50K · 36%`.
 4. Top-level task progress (`3/5 · 60%`); a skipped top-level task counts as
-   done (§9.1). The fraction and percent are muted; only the progress bar is
-   colourful (accent fill, dim empty cells).
+   done (§9.1). The whole progress element is neutral gray — bar fill and
+   empty cells included — so nothing in the progress info is colourful.
 5. Task list section: the top-level tasks shown by default in **pastel
    amber** (`mdHeading`) with colour-coded markers and ids (✓ complete muted
    green, ▸ current teal, ~ skipped gray, · pending amber), an aligned id
@@ -58,7 +58,8 @@ Compact rows, in order:
 6. Current task: `Current  t3 · Add the download button` (id and title in the
    accent color).
 7. Current-task subtask progress (`2/3 · 67%`) when the current task has
-   direct children (the current task's subtasks stay inline).
+   direct children (the current task's subtasks stay inline). The subtask
+   bar and its fraction are neutral gray like the top-level progress.
 8. Goal-level verification contract (first line, truncated).
 9. Blocked or paused detail (reason, suggested action).
 10. Active (or archived) goal file path.

--- a/docs/unified-dashboard.md
+++ b/docs/unified-dashboard.md
@@ -110,22 +110,28 @@ the window starts at the top; when a new task completes the window re-anchors
 to it. `↑ N more tasks` / `… +N more tasks` indicator rows mark rows hidden
 above and below the window.
 
-| Key | Action |
-| --- | --- |
-| `↑` / `↓` | Scroll one task row (window anchored at the latest completion by default) |
-| `PgUp` / `PgDn` | Scroll one page of task rows |
-| `Home` / `End` | Jump to the top / bottom of the list |
-| `F6` | Engage/disengage compact scrolling so the arrow keys scroll the compact widget instead of the editor |
-| `Esc` | Disengage compact scrolling; collapse the expanded dashboard |
+pi has no separate focus — the prompt editor owns the plain arrow keys — so
+the two views scroll differently:
 
-Scrolling keys are active only while the dashboard is focused: the expanded
-dashboard is focused while open (arrows scroll the full task tree, `Esc`
-collapses), and the compact widget is focused once `F6` engages scrolling
-(the footer shows `↑↓/PgUp/PgDn: scroll · Esc done`). Otherwise the arrow and
-page keys belong to the editor — typing and navigation are never hijacked.
-`/goal-status` renders the same anchored window as a static snapshot (it is
-not interactive). The window and its indicators are width-safe at every
-layout width.
+| View | Key | Action |
+| --- | --- | --- |
+| Expanded (modal) | `↑` / `↓` | Scroll one task row |
+| Expanded (modal) | `PgUp` / `PgDn` | Scroll one page of task rows |
+| Expanded (modal) | `Home` / `End` | Jump to the top / bottom of the list |
+| Compact (inline) | `Ctrl+Shift+↑` / `Ctrl+Shift+↓` | Scroll one task row |
+| Compact (inline) | `Ctrl+Shift+PgUp` / `Ctrl+Shift+PgDn` | Scroll one page |
+| Compact (inline) | `Ctrl+Shift+Home` / `Ctrl+Shift+End` | Jump to the top / bottom |
+
+While the expanded dashboard is open it is modal and owns the plain arrow
+keys (like the session tree or model selector); `Esc` collapses it. The
+compact widget never touches the editor's arrows — it scrolls with the
+`Ctrl+Shift` chords, which pi leaves unbound, so typing and navigation are
+never hijacked. The chords are consumed only when the compact list actually
+overflows its viewport; on a short list they pass through unused. When the
+list overflows, the compact footer advertises the chords
+(`Ctrl+Shift+↑↓: scroll`). `/goal-status` renders the same anchored window as
+a static snapshot (it is not interactive). The window and its indicators are
+width-safe at every layout width.
 
 ## Status states
 
@@ -189,9 +195,9 @@ auditor's findings, and returns to the normal dashboard so work can continue.
 | Key | Action |
 | --- | --- |
 | `Ctrl+Shift+T` | Toggle the dashboard between compact and expanded |
-| `↑` / `↓`, `PgUp` / `PgDn`, `Home` / `End` | Scroll the focused task list (see [Scrolling the task list](#scrolling-the-task-list)) |
-| `F6` | Engage/disengage compact scrolling |
-| `Esc` | Disengage compact scrolling or collapse the expanded dashboard; otherwise pause the goal |
+| `↑` / `↓`, `PgUp` / `PgDn`, `Home` / `End` | Scroll the expanded task tree (see [Scrolling the task list](#scrolling-the-task-list)) |
+| `Ctrl+Shift+↑` / `Ctrl+Shift+↓`, `Ctrl+Shift+PgUp` / `Ctrl+Shift+PgDn`, `Ctrl+Shift+Home` / `Ctrl+Shift+End` | Scroll the compact task list |
+| `Esc` | Collapse the expanded dashboard; otherwise pause the goal |
 | `Esc` (during audit) | Stop the audit and choose to continue working or complete without audit |
 
 ## Width behavior

--- a/docs/unified-dashboard.md
+++ b/docs/unified-dashboard.md
@@ -54,7 +54,7 @@ Compact rows, in order:
    minimal). The current task is fully highlighted in the theme's accent
    color (marker, id, title). The whole box chrome — top/bottom frame,
    left/right edges, corners and interior rules — is drawn in one tone: the
-   theme's light steel gray-blue (`mdLink`).
+   theme's neutral gray (`muted`). No blue tinge.
 6. Current task: `Current  t3 · Add the download button` (id and title in the
    accent color).
 7. Current-task subtask progress (`2/3 · 67%`) when the current task has
@@ -63,9 +63,10 @@ Compact rows, in order:
 9. Blocked or paused detail (reason, suggested action).
 10. Active (or archived) goal file path.
 11. Footer with the expansion shortcut. The whole footer line — leading dash,
-    shortcut hint and trailing fill — is drawn in one frame tone (`mdLink`),
-    so the blue-gray spans the full width with no two-tone split; the header
-    line is likewise one tone with only the `pi-goal-x` brand in accent.
+    shortcut hint and trailing fill — is drawn in one frame tone (the
+    neutral-gray `muted`), so the color spans the full width with no two-tone
+    split; the header line is likewise one tone with only the `pi-goal-x`
+    brand in accent.
 
 When every top-level task is done, the current line reads
 `Current  All tasks complete`. With `disableTasks` enabled the task rows are

--- a/docs/unified-dashboard.md
+++ b/docs/unified-dashboard.md
@@ -45,10 +45,13 @@ Compact rows, in order:
 3. Token budget (when configured): `⛽ Budget 18.2K / 50K · 36%`.
 4. Top-level task progress (`3/5 · 60%`); a skipped top-level task counts as
    done (§9.1).
-5. Task list section: the top-level tasks shown by default with colored
-   markers (✓ complete, ▸ current, ~ skipped, · pending), an aligned id
-   column, truncated titles, and a `… +N more` overflow line when the list is
-   longer than the row budget (5 rows at wide, 4 medium, 3 narrow, 2 minimal).
+5. Task list section: the top-level tasks shown by default in **pastel
+   amber** (`mdHeading`) with colour-coded markers (✓ complete muted green,
+   ▸ current teal, ~ skipped gray, · pending amber), an aligned id column,
+   truncated titles, and a `… +N more` overflow line when the list is longer
+   than the row budget (5 rows at wide, 4 medium, 3 narrow, 2 minimal). The
+   current task is highlighted in the theme's accent color; box borders are
+   drawn in the theme's gray (`muted`).
 6. Current task: `Current  t3 · Add the download button`.
 7. Current-task subtask progress (`2/3 · 67%`) when the current task has
    direct children (the current task's subtasks stay inline).

--- a/docs/unified-dashboard.md
+++ b/docs/unified-dashboard.md
@@ -52,9 +52,9 @@ Compact rows, in order:
    column, truncated amber titles, and a `… +N more` overflow line when the
    list is longer than the row budget (5 rows at wide, 4 medium, 3 narrow, 2
    minimal). The current task is fully highlighted in the theme's accent
-   color (marker, id, title). The outer box frame is drawn in the theme's
-   light steel gray-blue (`mdLink`) with interior rules in the theme's gray
-   (`muted`).
+   color (marker, id, title). The whole box chrome — top/bottom frame,
+   left/right edges, corners and interior rules — is drawn in one tone: the
+   theme's light steel gray-blue (`mdLink`).
 6. Current task: `Current  t3 · Add the download button` (id and title in the
    accent color).
 7. Current-task subtask progress (`2/3 · 67%`) when the current task has

--- a/docs/unified-dashboard.md
+++ b/docs/unified-dashboard.md
@@ -100,6 +100,33 @@ When no persisted current task exists, the dashboard falls back to the first
 pending task for display and marks it as inferred — the fallback is never
 persisted.
 
+## Scrolling the task list
+
+Both views show the task list as a **window** over the plan-ordered list, and
+by default the window is **anchored to the most recently completed task** —
+the viewport is "scrolled down" so recent completions (by `completedAt`) are
+visible instead of always showing the earliest tasks. With nothing completed
+the window starts at the top; when a new task completes the window re-anchors
+to it. `↑ N more tasks` / `… +N more tasks` indicator rows mark rows hidden
+above and below the window.
+
+| Key | Action |
+| --- | --- |
+| `↑` / `↓` | Scroll one task row (window anchored at the latest completion by default) |
+| `PgUp` / `PgDn` | Scroll one page of task rows |
+| `Home` / `End` | Jump to the top / bottom of the list |
+| `F6` | Engage/disengage compact scrolling so the arrow keys scroll the compact widget instead of the editor |
+| `Esc` | Disengage compact scrolling; collapse the expanded dashboard |
+
+Scrolling keys are active only while the dashboard is focused: the expanded
+dashboard is focused while open (arrows scroll the full task tree, `Esc`
+collapses), and the compact widget is focused once `F6` engages scrolling
+(the footer shows `↑↓/PgUp/PgDn: scroll · Esc done`). Otherwise the arrow and
+page keys belong to the editor — typing and navigation are never hijacked.
+`/goal-status` renders the same anchored window as a static snapshot (it is
+not interactive). The window and its indicators are width-safe at every
+layout width.
+
 ## Status states
 
 | Symbol | Status | Shown for |
@@ -162,7 +189,9 @@ auditor's findings, and returns to the normal dashboard so work can continue.
 | Key | Action |
 | --- | --- |
 | `Ctrl+Shift+T` | Toggle the dashboard between compact and expanded |
-| `Esc` | Collapse the expanded dashboard; otherwise pause the goal |
+| `↑` / `↓`, `PgUp` / `PgDn`, `Home` / `End` | Scroll the focused task list (see [Scrolling the task list](#scrolling-the-task-list)) |
+| `F6` | Engage/disengage compact scrolling |
+| `Esc` | Disengage compact scrolling or collapse the expanded dashboard; otherwise pause the goal |
 | `Esc` (during audit) | Stop the audit and choose to continue working or complete without audit |
 
 ## Width behavior

--- a/docs/unified-dashboard.md
+++ b/docs/unified-dashboard.md
@@ -46,13 +46,16 @@ Compact rows, in order:
 4. Top-level task progress (`3/5 · 60%`); a skipped top-level task counts as
    done (§9.1).
 5. Task list section: the top-level tasks shown by default in **pastel
-   amber** (`mdHeading`) with colour-coded markers (✓ complete muted green,
-   ▸ current teal, ~ skipped gray, · pending amber), an aligned id column,
-   truncated titles, and a `… +N more` overflow line when the list is longer
-   than the row budget (5 rows at wide, 4 medium, 3 narrow, 2 minimal). The
-   current task is highlighted in the theme's accent color; box borders are
-   drawn in the theme's gray (`muted`).
-6. Current task: `Current  t3 · Add the download button`.
+   amber** (`mdHeading`) with colour-coded markers and ids (✓ complete muted
+   green, ▸ current teal, ~ skipped gray, · pending amber), an aligned id
+   column, truncated amber titles, and a `… +N more` overflow line when the
+   list is longer than the row budget (5 rows at wide, 4 medium, 3 narrow, 2
+   minimal). The current task is fully highlighted in the theme's accent
+   color (marker, id, title). The outer box frame is drawn in the theme's
+   light steel gray-blue (`mdLink`) with interior rules in the theme's gray
+   (`muted`).
+6. Current task: `Current  t3 · Add the download button` (id and title in the
+   accent color).
 7. Current-task subtask progress (`2/3 · 67%`) when the current task has
    direct children (the current task's subtasks stay inline).
 8. Goal-level verification contract (first line, truncated).

--- a/docs/unified-dashboard.md
+++ b/docs/unified-dashboard.md
@@ -1,0 +1,219 @@
+# Unified Dashboard
+
+`pi-goal-x` renders one dashboard component in two presentation modes. The
+above-editor widget, `/goal-status`, and the completion flow all derive from
+the same presentation model (`extensions/widgets/goal-dashboard-model.ts`),
+so they can never drift apart on data or terminology.
+
+- **Compact mode** — a persistent summary above the editor while a goal is
+  focused.
+- **Expanded mode** — the full dashboard: task tree, current-task details,
+  verification, and recent activity. This replaces the former task-list
+  overlay; `Ctrl+Shift+T` now toggles between compact and expanded instead of
+  opening a separate overlay.
+
+Everything shown is derived from persisted goal state and the durable ledger:
+progress, the current task, verification status, the audit result, and recent
+activity are never fabricated for display.
+
+## Compact mode
+
+Always visible above the editor while a goal is focused:
+
+```text
+╭─ pi-goal-x ─ Add CSV export to reports────────────── 12m47s · 18.2K tok ─╮
+│ ● In progress · Focused: yes · Other goals: 2                            │
+│ Tasks  [███████████░░░░░░░] 3/5 · 60%                                    │
+├─ Tasks ─────────────────────────────────────────────────────────────────┤
+│ ✓ t1  Review reports page and data source                                │
+│ ✓ t2  Implement filtered CSV export                                      │
+│ ▸ t3  Add the download button                                            │
+│ · t4  Add documentation                                                  │
+│ … +1 more task                                                           │
+│ Current  t3 · Add the download button                                    │
+│ Subtasks [████████████░░░░░░] 2/3 · 67%                                  │
+│ Verify   Run npm test with zero failures.                                │
+│ File     .pi/goals/active_goal_g1.md                                     │
+╰─ Ctrl+Shift+T: expand tasks─────────────────────────────────────────────╯
+```
+
+Compact rows, in order:
+
+1. Header (rounded corners): title plus elapsed time and token usage.
+2. Status: colored symbol + explicit label, focus state, other open goals
+   (`·`-separated). Colors come from the theme with a monochrome fallback.
+3. Token budget (when configured): `⛽ Budget 18.2K / 50K · 36%`.
+4. Top-level task progress (`3/5 · 60%`); a skipped top-level task counts as
+   done (§9.1).
+5. Task list section: the top-level tasks shown by default with colored
+   markers (✓ complete, ▸ current, ~ skipped, · pending), an aligned id
+   column, truncated titles, and a `… +N more` overflow line when the list is
+   longer than the row budget (5 rows at wide, 4 medium, 3 narrow, 2 minimal).
+6. Current task: `Current  t3 · Add the download button`.
+7. Current-task subtask progress (`2/3 · 67%`) when the current task has
+   direct children (the current task's subtasks stay inline).
+8. Goal-level verification contract (first line, truncated).
+9. Blocked or paused detail (reason, suggested action).
+10. Active (or archived) goal file path.
+11. Footer with the expansion shortcut.
+
+When every top-level task is done, the current line reads
+`Current  All tasks complete`. With `disableTasks` enabled the task rows are
+omitted entirely.
+
+## Expanded mode
+
+`Ctrl+Shift+T` expands the same component:
+
+```text
+╭─ pi-goal-x ─ Add CSV export to reports ─────────────── 12m47s · 18.2K tok ─╮
+│ Status: ● In progress · Focused: yes · Other goals: 2                      │
+│ File: .pi/goals/active_goal_...                                             │
+├─ Progress ──────────────────────────────────────────────────────────────────┤
+│ [██████░░░░] 3/5 tasks · 60%                                               │
+├─ Tasks ─────────────────────────────────────────────────────────────────────┤
+│ ✓ t1  Review reports page and data source                                  │
+│ ✓ t2  Implement filtered CSV export                                        │
+│ ▸ t3  Add the download button ☑                                            │
+│   ✓ t3.1  Add loading state                                                 │
+│   ✓ t3.2  Generate timestamped filename                                    │
+│   · t3.3  Add error handling                                                │
+│ · t4  Add documentation                                                    │
+│ ~ t5  Add and run tests                                                    │
+├─ Current task ──────────────────────────────────────────────────────────────┤
+│ t3 · Add the download button                                               │
+│ Subtasks [███████░░░] 2/3 · 67%                                            │
+│ Contract: The button downloads a CSV using the active filters.             │
+├─ Verification ──────────────────────────────────────────────────────────────┤
+│ Run npm test with zero failures.                                            │
+├─ Recent activity ───────────────────────────────────────────────────────────┤
+│ ✓ Completed “Implement filtered CSV export”. — Done                        │
+│ ▸ Started “Add error handling”.                                             │
+╰─ Esc/Ctrl+Shift+T: collapse ────────────────────────────────────────────────╯
+```
+
+Task markers (§9.2): `✓` complete, `~` skipped, `▸` current, `·` pending.
+A `☑` suffix marks a task that carries its own verification contract; the full
+contract is shown in the current-task block.
+
+When no persisted current task exists, the dashboard falls back to the first
+pending task for display and marks it as inferred — the fallback is never
+persisted.
+
+## Status states
+
+| Symbol | Status | Shown for |
+| --- | --- | --- |
+| `●` | In progress | active goal with auto-continue on |
+| `○` | Idle | active goal with auto-continue off |
+| `◐` | Paused (user/agent) | paused goal, with reason |
+| `⊘` | Blocked | blocked goal, with blocker and suggested action |
+| `⛽` | Budget limited | goal at its token budget, with usage detail |
+| `✓` | Complete | completed goal, before/after archival |
+
+Status labels are always explicit words, so the dashboard stays readable
+without the symbols.
+
+## Unfocused state
+
+When open goals exist but none is focused:
+
+```text
+╭─ pi-goal-x ─ Goal focus required ───────────────────────────────────────────╮
+│ 3 open goals are available.                                                │
+│ Run /goal-focus to choose the goal for this session.                       │
+╰─────────────────────────────────────────────────────────────────────────────╯
+```
+
+## Audit view
+
+During an independent completion audit the widget switches to a structured
+audit dashboard with the same visual system:
+
+```text
+╭─ Independent completion audit ─ anthropic/claude-sonnet:high ─── 2m18s ─╮
+│ ✓ Objective and success criteria                                         │
+│ ✓ Verification contracts                                                 │
+│ ✓ Tasks and recorded evidence                                            │
+│ ◌ Workspace inspection                                                   │
+│ · Final decision                                                         │
+│ [███████░░░] 72%                                                         │
+╰─ Esc: stop audit ─────────────────────────────────────────────────────────╯
+```
+
+Raw auditor tools and output are hidden by default; they appear only in
+expanded/debug audit mode or when the audit failed and diagnostics are needed.
+
+After the audit, a result card shows the outcome:
+
+```text
+╭─ Audit result ─ APPROVED ─────────────────────────────────────────────────╮
+│ ✓ Objective satisfied.                                                    │
+│ ✓ Verification requirements satisfied.                                    │
+│ ✓ Required tasks and evidence accepted.                                   │
+╰────────────────────────────────────────────────────────────────────────────╯
+```
+
+A rejected audit keeps the goal open, shows `CHANGES REQUIRED` with the
+auditor's findings, and returns to the normal dashboard so work can continue.
+
+## Keybindings
+
+| Key | Action |
+| --- | --- |
+| `Ctrl+Shift+T` | Toggle the dashboard between compact and expanded |
+| `Esc` | Collapse the expanded dashboard; otherwise pause the goal |
+| `Esc` (during audit) | Stop the audit and choose to continue working or complete without audit |
+
+## Width behavior
+
+Layout modes (§5.5):
+
+- **Wide (≥100 columns):** full border, multiple fields per line, full task
+  titles, wider progress bars, current-task details.
+- **Medium (70–99):** mostly one field per line, shorter bars, truncated
+  paths and contracts.
+- **Narrow (50–69):** compact border, short labels, reduced metadata, one
+  task line at a time.
+- **Very narrow (<50):** the essential summary only — status, task progress,
+  the current task, and the verification contract.
+
+The renderer never emits a line wider than the terminal width: all alignment
+and truncation is visible-width aware (ANSI colors, Unicode, and double-width
+characters included). Golden tests assert `visibleWidth(line) <= width` for
+every rendered line at 40, 50, 60, 80, 100, and 140 columns.
+
+## `/goal-status`
+
+`/goal-status` renders the same model as the widget.
+
+- Standard mode: a static compact-dashboard rendering, current-task details,
+  recent activity, and the last audit result. No effective-settings noise.
+- `/goal-status verbose`: goal id, revision, full objective, the complete
+  task tree with full evidence and contracts, recent ledger history, token
+  budget detail, pause/blocker detail, active and archived paths, the last
+  audit report, and effective settings with provenance.
+
+## Migration behavior
+
+The current-task focus is a new **optional** persisted field
+(`currentTaskId`) on goal records.
+
+- Legacy goal files load without it and are **never rewritten** just because
+  the field is absent.
+- A persisted `currentTaskId` is accepted only when it references an existing
+  *pending* task; it is cleared when that task is completed, skipped, or
+  removed during normalization.
+- Task-list restructuring preserves the current task only while its id
+  remains pending; otherwise the focus clears and the dashboard recomputes.
+- For display only, the dashboard may infer the first pending task as the
+  current task and marks it as inferred.
+
+## Compatibility
+
+- Existing goal-file formats, archived goals, settings, slash commands, and
+  direct-goal behavior are preserved.
+- The task-overlay shortcut is retained but now expands the unified
+  dashboard; the separate overlay registration is removed.
+- Headless behavior remains functional without TUI rendering, and
+  audit-disabled completion remains explicit and distinct from approval.

--- a/extensions/goal-activity.ts
+++ b/extensions/goal-activity.ts
@@ -1,0 +1,162 @@
+/**
+ * Human-readable activity feed (plan §12).
+ *
+ * Maps the durable ledger into concise, readable activity items for the
+ * unified dashboard, `/goal-status`, and archived records. Pure module: no
+ * TUI imports; formatting lives here so every surface reads the same text.
+ *
+ * Rules (from the plan):
+ * - Prefer the task title over the task id.
+ * - Include completion evidence only when concise.
+ * - Exclude low-value checkpoint noise.
+ * - Deduplicate repeated lifecycle events.
+ * - Default to the latest three to five useful entries; preserve full history
+ *   for verbose status and archived records.
+ */
+
+import { truncateText } from "./goal-core.ts";
+import type { GoalLedgerEvent } from "./goal-ledger.ts";
+
+export type GoalActivityKind = "goal" | "task" | "verification" | "audit" | "archive";
+
+export interface GoalActivityItem {
+	at: string;
+	kind: GoalActivityKind;
+	text: string;
+	/**
+	 * Display marker category for the dashboard feed: done (✓), current (▸),
+	 * skipped (~), or neutral (·) — the renderer maps these to §5.2 symbols.
+	 */
+	marker?: "done" | "current" | "skipped";
+}
+
+export interface DeriveGoalActivityOptions {
+	/** taskId → title lookup; falls back to the raw task id when absent. */
+	taskTitles?: ReadonlyMap<string, string>;
+	/** Maximum items to return (the latest N, in chronological order). Default 5. */
+	limit?: number;
+}
+
+/** Completion evidence longer than this is omitted (kept only for full history). */
+export const CONCISE_EVIDENCE_MAX = 48;
+/** Lifecycle reasons (pause/block/skip) longer than this are truncated. */
+export const ACTIVITY_REASON_MAX = 80;
+
+function quote(title: string): string {
+	return `“${title}”`;
+}
+
+function titleFor(taskTitles: ReadonlyMap<string, string> | undefined, taskId: string): string {
+	const title = taskTitles?.get(taskId);
+	return title ?? taskId;
+}
+
+function oneLine(value: string): string {
+	return value.replace(/\s+/g, " ").trim();
+}
+
+function mapEvent(event: GoalLedgerEvent, taskTitles: ReadonlyMap<string, string> | undefined): GoalActivityItem | undefined {
+	switch (event.type) {
+		case "goal_created":
+			return { at: event.at, kind: "goal", text: "Created and focused the goal." };
+		case "goal_tweaked":
+			return { at: event.at, kind: "goal", text: "Updated the goal objective and task plan." };
+		case "goal_paused":
+			return {
+				at: event.at,
+				kind: "goal",
+				text: event.reason ? `Paused the goal — ${truncateText(oneLine(event.reason), ACTIVITY_REASON_MAX)}` : "Paused the goal.",
+			};
+		case "goal_resumed":
+			return { at: event.at, kind: "goal", text: "Resumed the goal." };
+		case "goal_blocked":
+			return {
+				at: event.at,
+				kind: "goal",
+				text: event.reason ? `Blocked — ${truncateText(oneLine(event.reason), ACTIVITY_REASON_MAX)}` : "Reported a blocker.",
+			};
+		case "goal_budget_limited":
+			return { at: event.at, kind: "goal", text: "Reached the configured token budget." };
+		case "goal_completed":
+			return { at: event.at, kind: "goal", text: "Completed the goal." };
+		case "goal_aborted":
+			return {
+				at: event.at,
+				kind: "goal",
+				text: event.reason ? `Aborted the goal — ${truncateText(oneLine(event.reason), ACTIVITY_REASON_MAX)}` : "Aborted the goal.",
+			};
+		case "task_started":
+			return { at: event.at, kind: "task", marker: "current", text: `Started ${quote(titleFor(taskTitles, event.taskId))}.` };
+		case "task_complete": {
+			const title = titleFor(taskTitles, event.taskId);
+			const evidence = event.evidence ? oneLine(event.evidence) : undefined;
+			// Include evidence only when concise; never bloat the feed.
+			const suffix = evidence && evidence.length <= CONCISE_EVIDENCE_MAX ? ` — ${evidence}` : "";
+			return { at: event.at, kind: "task", marker: "done", text: `Completed ${quote(title)}.${suffix}` };
+		}
+		case "task_skipped": {
+			const title = titleFor(taskTitles, event.taskId);
+			const reason = event.reason ? ` — ${truncateText(oneLine(event.reason), ACTIVITY_REASON_MAX)}` : "";
+			return { at: event.at, kind: "task", marker: "skipped", text: `Skipped ${quote(title)}${reason}.` };
+		}
+		case "task_reopened":
+			return { at: event.at, kind: "task", text: `Reopened ${quote(titleFor(taskTitles, event.taskId))}.` };
+		case "completion_requested":
+			return { at: event.at, kind: "verification", text: "Requested completion review." };
+		case "audit_started":
+			return { at: event.at, kind: "audit", text: "Started independent completion review." };
+		case "audit_result":
+			return event.verdict === "approved"
+				? { at: event.at, kind: "audit", text: "Independent auditor approved completion." }
+				: event.verdict === "disapproved"
+					? { at: event.at, kind: "audit", text: "Completion review requested additional work." }
+					: { at: event.at, kind: "audit", text: "Completion review could not finish." };
+		case "audit_skipped":
+			return {
+				at: event.at,
+				kind: "audit",
+				text:
+					event.reason === "user_aborted"
+						? "Completion review was aborted by the user."
+						: "Skipped independent completion review (auditor disabled).",
+			};
+		case "goal_archived":
+			return { at: event.at, kind: "archive", marker: "done", text: "Archived the completed goal." };
+		// Low-value checkpoint noise / focus churn: excluded from the default feed.
+		case "goal_focused":
+		case "goal_unfocused":
+		case "goal_stalled":
+		case "goal_budget_warning":
+		case "task_list_set":
+			return undefined;
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Derive the readable activity feed for one goal from its durable ledger
+ * events. Returns items in chronological order (oldest first), capped to the
+ * latest `limit` entries, with adjacent duplicates merged.
+ */
+export function deriveGoalActivity(
+	events: readonly GoalLedgerEvent[],
+	goalId: string,
+	options: DeriveGoalActivityOptions = {},
+): GoalActivityItem[] {
+	const { taskTitles, limit = 5 } = options;
+	const items: GoalActivityItem[] = [];
+	for (const event of events) {
+		if (!("goalId" in event) || event.goalId !== goalId) continue;
+		const item = mapEvent(event, taskTitles);
+		if (!item) continue;
+		const last = items[items.length - 1];
+		if (last && last.kind === item.kind && last.text === item.text) continue;
+		items.push(item);
+	}
+	// The ledger is append-ordered, but sort defensively so the feed is
+	// always correctly ordered regardless of input order (stable sort keeps
+	// equal timestamps in input order).
+	items.sort((a, b) => (a.at < b.at ? -1 : a.at > b.at ? 1 : 0));
+	return items.slice(-limit);
+}

--- a/extensions/goal-commands.ts
+++ b/extensions/goal-commands.ts
@@ -1,6 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { extractVerificationContract, sisyphusObjectiveSufficient } from "./goal-contract.ts";
-import { buildGoalHistoryBlock, detailedSummary, oneLineSummary } from "./goal-format.ts";
+import { detailedSummary, oneLineSummary } from "./goal-format.ts";
 import {
 	goalSettingsPath,
 	loadGoalSettings,
@@ -16,6 +16,7 @@ import {
 } from "./goal-pool.ts";
 import { clearGoalCommandMessage, validateResumeGoal } from "./goal-policy.ts";
 import { readGoalLedger } from "./goal-ledger.ts";
+import { buildGoalStatusText } from "./goal-status.ts";
 import { effectiveSettingsReport, envOverrideFor } from "./goal-settings.ts";
 import { mergeGoalPromptFromDisk } from "./storage/goal-files.ts";
 import { nowIso, type GoalMode, type GoalRecord } from "./goal-record.ts";
@@ -154,20 +155,22 @@ export function registerGoalCommands(core: GoalCore): void {
 		core.replaceGoal({ objective, autoContinue: true, sisyphus: mode === "sisyphus" }, ctx, true, verificationContract);
 	}
 
-	async function showGoalStatus(ctx: ExtensionContext): Promise<void> {
+	async function showGoalStatus(rawArgs: string, ctx: ExtensionContext): Promise<void> {
 		core.reconcileFocusedGoalFromDisk(ctx);
 		if (core.state.goal) core.syncGoalPromptFromDisk(ctx);
 		const view = core.goalForDisplay() ?? core.state.goal;
 		const otherCount = otherOpenGoalCount(core.goalsById, core.focusedGoalId);
-		const extra = view && otherCount > 0 ? `\nOther open goals: ${otherCount} (run /goal-list or /goal-focus)` : "";
-		let text = view ? `${detailedSummary(view)}${extra}` : core.openGoals().length > 0 ? buildUnfocusedOpenGoalsSummary(core.openGoals().length) : detailedSummary(null);
-		if (view) {
-			// E1: goal history (last audit verdict + recent lifecycle events).
-			const history = buildGoalHistoryBlock(view, readGoalLedger(ctx).events);
-			if (history) text += `\n\n${history}`;
-			// E2: effective settings with provenance.
-			text += `\n\n${effectiveSettingsReport(ctx.cwd).join("\n")}`;
-		}
+		const verbose = /^\s*verbose\b/i.test(rawArgs);
+		const text = buildGoalStatusText({
+			goal: view,
+			focused: view !== null && core.focusedGoalId === view.id,
+			otherOpenGoals: otherCount,
+			ledgerEvents: readGoalLedger(ctx).events,
+			verbose,
+			// §13.2: effective settings with provenance appear only in verbose mode;
+			// the standard mode stays free of settings noise (§13.1).
+			settingsReport: verbose ? effectiveSettingsReport(ctx.cwd) : [],
+		});
 		ctx.ui.notify(text, "info");
 		core.updateUI(ctx);
 	}
@@ -337,16 +340,16 @@ export function registerGoalCommands(core: GoalCore): void {
 				continue;
 			}
 			if (row.kind === "positiveInteger") {
-				const input = await ctx.ui.input("Set subtaskDepth", String(config.subtaskDepth ?? 1));
+				const input = await ctx.ui.input(`Set ${row.label}`, settingsValue(config, key));
 				if (input === undefined) continue;
 				// Full-string decimal validation: no partial parseInt. Rejects
 				// 1.5, 1x, 0, negatives, infinity, and unsafe integers alike.
 				const trimmed = input.trim();
 				if (!/^[0-9]+$/.test(trimmed) || !Number.isSafeInteger(Number(trimmed)) || Number(trimmed) < 1) {
-					ctx.ui.notify("subtaskDepth must be a positive integer (e.g. 1, 2, 3)", "warning");
+					ctx.ui.notify(`${row.label} must be a positive integer (e.g. 1, 2, 3)`, "warning");
 					continue;
 				}
-				const next = { ...config, subtaskDepth: Number(trimmed) };
+				const next = { ...config, [key]: Number(trimmed) };
 				saveSettings(next);
 				ctx.ui.notify(`Settings saved:\n${settingsLines(loadGoalSettingsFileConfig(ctx.cwd)).join("\n")}`, "info");
 				continue;
@@ -363,6 +366,7 @@ export function registerGoalCommands(core: GoalCore): void {
 				} else if ((AUDITOR_THINKING_LEVELS as readonly string[]).includes(trimmed)) {
 					next.thinkingLevel = trimmed as GoalSettings["thinkingLevel"];
 				} else {
+					ctx.ui.notify(`thinking_level must be one of: ${AUDITOR_THINKING_LEVELS.join(", ")} (or "(default)")`, "warning");
 					continue;
 				}
 				saveSettings(next);
@@ -520,9 +524,9 @@ export function registerGoalCommands(core: GoalCore): void {
 		},
 	});
 	pi.registerCommand("goal-status", {
-		description: "Show the focused goal and how many other goals are open (read-only).",
-		handler: async (_rawArgs, ctx) => {
-			await showGoalStatus(ctx);
+		description: "Show the unified goal dashboard for the focused goal (read-only). Append \"verbose\" for full diagnostic detail (goal id, revision, objective, task tree with evidence and contracts, ledger history, budget, pause/blocker, paths, audit report, effective settings).",
+		handler: async (rawArgs, ctx) => {
+			await showGoalStatus(rawArgs ?? "", ctx);
 		},
 	});
 	pi.registerCommand("goal-focus", {

--- a/extensions/goal-completion.ts
+++ b/extensions/goal-completion.ts
@@ -218,6 +218,7 @@ if (settings.disabled === true) {
 		recentOutput: [],
 		phase: "running",
 		elapsedMs: 0,
+		auditorLabel,
 	};
 	// Start animation timer for the spinner in the auditor widget
 	core.stopAuditAnimation();
@@ -361,8 +362,11 @@ if (settings.disabled === true) {
 		// Ledger append failure should not block completion
 	}
 	if (!auditor.approved) {
-		// Clear auditor progress to restore normal widget state
+		// Clear auditor progress to restore normal widget state, then show the
+		// §15.4 result card briefly so the required next work is visible before
+		// the normal dashboard returns (the goal stays open).
 		core.auditProgress = null;
+		core.setAuditResult(auditor.error ? "error" : "disapproved", auditor.output || "Auditor produced no output.");
 		core.goalWidgetComponentRef.current?.invalidate();
 		const rejectionText = [
 			"Goal audit rejected.",
@@ -396,6 +400,8 @@ if (settings.disabled === true) {
 		display: true,
 		details: { phase: "approved", goalId: auditTarget.id, auditor: auditor.model },
 	});
+	// §15.4: the approval card shows during the deferred archival window.
+	core.setAuditResult("approved", auditor.output || "Auditor approved completion.");
 	// Account for any remaining elapsed time.
 	// Deferred archival happens inside commitGoalCompletion; archival occurs at
 	// turn_end so the agent can see the auditor approval before the goal is

--- a/extensions/goal-draft.ts
+++ b/extensions/goal-draft.ts
@@ -1,4 +1,4 @@
-import type { GoalTask } from "./goal-record.ts";
+import type { GoalTask, GoalTaskList } from "./goal-record.ts";
 import { promptSafeObjective } from "./goal-contract.ts";
 import { renderConfirmationTasks } from "./goal-task-confirmation.ts";
 
@@ -192,4 +192,51 @@ export function goalDraftingPrompt(topic: string, focus: GoalDraftingFocus): str
 		"",
 		...(focus === "sisyphus" ? sisyphusFocusItems : goalFocusItems),
 	].join("\n");
+}
+
+
+// ── §14 durable proposal summary ─────────────────────────────────────────────
+
+export interface ProposalSummaryArgs {
+	objective: string;
+	taskList?: GoalTaskList;
+	verificationContract?: string;
+	autoContinue: boolean;
+	auditorEnabled: boolean;
+}
+
+/**
+ * Durable proposal summary written to the terminal transcript (plan §14):
+ * proposed objective, proposed plan (numbered top-level tasks), verification,
+ * automatic-continuation state, and auditor state. Produced for every proposal
+ * outcome (confirm / continue refining / cancel) so the summary is always part
+ * of the conversation, not only the confirmation dialog.
+ */
+export function buildProposalSummary(args: ProposalSummaryArgs): string {
+	const lines: string[] = ["Proposed objective:", args.objective.trim()];
+	if (args.taskList && args.taskList.tasks.length > 0) {
+		lines.push("", "Proposed plan:");
+		lines.push(...renderProposalPlan(args.taskList.tasks));
+	}
+	if (args.verificationContract?.trim()) {
+		lines.push("", "Verification:", args.verificationContract.trim());
+	}
+	lines.push("", `Automatic continuation: ${args.autoContinue ? "enabled" : "disabled"}`);
+	lines.push(`Independent auditor: ${args.auditorEnabled ? "enabled" : "disabled"}`);
+	return lines.join("\n");
+}
+
+function renderProposalPlan(tasks: GoalTask[]): string[] {
+	const lines: string[] = [];
+	let index = 1;
+	for (const t of tasks) {
+		lines.push(`${index}. ${t.title}`);
+		if (t.subtasks && t.subtasks.length > 0) {
+			for (const child of t.subtasks) {
+				lines.push(`   - ${child.title}`);
+			}
+		}
+		index++;
+	}
+	return lines;
 }

--- a/extensions/goal-drafting.ts
+++ b/extensions/goal-drafting.ts
@@ -2,16 +2,16 @@ import { Type } from "@earendil-works/pi-ai";
 import { defineTool, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { extractVerificationContract, sisyphusObjectiveSufficient } from "./goal-contract.ts";
-import { buildDraftConfirmationText, buildTweakConfirmationText, goalDraftingPrompt, type GoalDraftingFocus } from "./goal-draft.ts";
+import { buildDraftConfirmationText, buildProposalSummary, buildTweakConfirmationText, goalDraftingPrompt, type GoalDraftingFocus } from "./goal-draft.ts";
 import { renderConfirmationTasks } from "./goal-task-confirmation.ts";
 import { deriveTasksFromObjective } from "./goal-task-derive.ts";
 import { goalDetails, renderGoalResult } from "./goal-format.ts";
 import { buildGoalCreatedReport } from "./goal-policy.ts";
 import { loadGoalSettings } from "./goal-settings.ts";
 import { formatQuestionnaireAnswers, runGoalQuestionnaire, shouldAutoConfirmProposal, showProposalDialog, type GoalQuestionnaireQuestion, type ProposalDecision } from "./goal-questionnaire.ts";
-import { nowIso, type GoalRecord, type GoalTaskList } from "./goal-record.ts";
+import { currentTaskIdIsPending, nowIso, type GoalRecord, type GoalTaskList } from "./goal-record.ts";
 import type { GoalCore } from "./goal-state.ts";
-import { countTasks, convertFlatTasks, type FlatTaskInput } from "./goal-task-tools.ts";
+import { convertFlatTasks, countTasks, mergeTasksWithExisting, type FlatTaskInput } from "./goal-task-tools.ts";
 import { PROPOSE_DRAFT_TOOL_NAME, QUESTIONNAIRE_TOOL_NAME, QUESTION_TOOL_NAME } from "./goal-tool-names.ts";
 
 export type GoalDraftMode = GoalDraftingFocus | "tweak";
@@ -35,7 +35,7 @@ export interface GoalDraftSession {
 	clearedAt?: string;
 }
 
-interface ActiveGoalDraft {
+export interface ActiveGoalDraft {
 	mode: GoalDraftMode;
 	originalTopic: string;
 	targetGoalId?: string;
@@ -183,24 +183,33 @@ function proposedTaskList(core: GoalCore, ctx: ExtensionContext, tasks: FlatTask
 	return { ok: true, value: { tasks: converted.tasks, blockCompletion: blockCompletion === true, proposedAt: nowIso() } };
 }
 
-function proposalText(draft: ActiveGoalDraft, objective: string, autoContinue: boolean, taskList: GoalTaskList | undefined, current?: GoalRecord): string {
+export function proposalText(draft: ActiveGoalDraft, objective: string, autoContinue: boolean, taskList: GoalTaskList | undefined, current?: GoalRecord): string {
 	const base = draft.mode === "tweak" && current
 		? buildTweakConfirmationText({ currentObjective: current.objective, newObjective: objective, changeSummary: draft.originalTopic || "Goal revised through guided drafting.", sisyphus: current.sisyphus, tasks: taskList?.tasks })
 		: buildDraftConfirmationText({ focus: draft.mode === "sisyphus" ? "sisyphus" : "goal", originalTopic: draft.originalTopic, objective, autoContinue });
-	// F2 (option A, user-approved 2026-08-05): when a new draft has no proposed
-	// task list but the objective has ≥2 checklist/ordered markers, preview the
-	// derived tree in the confirmation so the human can adjust it before the
-	// goal exists. Plain objectives render byte-identical to 383ae52.
+	// The task list is always shown exactly once in a proposal: explicitly
+	// proposed tasks, or (new drafts) tasks derived from the RAW objective, or
+	// (tweaks) the current goal's list when it is retained unchanged. Deriving
+	// from the boxed base text would never match: formatPrefixedLines prefixes
+	// every objective line with "│   " so checklist/ordered markers are hidden.
 	let tasksText = "";
-	if (taskList && taskList.tasks.length > 0) {
+	if (draft.mode === "tweak") {
+		// buildTweakConfirmationText already renders explicit tasks exactly once
+		// inside its ┌─ TASKS ─┐ box; never append a second render. When no
+		// explicit list is proposed the current list is retained on apply
+		// (taskResult.value ?? goal.taskList), so preview it for confirmation.
+		if (!taskList && current?.taskList && current.taskList.tasks.length > 0) {
+			tasksText = "\n\nCurrent task list (retained unchanged):\n" + renderConfirmationTasks(current.taskList.tasks, 0).join("\n");
+		}
+	} else if (taskList && taskList.tasks.length > 0) {
 		tasksText = "\n\nTasks proposed for confirmation:\n" + renderConfirmationTasks(taskList.tasks, 0).join("\n");
-	} else if (draft.mode !== "tweak") {
-		const derived = deriveTasksFromObjective(base);
+	} else {
+		const derived = deriveTasksFromObjective(objective);
 		if (derived && derived.length > 0) {
 			tasksText = "\n\nTasks derived from the objective (confirm or ask the agent to adjust):\n" + renderConfirmationTasks(derived, 0).join("\n");
 		}
 	}
-	return !taskList && draft.mode === "tweak" ? base : base + tasksText;
+	return base + tasksText;
 }
 
 function flatTaskSchema() {
@@ -319,9 +328,21 @@ export function registerDraftingTools(core: GoalCore): void {
 					core.exitGoalModal();
 				}
 			}
+			const settings = loadGoalSettings(ctx.cwd);
+			const extracted = settings.disableContracts ? { objective, verificationContract: undefined } : extractVerificationContract(objective);
+			// §14: the durable proposal summary is part of the transcript for
+			// EVERY outcome (confirm / continue refining / cancel), so the user
+			// can review the proposal after the dialog closes.
+			const summary = buildProposalSummary({
+				objective: extracted.objective,
+				taskList: taskResult.value,
+				verificationContract: extracted.verificationContract,
+				autoContinue: params.auto_continue !== false,
+				auditorEnabled: draft.auditorEnabled,
+			});
 			if (confirmation.decision === "cancel") {
 				clearGoalDrafting(core, ctx);
-				return { content: [{ type: "text", text: "Draft cancelled; no goal was created. Run /goal or /sisyphus to start a new draft." }], details: goalDetails(core.state.goal) };
+				return { content: [{ type: "text", text: `${summary}\n\nDraft cancelled; no goal was created. Run /goal or /sisyphus to start a new draft.` }], details: goalDetails(core.state.goal) };
 			}
 			if (confirmation.decision !== "confirm") {
 				// Continue refining: preserve the user's auditor choice for the
@@ -331,11 +352,12 @@ export function registerDraftingTools(core: GoalCore): void {
 					activeDrafts.set(core, next);
 					draftSessionEntry(core, { version: 1, mode: next.mode, seed: next.originalTopic, targetGoalId: next.targetGoalId, startedAt: next.startedAt, auditorEnabled: next.auditorEnabled });
 				}
-				return { content: [{ type: "text", text: "Goal draft refinement requested. The goal was not changed; ask what the user wants revised before proposing again." }], details: goalDetails(core.state.goal) };
+				return { content: [{ type: "text", text: `${summary}\n\nGoal draft refinement requested. The goal was not changed; ask what the user wants revised before proposing again.` }], details: goalDetails(core.state.goal) };
 			}
 			const skipAuditor = confirmation.auditorEnabled === false;
-			const settings = loadGoalSettings(ctx.cwd);
-			const extracted = settings.disableContracts ? { objective, verificationContract: undefined } : extractVerificationContract(objective);
+			// §14: capture the questionnaire answers BEFORE clearing draft state so
+			// the confirmed-goal report can include them reliably (E5).
+			const qaEcho = draft.questionnaireEcho;
 			if (draft.mode !== "tweak") {
 				// F2: if the confirmation carried no task plan but the objective has
 				// structure, bootstrap the derived tree so the goal starts trackable.
@@ -345,24 +367,48 @@ export function registerDraftingTools(core: GoalCore): void {
 				})();
 				core.replaceGoal({ objective: extracted.objective, autoContinue: params.auto_continue !== false, sisyphus: expectedSisyphus, taskList: effectiveTaskList, skipAuditor }, ctx, true, extracted.verificationContract);
 				clearGoalDrafting(core, ctx);
-				// E5: echo the questionnaire Q&A in the created-goal report so the
-				// user can verify their input survived the clarification loop.
-				const qaEcho = activeDraft(core)?.questionnaireEcho;
-				return { content: [{ type: "text", text: buildGoalCreatedReport({ objective: extracted.objective, detailedSummary: qaEcho }) }], details: goalDetails(core.state.goal), terminate: true };
+				const created = core.state.goal;
+				return { content: [{ type: "text", text: `${summary}\n\n${buildGoalCreatedReport({
+					objective: extracted.objective,
+					detailedSummary: qaEcho,
+					confirmed: true,
+					goalId: created?.id,
+					filePath: created?.activePath,
+					taskCount: created?.taskList ? countTasks(created.taskList.tasks) : undefined,
+					verificationContract: created?.verificationContract,
+					auditorEnabled: !skipAuditor,
+					tokenBudget: created?.tokenBudget,
+				})}` }], details: goalDetails(core.state.goal), terminate: true };
 			}
 			if (!target) return { content: [{ type: "text", text: "The goal changed while drafting; review it and start /goal-tweak again." }], details: goalDetails(core.state.goal) };
 			const token = core.focusedOperationToken(target.id);
 			const now = nowIso();
+			// §7.5 merge: a goal tweak must never change the status of steps that
+			// persist across the tweak. The proposed list merges into the goal's
+			// existing tree by id (same semantics as set_goal_tasks): surviving ids
+			// keep status/evidence/completedAt/skippedAt/skipReason, new ids start
+			// pending, removed ids drop. currentTaskId survives only while its task
+			// is still pending in the merged tree.
 			const result = core.goalService.apply(ctx, {
 				reconcile: false, focusToken: token, refreshFromDisk: true,
-				mutate: (goal) => ({ ...goal, objective: extracted.objective, verificationContract: extracted.verificationContract ?? goal.verificationContract, taskList: taskResult.value ?? goal.taskList, skipAuditor, updatedAt: now }),
-				ledger: (written) => [{ type: "goal_tweaked", goalId: written.id, changeSummary: "Goal revised through /goal-tweak drafting.", at: written.updatedAt }, ...(taskResult.value ? [{ type: "task_list_set" as const, goalId: written.id, taskCount: countTasks(taskResult.value.tasks), blockCompletion: taskResult.value.blockCompletion, at: written.updatedAt }] : [])],
+				mutate: (goal) => {
+					const proposed = taskResult.value;
+					const mergedTaskList = proposed && goal.taskList
+						? { ...proposed, tasks: mergeTasksWithExisting(goal.taskList.tasks, proposed.tasks) }
+						: proposed;
+					const taskList = mergedTaskList ?? goal.taskList;
+					const currentTaskId = mergedTaskList && goal.currentTaskId && !currentTaskIdIsPending(mergedTaskList.tasks, goal.currentTaskId)
+						? undefined
+						: goal.currentTaskId;
+					return { ...goal, objective: extracted.objective, verificationContract: extracted.verificationContract ?? goal.verificationContract, taskList, currentTaskId, skipAuditor, updatedAt: now };
+				},
+				ledger: (written) => [{ type: "goal_tweaked", goalId: written.id, changeSummary: "Goal revised through /goal-tweak drafting.", at: written.updatedAt }, ...(taskResult.value ? [{ type: "task_list_set" as const, goalId: written.id, taskCount: countTasks(written.taskList?.tasks), blockCompletion: taskResult.value.blockCompletion, at: written.updatedAt }] : [])],
 			});
 			if (!result.ok) return { content: [{ type: "text", text: "Goal tweak was not applied: " + result.message }], details: goalDetails(core.state.goal) };
 			core.clearContinuationState();
 			core.updateUI(ctx);
 			clearGoalDrafting(core, ctx);
-			return { content: [{ type: "text", text: "Goal tweak confirmed and applied." }], details: goalDetails(result.goal), terminate: true };
+			return { content: [{ type: "text", text: `${summary}\n\nGoal tweak confirmed and applied.` }], details: goalDetails(result.goal), terminate: true };
 		},
 		renderCall(args, theme) { return new Text(theme.fg("toolTitle", "propose_goal_draft ") + theme.fg("muted", args?.objective ?? ""), 0, 0); },
 		renderResult(result, _opts, theme) { return renderGoalResult(result, _opts, theme); },

--- a/extensions/goal-events.ts
+++ b/extensions/goal-events.ts
@@ -171,10 +171,37 @@ export function registerGoalEvents(core: GoalCore): void {
 				core.goalsById.delete(completedGoal.id);
 				core.assignFocusedGoalId(null);
 				core.appendFocusEntry(null, "completed");
+				// §16.6: append the dedicated goal_archived event (the completion
+				// transaction keeps goal_completed for compatibility) and emit the
+				// real archive path.
+				try {
+					core.goalService.appendEvents(ctx, [{
+						type: "goal_archived",
+						goalId: completedGoal.id,
+						archivePath: archiveResult.goal?.archivedPath ?? "",
+						at: nowIso(),
+					}]);
+				} catch {
+					// Best-effort; the archive itself already succeeded.
+				}
+				const path = archiveResult.goal?.archivedPath ?? "";
+				ctx.ui.notify(path ? `Goal archived.\nFile: ${path}` : "Goal archived.", "info");
 			} else {
-				// The completed goal stays open and focused; make the failure
-				// observable instead of silently dropping it.
-				ctx.ui.notify(`Failed to archive completed goal: ${archiveResult.message}`, "warning");
+				// §16.6 failure behavior: never claim success, keep the complete
+				// record recoverable at its active path, and write a diagnostic
+				// ledger event when possible.
+				const remainingPath = completedGoal.activePath ?? "(unknown)";
+				ctx.ui.notify(`Failed to archive completed goal: ${archiveResult.message}. The complete record remains at ${remainingPath}.`, "warning");
+				try {
+					core.goalService.appendEvents(ctx, [{
+						type: "goal_archive_failed",
+						goalId: completedGoal.id,
+						message: archiveResult.message ?? "archive write failed",
+						at: nowIso(),
+					}]);
+				} catch {
+					// Diagnostic write is best-effort.
+				}
 			}
 			core.updateUI(ctx);
 		}

--- a/extensions/goal-format.ts
+++ b/extensions/goal-format.ts
@@ -288,7 +288,7 @@ export function buildGoalTaskDetailBlock(goal: GoalRecord): string {
 		lines.push(`${"  ".repeat(entry.depth)}[ ] ${entry.task.id}: ${entry.task.title}`);
 		if (entry.task.verificationContract) lines.push(`${"  ".repeat(entry.depth + 1)}contract: ${entry.task.verificationContract}`);
 	}
-	if (pending.length > 3) lines.push(`(+${pending.length - 3} more pending — see the task overlay)`);
+	if (pending.length > 3) lines.push(`(+${pending.length - 3} more pending — expand the dashboard with Ctrl+Shift+T)`);
 	for (const t of recent) {
 		lines.push(`[x] ${t.id}: ${t.title}${t.evidence ? ` — ${t.evidence}` : ""}`);
 	}

--- a/extensions/goal-ledger.ts
+++ b/extensions/goal-ledger.ts
@@ -16,11 +16,14 @@ export type GoalLedgerEvent =
   | { type: "audit_result"; goalId: string; verdict: "approved" | "disapproved" | "error"; report: string; at: string }
   | { type: "audit_skipped"; goalId: string; reason: "disabled" | "user_aborted"; provider?: string; model?: string; thinkingLevel?: string; at: string }
   | { type: "goal_completed"; goalId: string; archivePath?: string; at: string }
+  | { type: "goal_archived"; goalId: string; archivePath: string; at: string }
+  | { type: "goal_archive_failed"; goalId: string; message: string; at: string }
   | { type: "goal_aborted"; goalId: string; reason: string; archivePath?: string; at: string }
   | { type: "task_list_set"; goalId: string; taskCount: number; blockCompletion: boolean; at: string }
   | { type: "task_complete"; goalId: string; taskId: string; evidence?: string; at: string }
   | { type: "task_skipped"; goalId: string; taskId: string; reason: string; at: string }
   | { type: "task_reopened"; goalId: string; taskId: string; at: string }
+  | { type: "task_started"; goalId: string; taskId: string; at: string }
   | { type: "goal_budget_limited"; goalId: string; budget: number; tokensUsed: number; at: string }
   | { type: "goal_budget_warning"; goalId: string; budget: number; tokensUsed: number; pct: number; at: string }
   | { type: "goal_stalled"; goalId: string; reason: string; at: string }
@@ -285,6 +288,10 @@ function isValidLedgerEvent(value: unknown): value is GoalLedgerEvent {
       return typeof obj.goalId === "string" && (obj.reason === "disabled" || obj.reason === "user_aborted") && (obj.provider === undefined || typeof obj.provider === "string") && (obj.model === undefined || typeof obj.model === "string") && (obj.thinkingLevel === undefined || typeof obj.thinkingLevel === "string");
     case "goal_completed":
       return typeof obj.goalId === "string" && (obj.archivePath === undefined || typeof obj.archivePath === "string");
+    case "goal_archived":
+      return typeof obj.goalId === "string" && typeof obj.archivePath === "string";
+    case "goal_archive_failed":
+      return typeof obj.goalId === "string" && typeof obj.message === "string";
     case "goal_aborted":
       return typeof obj.goalId === "string" && typeof obj.reason === "string" && (obj.archivePath === undefined || typeof obj.archivePath === "string");
     case "task_list_set":
@@ -294,6 +301,8 @@ function isValidLedgerEvent(value: unknown): value is GoalLedgerEvent {
     case "task_skipped":
       return typeof obj.goalId === "string" && typeof obj.taskId === "string" && typeof obj.reason === "string";
     case "task_reopened":
+      return typeof obj.goalId === "string" && typeof obj.taskId === "string";
+    case "task_started":
       return typeof obj.goalId === "string" && typeof obj.taskId === "string";
     case "goal_budget_limited":
       return typeof obj.goalId === "string" && typeof obj.budget === "number" && typeof obj.tokensUsed === "number";
@@ -330,6 +339,10 @@ function sanitizeEvent(event: GoalLedgerEvent): GoalLedgerEvent {
       return { ...event, goalId: safeGoalId(event.goalId) };
     case "goal_completed":
       return { ...event, goalId: safeGoalId(event.goalId) };
+    case "goal_archived":
+      return { ...event, goalId: safeGoalId(event.goalId) };
+    case "goal_archive_failed":
+      return { ...event, goalId: safeGoalId(event.goalId) };
     case "goal_aborted":
       return { ...event, goalId: safeGoalId(event.goalId) };
     case "task_list_set":
@@ -339,6 +352,8 @@ function sanitizeEvent(event: GoalLedgerEvent): GoalLedgerEvent {
     case "task_skipped":
       return { ...event, goalId: safeGoalId(event.goalId) };
     case "task_reopened":
+      return { ...event, goalId: safeGoalId(event.goalId) };
+    case "task_started":
       return { ...event, goalId: safeGoalId(event.goalId) };
     case "goal_budget_limited":
       return { ...event, goalId: safeGoalId(event.goalId) };

--- a/extensions/goal-policy.ts
+++ b/extensions/goal-policy.ts
@@ -284,11 +284,39 @@ export function buildCompletionReport(args: { detailedSummary: string; auditorRe
 	return lines.join("\n");
 }
 
-export function buildGoalCreatedReport(args: { objective: string; detailedSummary?: string | null }): string {
-	const lines = ["Goal confirmed and created.", "", "Finalized goal:", "", args.objective.trim()];
+export interface GoalCreatedReportArgs {
+	objective: string;
+	detailedSummary?: string | null;
+	/**
+	 * Guided-confirmation report (§14): the richer opening line plus expanded
+	 * detail (goal id, active file, task count, verification contract, auditor
+	 * configuration, token budget). Direct creation keeps the default text.
+	 */
+	confirmed?: boolean;
+	goalId?: string;
+	filePath?: string;
+	taskCount?: number;
+	verificationContract?: string;
+	auditorEnabled?: boolean;
+	tokenBudget?: number;
+}
+
+export function buildGoalCreatedReport(args: GoalCreatedReportArgs): string {
+	const opening = args.confirmed
+		? ["✓ Goal created and focused.", "Continuing automatically with the confirmed plan."]
+		: ["Goal confirmed and created."];
+	const lines = [...opening, "", "Finalized goal:", "", args.objective.trim()];
+	const details: string[] = [];
+	if (args.goalId) details.push(`Goal id: ${args.goalId}`);
+	if (args.filePath) details.push(`File: ${args.filePath}`);
+	if (args.taskCount !== undefined) details.push(`Tasks: ${args.taskCount}`);
+	if (args.verificationContract?.trim()) details.push(`Verification: ${args.verificationContract.trim()}`);
+	if (args.auditorEnabled !== undefined) details.push(`Auditor: ${args.auditorEnabled ? "enabled" : "disabled"}`);
+	if (args.tokenBudget !== undefined) details.push(`Token budget: ${args.tokenBudget}`);
 	const summary = args.detailedSummary?.trim();
-	if (summary) {
-		lines.push("", "Goal details:", summary);
+	if (summary) details.push(summary);
+	if (details.length > 0) {
+		lines.push("", "Goal details:", ...details);
 	}
 	return lines.join("\n");
 }

--- a/extensions/goal-record.ts
+++ b/extensions/goal-record.ts
@@ -56,6 +56,13 @@ export interface GoalRecord {
 	revision?: number;
 	/** Optional token budget (whole tokens). When accounted usage reaches it, the runtime marks the goal budget_limited. */
 	tokenBudget?: number;
+	/**
+	 * Execution focus: the id of the task (or subtask) the agent is working on.
+	 * Optional for backward compatibility; normalized at load (only an existing
+	 * pending task id is accepted; cleared on complete/skip/removal). Describes
+	 * execution focus, not completion state — TaskStatus is unchanged.
+	 */
+	currentTaskId?: string;
 	taskList?: GoalTaskList;
 	/** Plain-text description of what verification evidence is required before completing this goal. */
 	verificationContract?: string;
@@ -264,6 +271,22 @@ export function normalizePositiveSafeInteger(value: unknown): number | undefined
 	return typeof value === "number" && Number.isSafeInteger(value) && value >= 1 ? value : undefined;
 }
 
+/**
+ * §7.4: a persisted currentTaskId is accepted only when it references an
+ * existing PENDING task (top-level or nested). It is cleared when the task is
+ * complete, skipped, or no longer exists; absent for historical files. The
+ * caller decides whether to persist the normalized value — normalization
+ * itself never rewrites old files.
+ */
+export function currentTaskIdIsPending(tasks: readonly GoalTask[] | undefined, id: string | undefined): boolean {
+	if (!id || !tasks) return false;
+	for (const t of tasks) {
+		if (t.id === id) return t.status === "pending";
+		if (t.subtasks && currentTaskIdIsPending(t.subtasks, id)) return true;
+	}
+	return false;
+}
+
 export function normalizeGoalRecord(value: unknown): GoalRecord | null {
 	const raw = asRecord(value);
 	if (!raw) return null;
@@ -287,6 +310,14 @@ export function normalizeGoalRecord(value: unknown): GoalRecord | null {
 	const autoContinue = typeof raw.autoContinue === "boolean" ? raw.autoContinue : true;
 	const usage = normalizeUsage(raw.usage);
 	const sisyphus = raw.sisyphus === true;
+	const taskList = normalizeTaskList(raw.taskList);
+	// §7.4: accept a persisted currentTaskId only when it references an existing
+	// pending task; otherwise leave it absent. Historical files stay absent and
+	// are never rewritten just because the field is missing.
+	const currentTaskId =
+		typeof raw.currentTaskId === "string" && currentTaskIdIsPending(taskList?.tasks, raw.currentTaskId.trim())
+			? raw.currentTaskId.trim()
+			: undefined;
 
 	return {
 		id: typeof raw.id === "string" && raw.id ? safeIdPart(raw.id) : newGoalId(),
@@ -305,7 +336,8 @@ export function normalizeGoalRecord(value: unknown): GoalRecord | null {
 		skipAuditor: raw.skipAuditor === true ? true : undefined,
 		revision: Number.isSafeInteger(raw.revision) && (raw.revision as number) >= 0 ? (raw.revision as number) : 0,
 		tokenBudget: normalizePositiveSafeInteger(raw.tokenBudget),
-		taskList: normalizeTaskList(raw.taskList),
+		taskList,
+		currentTaskId,
 		verificationContract: typeof raw.verificationContract === "string" ? raw.verificationContract : undefined,
 	};
 }

--- a/extensions/goal-service.ts
+++ b/extensions/goal-service.ts
@@ -119,11 +119,30 @@ export interface GoalTaskUpdateSpec {
 	validate?(task: GoalTask): { ok: true } | { ok: false; message: string };
 	/** Transform the FRESH task. A failure aborts; only this task's path changes. */
 	update(task: GoalTask): GoalTask | { ok: false; message: string };
+	/**
+	 * §8.1: explicit execution focus — set the persisted currentTaskId to this
+	 * task id (start). Replaces any previous current task. Otherwise focus is
+	 * cleared automatically when the updated task becomes terminal
+	 * (complete/skipped) and was the current task (§8.2/§8.3).
+	 */
+	setCurrentTaskId?: string;
 	/** Ledger events appended best-effort AFTER the authoritative file write. */
 	ledger?(written: GoalRecord, updatedTask: GoalTask): GoalLedgerEvent[];
 }
 
 export type GoalTaskUpdateOutcome = { ok: true; goal: GoalRecord; task: GoalTask } | { ok: false; message: string };
+
+/**
+ * §8 execution-focus resolution for a task update: an explicit start sets the
+ * currentTaskId (replacing any previous); otherwise completing or skipping the
+ * current task clears it; otherwise focus is untouched.
+ */
+function resolveUpdatedCurrentTaskId(spec: GoalTaskUpdateSpec, current: string | undefined, updatedTask: GoalTask): string | undefined {
+	if (spec.setCurrentTaskId !== undefined) return spec.setCurrentTaskId;
+	const terminal = updatedTask.status === "complete" || updatedTask.status === "skipped";
+	if (terminal && current === spec.taskId) return undefined;
+	return current;
+}
 
 export class GoalService {
 	private readonly ref: GoalServiceRef;
@@ -484,6 +503,9 @@ export class GoalService {
 			const mutated = sanitizeGoalPaths(ctx, {
 				...current,
 				taskList: { ...current.taskList, tasks: updatedTasks },
+				// Execution focus (§8): start sets it explicitly; completing or
+				// skipping the current task clears it.
+				currentTaskId: resolveUpdatedCurrentTaskId(spec, current.currentTaskId, updatedTask),
 				updatedAt: nowIso(),
 				revision: (current.revision ?? 0) + 1,
 			});
@@ -565,6 +587,7 @@ export class GoalService {
 			const mutated = sanitizeGoalPaths(ctx, {
 				...base,
 				taskList: { ...base.taskList, tasks: updatedTasks },
+				currentTaskId: resolveUpdatedCurrentTaskId(spec, base.currentTaskId, updatedTask),
 				updatedAt: nowIso(),
 				revision: capturedRevision + 1,
 			});

--- a/extensions/goal-state.ts
+++ b/extensions/goal-state.ts
@@ -31,6 +31,7 @@ import {
 	sanitizeGoalPaths,
 } from "./storage/goal-files.ts";
 import { GoalService } from "./goal-service.ts";
+import { readGoalLedger } from "./goal-ledger.ts";
 import { GoalAccounting } from "./goal-accounting.ts";
 import { GoalRuntime } from "./goal-runtime.ts";
 import {
@@ -41,6 +42,7 @@ import {
 } from "./goal-pool.ts";
 import { buildGoalRunningNotification } from "./widgets/goal-notifications.ts";
 import { GOAL_WIDGET_KEY, GoalWidgetComponent, liveDisplayGoal, makeGoalWidgetFactory, type AuditorWidgetProgress } from "./widgets/goal-widget.ts";
+import type { AuditVerdict } from "./widgets/auditor-dashboard-model.ts";
 import { runGoalCompletionAuditor } from "./goal-auditor.ts";
 
 
@@ -63,6 +65,10 @@ export interface GoalCore {
 	auditProgress: AuditorWidgetProgress | null;
 	auditAnimationTimer: ReturnType<typeof setInterval> | null;
 	auditAbortController: AbortController | null;
+	/** §15.4: finished audit result card shown briefly before the dashboard returns. */
+	auditResult: { verdict: AuditVerdict; report: string; at: string } | null;
+	setAuditResult(verdict: AuditVerdict, report: string): void;
+	clearAuditResult(): void;
 	goalModalDepth: number;
 	enterGoalModal(): void;
 	exitGoalModal(): void;
@@ -93,6 +99,10 @@ export interface GoalCore {
 	isStaleCheckpointBlockedToolCall(toolName: string): boolean;
 	clearStoppedRuntimeState(): void;
 	openGoals(): GoalRecord[];
+	/** §10: toggle the unified dashboard between compact and expanded modes. */
+	toggleDashboardExpanded(): void;
+	/** §10: whether the unified dashboard is currently expanded. */
+	isDashboardExpanded(): boolean;
 	reconcileFocusedGoalFromDisk(ctx: ExtensionContext, opts?: { preserveMemoryUsage?: boolean }): boolean;
 	appendFocusEntry(goalId: string | null, reason: GoalFocusReason): void;
 	setFocusedGoalId(goalId: string | null, ctx: ExtensionContext, reason: GoalFocusReason, opts?: { recordLedger?: boolean }): void;
@@ -210,11 +220,36 @@ export function createGoalCore(
 	let terminalInputUnsubscribe: (() => void) | null = null;
 	let auditProgress: AuditorWidgetProgress | null = null;
 	let auditAnimationTimer: ReturnType<typeof setInterval> | null = null;
+	let auditResult: { verdict: AuditVerdict; report: string; at: string } | null = null;
+	let auditResultClearTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function setAuditResult(verdict: AuditVerdict, report: string): void {
+		auditResult = { verdict, report, at: nowIso() };
+		if (auditResultClearTimer) clearTimeout(auditResultClearTimer);
+		// Short-lived foreground display (§2.5): the card is visible while the
+		// user reads it, then the normal dashboard returns automatically.
+		auditResultClearTimer = setTimeout(() => {
+			auditResult = null;
+			auditResultClearTimer = null;
+			goalWidgetComponentRef.current?.invalidate();
+		}, 6000);
+		auditResultClearTimer.unref?.();
+		goalWidgetComponentRef.current?.invalidate();
+	}
+
+	function clearAuditResult(): void {
+		if (auditResultClearTimer) clearTimeout(auditResultClearTimer);
+		auditResultClearTimer = null;
+		auditResult = null;
+	}
 	let auditAbortController: AbortController | null = null;
 	let auditAborted = false;
 
 	let goalModalDepth = 0;
 	let debugMode = false;
+	// §10: unified dashboard expansion state (compact vs expanded task view),
+	// owned by the core so it survives host-side widget re-instantiation.
+	let dashboardExpanded = false;
 
 	// Per-turn flags reset in turn_start (#4, C9 fix).
 	// goalWorkToolCalledThisTurn: tracks whether a real goal-work tool was called.
@@ -621,6 +656,9 @@ export function createGoalCore(
 						getSettings: () => loadGoalSettings(ctx.cwd),
 						getDebugMode: () => debugMode,
 						getStalled: () => stallNotified,
+						getExpanded: () => dashboardExpanded,
+						getLedgerEvents: () => readGoalLedger(ctx).events,
+						getAuditResult: () => auditResult,
 					}),
 					{ placement: "aboveEditor" },
 				);
@@ -645,6 +683,9 @@ export function createGoalCore(
 					getSettings: () => loadGoalSettings(ctx.cwd),
 					getDebugMode: () => debugMode,
 					getStalled: () => stallNotified,
+					getExpanded: () => dashboardExpanded,
+					getLedgerEvents: () => readGoalLedger(ctx).events,
+					getAuditResult: () => auditResult,
 				}),
 				{ placement: "aboveEditor" },
 			);
@@ -846,6 +887,14 @@ export function createGoalCore(
 		set auditProgress(value: AuditorWidgetProgress | null) {
 			auditProgress = value;
 		},
+		get auditResult() {
+			return auditResult;
+		},
+		set auditResult(value: { verdict: AuditVerdict; report: string; at: string } | null) {
+			auditResult = value;
+		},
+		setAuditResult,
+		clearAuditResult,
 		get auditAnimationTimer() {
 			return auditAnimationTimer;
 		},
@@ -893,6 +942,13 @@ export function createGoalCore(
 		},
 		set terminalInputUnsubscribe(value: (() => void) | null) {
 			terminalInputUnsubscribe = value;
+		},
+		toggleDashboardExpanded() {
+			dashboardExpanded = !dashboardExpanded;
+			goalWidgetComponentRef.current?.invalidate();
+		},
+		isDashboardExpanded() {
+			return dashboardExpanded;
 		},
 		goalWidgetComponentRef,
 		goalService,

--- a/extensions/goal-status.ts
+++ b/extensions/goal-status.ts
@@ -1,0 +1,185 @@
+/**
+ * /goal-status text builder (plan §13).
+ *
+ * Renders the SAME shared dashboard model as the above-editor widget: the
+ * standard mode composes a static compact-dashboard box, the current-task
+ * details block, recent activity, and the last audit result; verbose mode adds
+ * the full diagnostic detail (§13.2). Pure module — no TUI imports, no ctx —
+ * so the exact text is unit-testable and can never drift from the widget.
+ */
+
+import { truncateText } from "./goal-core.ts";
+import type { GoalLedgerEvent, GoalLedgerEvent as LedgerEvent } from "./goal-ledger.ts";
+import { latestAuditorResultForGoal, latestEventsForGoal } from "./goal-ledger.ts";
+import type { GoalRecord, GoalTask } from "./goal-record.ts";
+import { deriveGoalDashboardModel, formatCompactTokens, formatDashboardDuration } from "./widgets/goal-dashboard-model.ts";
+import {
+	renderActivityBlock,
+	renderCompactDashboard,
+	renderCurrentTaskBlock,
+	renderUnfocusedDashboard,
+} from "./widgets/goal-dashboard-renderer.ts";
+
+/** Fixed rendering width for the notify text (medium layout mode). */
+export const GOAL_STATUS_WIDTH = 78;
+
+/** Identity theme: the box text is emitted as plain text for ctx.ui.notify. */
+export const PLAIN_THEME = {
+	fg: (_color: string, value: string) => value,
+	bold: (value: string) => value,
+} as never;
+
+export interface GoalStatusTextOptions {
+	goal: GoalRecord | null;
+	focused: boolean;
+	otherOpenGoals: number;
+	ledgerEvents?: GoalLedgerEvent[];
+	verbose?: boolean;
+	/** Effective settings lines with provenance (verbose only). */
+	settingsReport?: string[];
+	width?: number;
+}
+
+/**
+ * Build the /goal-status text.
+ *
+ * Standard (§13.1): static compact-dashboard rendering + current-task details
+ * + recent activity + last audit result when available. The terminology and
+ * hierarchy match the expanded dashboard (§13.3); no effective settings by
+ * default.
+ *
+ * Verbose (§13.2): goal id, revision, full objective, complete task tree with
+ * full evidence and contracts, recent ledger history, effective settings and
+ * provenance, token budget detail, pause/blocker detail, paths, and the last
+ * audit report.
+ */
+export function buildGoalStatusText(options: GoalStatusTextOptions): string {
+	const width = options.width ?? GOAL_STATUS_WIDTH;
+	if (!options.goal) {
+		return options.otherOpenGoals > 0
+			? renderUnfocusedDashboard(options.otherOpenGoals, PLAIN_THEME, width).join("\n")
+			: "No goal is set. Use /goal <objective> or /sisyphus <objective> to start immediately.";
+	}
+	const events = options.ledgerEvents ?? [];
+	const model = deriveGoalDashboardModel(options.goal, {
+		focused: options.focused,
+		otherOpenGoals: options.otherOpenGoals,
+		ledgerEvents: events,
+	});
+	if (!model) return "No goal is set.";
+
+	if (options.verbose) {
+		return buildVerboseStatus(options.goal, model, events, options.settingsReport ?? [], width);
+	}
+
+	const parts: string[] = [];
+	parts.push(renderCompactDashboard(model, PLAIN_THEME, width, { footerHint: "Run /goal-status verbose for full detail" }).join("\n"));
+	if (model.currentTask) {
+		parts.push(renderCurrentTaskBlock(model, PLAIN_THEME, width).join("\n"));
+	}
+	if (model.recentActivity.length > 0) {
+		parts.push(renderActivityBlock(model.recentActivity, PLAIN_THEME, width).join("\n"));
+	}
+	const audit = latestAuditorResultForGoal(events, model.goalId);
+	if (audit) {
+		parts.push(lastAuditBlock(audit, width));
+	}
+	return parts.join("\n\n");
+}
+
+function lastAuditBlock(
+	audit: { verdict: "approved" | "disapproved" | "error"; report: string; at: string },
+	width: number,
+): string {
+	const verdictLabel = audit.verdict === "approved" ? "APPROVED" : audit.verdict === "disapproved" ? "CHANGES REQUIRED" : "ERROR";
+	const line = `Last audit: ${verdictLabel} (${audit.at.slice(0, 10)}) — ${truncateText(audit.report.replace(/\s+/g, " "), 90)}`;
+	const inner = Math.max(4, width - 2);
+	return [
+		`╭─ Audit result ─ ${verdictLabel} ${"─".repeat(Math.max(1, inner - visibleLen(`─ Audit result ─ ${verdictLabel} `) - 1))}╮`,
+		`│ ${truncateText(line, inner - 2)}${" ".repeat(Math.max(0, inner - 2 - truncateText(line, inner - 2).length))}│`,
+		`╰${"─".repeat(inner)}╯`,
+	].join("\n");
+}
+
+function visibleLen(value: string): number {
+	return value.length;
+}
+
+// ── Verbose (§13.2) ─────────────────────────────────────────────────────────
+
+function buildVerboseStatus(goal: GoalRecord, model: ReturnType<typeof deriveGoalDashboardModel>, events: GoalLedgerEvent[], settingsReport: string[], _width: number): string {
+	const lines: string[] = [];
+	lines.push(`Goal id: ${goal.id}`);
+	lines.push(`Revision: ${goal.revision ?? 0}`);
+	lines.push(`Status: ${model?.status.label}${model?.focused ? " (focused)" : " (not focused)"}`);
+	lines.push(`Mode: ${goal.sisyphus ? "sisyphus" : "goal"} · auto-continue: ${goal.autoContinue ? "on" : "off"}`);
+	lines.push(`Usage: ${formatDashboardDuration(goal.usage.activeSeconds)} · ${formatCompactTokens(goal.usage.tokensUsed)} tokens`);
+	if (model?.budget) {
+		lines.push(`Budget: ${formatCompactTokens(model.budget.used)} / ${formatCompactTokens(model.budget.total)} · ${model.budget.percentage}% used · ${formatCompactTokens(model.budget.remaining)} remaining`);
+	}
+	if (goal.pauseReason) lines.push(`Pause/blocker: ${goal.pauseReason}`);
+	if (goal.pauseSuggestedAction) lines.push(`Suggested action: ${goal.pauseSuggestedAction}`);
+	if (goal.activePath) lines.push(`File: ${goal.activePath}`);
+	if (goal.archivedPath) lines.push(`Archive: ${goal.archivedPath}`);
+
+	lines.push("", "Objective:", goal.objective.trim());
+
+	if (goal.verificationContract) {
+		lines.push("", `Verification contract: ${goal.verificationContract.trim()}`);
+	}
+	if (goal.taskList) {
+		lines.push("", `Tasks (${topLevelCount(goal.taskList.tasks)} top-level, ${goal.taskList.tasks.filter((t) => t.status === "complete" || t.status === "skipped").length} done):`);
+		for (const line of renderTaskTreeVerbose(goal.taskList.tasks, 0, goal.currentTaskId)) {
+			lines.push(line);
+		}
+	}
+	if (model?.currentTask) {
+		lines.push("", `Current task: ${model.currentTask.id} · ${model.currentTask.title}${model.currentTask.inferred ? " (inferred)" : ""}`);
+		if (model.currentTask.totalSubtasks > 0) {
+			lines.push(`  subtasks: ${model.currentTask.completedSubtasks}/${model.currentTask.totalSubtasks} (${model.currentTask.subtaskPercentage}%)`);
+		}
+		if (model.currentTask.verificationContract) lines.push(`  contract: ${model.currentTask.verificationContract}`);
+		if (model.currentTask.evidence) lines.push(`  evidence: ${model.currentTask.evidence}`);
+	}
+
+	const recent = latestEventsForGoal(events, goal.id, 12);
+	if (recent.length > 0) {
+		lines.push("", "Recent ledger:");
+		for (const event of recent) {
+			lines.push(`  ${event.at.slice(0, 19)} ${event.type}`);
+		}
+	}
+	const audit = latestAuditorResultForGoal(events, goal.id);
+	if (audit) {
+		lines.push("", `Last audit (${audit.at.slice(0, 10)}): ${audit.verdict}`);
+		lines.push(truncateText(audit.report.replace(/\s+/g, " "), 400));
+	}
+	if (settingsReport.length > 0) {
+		lines.push("", "Effective settings:");
+		lines.push(...settingsReport.map((line) => `  ${line}`));
+	}
+	return lines.join("\n");
+}
+
+function topLevelCount(tasks: GoalTask[]): number {
+	return tasks.length;
+}
+
+function renderTaskTreeVerbose(tasks: GoalTask[], depth = 0, currentTaskId?: string): string[] {
+	const lines: string[] = [];
+	const indent = "  ".repeat(depth);
+	for (const t of tasks) {
+		const isCurrent = t.id === currentTaskId;
+		const marker = isCurrent ? "▸" : t.status === "complete" ? "✓" : t.status === "skipped" ? "~" : "·";
+		const contract = t.verificationContract ? ` — contract: ${t.verificationContract}` : "";
+		const evidence = t.status === "complete" && t.evidence ? ` — evidence: ${t.evidence}` : "";
+		lines.push(`${indent}${marker} ${t.id}  ${t.title}${contract}${evidence}`);
+		if (t.subtasks && t.subtasks.length > 0) {
+			lines.push(...renderTaskTreeVerbose(t.subtasks, depth + 1, currentTaskId));
+		}
+	}
+	return lines;
+}
+
+// Re-export for consumers that want the same event type.
+export type { LedgerEvent };

--- a/extensions/goal-task-tools.ts
+++ b/extensions/goal-task-tools.ts
@@ -14,13 +14,13 @@ import { Text } from "@earendil-works/pi-tui";
 import { goalDetails, renderGoalResult } from "./goal-format.ts";
 import { statusLabel, truncateText } from "./goal-core.ts";
 import { loadGoalSettings } from "./goal-settings.ts";
-import { buildTaskSummary, checkSubtasksComplete, findSubtaskDepthViolation, skipAllSubtasks } from "./goal-policy.ts";
+import { buildTaskSummary, checkSubtasksComplete, findSubtaskDepthViolation, findTaskInTree, skipAllSubtasks } from "./goal-policy.ts";
 import { showTaskConfirmation, type TaskConfirmationResult } from "./goal-task-confirmation.ts";
 import {
 	SET_GOAL_TASKS_TOOL_NAME,
 	UPDATE_GOAL_TASK_TOOL_NAME,
 } from "./goal-tool-names.ts";
-import { nowIso, type GoalTask, type GoalTaskList } from "./goal-record.ts";
+import { nowIso, currentTaskIdIsPending, type GoalTask, type GoalTaskList } from "./goal-record.ts";
 
 export const MAX_TASKS = 50;
 
@@ -310,7 +310,11 @@ pi.registerTool(defineTool({
 			// requested operation changes the same task.
 			mutate: (g) => {
 				const merged = mergeTasksWithExisting(g.taskList?.tasks, converted.tasks);
-				return { ...g, taskList: { tasks: merged, blockCompletion, proposedAt: now }, updatedAt: now };
+				// §7.5: preserve currentTaskId only when the same id remains pending;
+				// otherwise clear it. Dashboard state recomputes on the next render.
+				const currentTaskId =
+					g.currentTaskId && currentTaskIdIsPending(merged, g.currentTaskId) ? g.currentTaskId : undefined;
+				return { ...g, currentTaskId, taskList: { tasks: merged, blockCompletion, proposedAt: now }, updatedAt: now };
 			},
 			ledger: (written) => [{
 				type: "task_list_set",
@@ -351,17 +355,18 @@ pi.registerTool(defineTool({
 pi.registerTool(defineTool({
 	name: UPDATE_GOAL_TASK_TOOL_NAME,
 	label: "Update Goal Task",
-	description: "Update one task in the focused goal's task tree without stopping the turn: status \"complete\" (with optional evidence; requires evidence when the task has a verification contract and enforces completed children), \"skipped\" (requires a reason; restricted to explicit user direction or a hard contradiction), or \"pending\" (reopens a skipped task). Completed tasks are immutable through this tool.",
-	promptSnippet: "Mark one task complete, skipped, or reopened. Does not stop the turn.",
+	description: "Update one task in the focused goal's task tree without stopping the turn: status \"start\" sets explicit execution focus (persisted currentTaskId; requires a pending task), \"complete\" (with optional evidence; requires evidence when the task has a verification contract and enforces completed children), \"skipped\" (requires a reason; restricted to explicit user direction or a hard contradiction), or \"pending\" (reopens a skipped task). Completed tasks are immutable through this tool. Starting another task replaces focus; completing or skipping the current task clears focus.",
+	promptSnippet: "Mark one task started, complete, skipped, or reopened. Does not stop the turn.",
 	promptGuidelines: [
 		"Use update_goal_task to update exactly one task; the turn does NOT stop so you may continue with other work.",
+		"status=start sets the persisted current task (execution focus); use it when you begin working on a task. Only pending tasks can be started.",
 		"status=complete requires evidence when the task has a verification contract, and requires all non-lightweight children to be complete first.",
 		"status=skipped requires a concrete reason and is restricted to explicit user direction or a hard contradiction (e.g. an impossible requirement). Do not skip to avoid work.",
 		"status=pending reopens a skipped task (clears its skip state). Completed tasks cannot be reopened through this tool.",
 	],
 	parameters: Type.Object({
 		task_id: Type.String({ description: "Task id to update" }),
-		status: StringEnum(["complete", "skipped", "pending"] as const, { description: "complete (with optional evidence), skipped (requires reason), or pending (reopens a skipped task)." }),
+		status: StringEnum(["start", "complete", "skipped", "pending"] as const, { description: "start (sets execution focus; requires pending), complete (with optional evidence), skipped (requires reason), or pending (reopens a skipped task)." }),
 		evidence: Type.Optional(Type.String({ description: "Evidence note for complete (max 200 characters). Required when the task has a verification contract." })),
 		reason: Type.Optional(Type.String({ description: "Reason for skipped. Required when status=skipped." })),
 	}, { additionalProperties: false }),
@@ -391,6 +396,41 @@ pi.registerTool(defineTool({
 		const settings = loadGoalSettings(ctx.cwd);
 		const now = nowIso();
 		const taskFocus = core.focusedOperationToken(core.state.goal.id);
+
+		if (params.status === "start") {
+			const result = core.goalService.updateTask(ctx, {
+				focusToken: taskFocus,
+				taskId: params.task_id,
+				validate: (task) => {
+					if (task.status !== "pending") {
+						return { ok: false, message: `Task "${params.task_id}" is ${task.status}; only pending tasks can be started.` };
+					}
+					return { ok: true };
+				},
+				update: (task) => task,
+				// §8.1: set explicit execution focus; a later start replaces it, and
+				// completing/skipping this task clears it.
+				setCurrentTaskId: params.task_id,
+				ledger: (written) => [{
+					type: "task_started",
+					goalId: written.id,
+					taskId: params.task_id,
+					at: written.updatedAt,
+				}],
+			});
+			if (!result.ok) {
+				return { content: [{ type: "text", text: result.message }], details: goalDetails(core.state.goal) };
+			}
+			core.updateUI(ctx);
+			// §8.1: surface the task contract so the next continuation prompt and
+			// the dashboard can show what starting this task requires.
+			const started = findTaskInTree(core.state.goal.taskList?.tasks ?? [], params.task_id);
+			const contract = started?.verificationContract ? ` Contract: ${started.verificationContract}` : "";
+			return {
+				content: [{ type: "text", text: `Started ${params.task_id}${contract}. ${buildTaskSummary(core.state.goal.taskList!)}.` }],
+				details: goalDetails(core.state.goal),
+			};
+		}
 
 		if (params.status === "complete") {
 			const evidence = params.evidence?.trim().slice(0, 200) || undefined;

--- a/extensions/goal-widget.ts
+++ b/extensions/goal-widget.ts
@@ -127,9 +127,17 @@ export function syncTerminalInputPause(core: GoalCore, ctx: ExtensionContext): v
 				return { consume: true };
 			}
 			// §10: Escape collapses the expanded dashboard before it can pause the
-			// goal; Ctrl+Shift+T toggles compact/expanded (§19.5).
+			// goal; Ctrl+Shift+T toggles compact/expanded (§19.5). While the
+			// compact widget holds scroll focus, Escape disengages it instead of
+			// pausing; ↑/↓/PgUp/PgDn/Home/End scroll the focused dashboard
+			// (expanded, or compact while scroll focus is engaged). Editor
+			// keybindings are untouched whenever the dashboard is not focused.
 			if (matchesKey(data, "escape") && core.isDashboardExpanded()) {
 				core.toggleDashboardExpanded();
+				return { consume: true };
+			}
+			if (matchesKey(data, "escape") && core.goalWidgetComponentRef?.current?.isCompactScrollFocusActive()) {
+				core.goalWidgetComponentRef.current.clearScrollFocus();
 				return { consume: true };
 			}
 			if (matchesKey(data, "escape") && core.state.goal?.status === "active" && core.state.goal.autoContinue) {
@@ -141,8 +149,25 @@ export function syncTerminalInputPause(core: GoalCore, ctx: ExtensionContext): v
 			// expanded task views (the task-list overlay is merged into the
 			// dashboard; §10).
 			if (matchesKey(data, "ctrl+shift+t")) {
+				core.goalWidgetComponentRef?.current?.clearScrollFocus();
 				core.toggleDashboardExpanded();
 				return { consume: true };
+			}
+
+			// F6 — engage/disengage compact scroll focus so ↑/↓/PgUp/PgDn scroll
+			// the compact task list without touching editor navigation (§9.6).
+			if (matchesKey(data, "f6") && !core.isDashboardExpanded()) {
+				core.goalWidgetComponentRef?.current?.toggleCompactScrollFocus();
+				return { consume: true };
+			}
+
+			// Navigation keys scroll the focused dashboard (expanded, or compact
+			// while scroll focus is engaged).
+			if (matchesKey(data, "up") || matchesKey(data, "down") || matchesKey(data, "pageUp") || matchesKey(data, "pageDown") || matchesKey(data, "home") || matchesKey(data, "end")) {
+				const key = matchesKey(data, "up") ? "up" : matchesKey(data, "down") ? "down" : matchesKey(data, "pageUp") ? "pageUp" : matchesKey(data, "pageDown") ? "pageDown" : matchesKey(data, "home") ? "home" : "end";
+				if (core.goalWidgetComponentRef?.current?.handleNavigationKey(key)) {
+					return { consume: true };
+				}
 			}
 
 			// Debug keybindings are inert unless PI_GOAL_DEBUG is set (P1-13).

--- a/extensions/goal-widget.ts
+++ b/extensions/goal-widget.ts
@@ -128,16 +128,13 @@ export function syncTerminalInputPause(core: GoalCore, ctx: ExtensionContext): v
 			}
 			// §10: Escape collapses the expanded dashboard before it can pause the
 			// goal; Ctrl+Shift+T toggles compact/expanded (§19.5). While the
-			// compact widget holds scroll focus, Escape disengages it instead of
-			// pausing; ↑/↓/PgUp/PgDn/Home/End scroll the focused dashboard
-			// (expanded, or compact while scroll focus is engaged). Editor
-			// keybindings are untouched whenever the dashboard is not focused.
+			// expanded dashboard is open it owns the plain arrow keys; the
+			// compact widget scrolls with Ctrl+Shift chords that pi never binds
+			// (the editor owns ↑/↓/PgUp/PgDn), so no focus state is needed and
+			// editor keybindings are untouched whenever the dashboard is not
+			// focused.
 			if (matchesKey(data, "escape") && core.isDashboardExpanded()) {
 				core.toggleDashboardExpanded();
-				return { consume: true };
-			}
-			if (matchesKey(data, "escape") && core.goalWidgetComponentRef?.current?.isCompactScrollFocusActive()) {
-				core.goalWidgetComponentRef.current.clearScrollFocus();
 				return { consume: true };
 			}
 			if (matchesKey(data, "escape") && core.state.goal?.status === "active" && core.state.goal.autoContinue) {
@@ -149,23 +146,23 @@ export function syncTerminalInputPause(core: GoalCore, ctx: ExtensionContext): v
 			// expanded task views (the task-list overlay is merged into the
 			// dashboard; §10).
 			if (matchesKey(data, "ctrl+shift+t")) {
-				core.goalWidgetComponentRef?.current?.clearScrollFocus();
 				core.toggleDashboardExpanded();
 				return { consume: true };
 			}
 
-			// F6 — engage/disengage compact scroll focus so ↑/↓/PgUp/PgDn scroll
-			// the compact task list without touching editor navigation (§9.6).
-			if (matchesKey(data, "f6") && !core.isDashboardExpanded()) {
-				core.goalWidgetComponentRef?.current?.toggleCompactScrollFocus();
-				return { consume: true };
-			}
-
-			// Navigation keys scroll the focused dashboard (expanded, or compact
-			// while scroll focus is engaged).
+			// Navigation keys: plain arrows scroll the expanded dashboard (it is
+			// modal while open); Ctrl+Shift+↑/↓/PgUp/PgDn/Home/End scroll the
+			// compact task list — free chords, consumed only when the compact
+			// list overflows (§9.6).
 			if (matchesKey(data, "up") || matchesKey(data, "down") || matchesKey(data, "pageUp") || matchesKey(data, "pageDown") || matchesKey(data, "home") || matchesKey(data, "end")) {
 				const key = matchesKey(data, "up") ? "up" : matchesKey(data, "down") ? "down" : matchesKey(data, "pageUp") ? "pageUp" : matchesKey(data, "pageDown") ? "pageDown" : matchesKey(data, "home") ? "home" : "end";
 				if (core.goalWidgetComponentRef?.current?.handleNavigationKey(key)) {
+					return { consume: true };
+				}
+			}
+			if (matchesKey(data, "ctrl+shift+up") || matchesKey(data, "ctrl+shift+down") || matchesKey(data, "ctrl+shift+pageUp") || matchesKey(data, "ctrl+shift+pageDown") || matchesKey(data, "ctrl+shift+home") || matchesKey(data, "ctrl+shift+end")) {
+				const key = matchesKey(data, "ctrl+shift+up") ? "up" : matchesKey(data, "ctrl+shift+down") ? "down" : matchesKey(data, "ctrl+shift+pageUp") ? "pageUp" : matchesKey(data, "ctrl+shift+pageDown") ? "pageDown" : matchesKey(data, "ctrl+shift+home") ? "home" : "end";
+				if (core.goalWidgetComponentRef?.current?.handleCompactScrollKey(key)) {
 					return { consume: true };
 				}
 			}

--- a/extensions/goal-widget.ts
+++ b/extensions/goal-widget.ts
@@ -4,14 +4,13 @@ import { cloneGoal, createGoal, nowIso, type GoalTask } from "./goal-record.ts";
 import { checkSubtasksComplete, findTaskInTree } from "./goal-policy.ts";
 import { loadGoalSettings } from "./goal-settings.ts";
 import { serializeGoalFile } from "./storage/goal-files.ts";
-import { showTaskListOverlay } from "./widgets/task-list-overlay.ts";
 import type { AuditorWidgetProgress } from "./widgets/goal-widget.ts";
 import type { GoalCore } from "./goal-state.ts";
 
 const DEBUG_GOALS_DIR = ".pi/goals/debug";
 
 /**
- * Terminal input keybindings (Escape pause/abort-audit, Ctrl+Shift+T task
+ * Terminal input keybindings (Escape pause/abort-audit, Ctrl+Shift+T dashboard
  * overlay, and the hidden debug-mode bindings) plus the debug goal/task/audit
  * helpers. Re-registered at session start/tree navigation; the handler reads
  * live state through the core at event time.
@@ -127,18 +126,22 @@ export function syncTerminalInputPause(core: GoalCore, ctx: ExtensionContext): v
 				core.abortAudit(ctx);
 				return { consume: true };
 			}
+			// §10: Escape collapses the expanded dashboard before it can pause the
+			// goal; Ctrl+Shift+T toggles compact/expanded (§19.5).
+			if (matchesKey(data, "escape") && core.isDashboardExpanded()) {
+				core.toggleDashboardExpanded();
+				return { consume: true };
+			}
 			if (matchesKey(data, "escape") && core.state.goal?.status === "active" && core.state.goal.autoContinue) {
 				core.pauseActiveGoal(ctx);
 				return { consume: true };
 			}
 
-			// Ctrl+Shift+T — show task list overlay for all open goals (F3:
-			// interactive: Enter toggles a task through goal-service).
+			// Ctrl+Shift+T — toggle the unified dashboard between compact and
+			// expanded task views (the task-list overlay is merged into the
+			// dashboard; §10).
 			if (matchesKey(data, "ctrl+shift+t")) {
-				core.enterGoalModal();
-				showTaskListOverlay(ctx, core.goalsById, core.focusedGoalId, {
-					onToggleTask: (goalId, taskId) => toggleTaskViaService(core, ctx, goalId, taskId),
-				}).finally(() => core.exitGoalModal());
+				core.toggleDashboardExpanded();
 				return { consume: true };
 			}
 

--- a/extensions/goal.ts
+++ b/extensions/goal.ts
@@ -27,6 +27,8 @@ export default function goalExtension(
 	pi.registerMessageRenderer<GoalAuditEventDetails>(GOAL_AUDIT_ENTRY, renderGoalAuditEvent);
 
 	const core = createGoalCore(pi, dependencies);
+	// Test/debug hook: expose the core for harness introspection (no behavior).
+	(pi as unknown as { _goalCore?: typeof core })._goalCore = core;
 	registerGoalCommands(core);
 	registerGoalTools(core);
 	registerGoalEvents(core);

--- a/extensions/prompts/goal-prompts.ts
+++ b/extensions/prompts/goal-prompts.ts
@@ -1,12 +1,10 @@
-import {
-	statusLabel,
-	truncateText,
-} from "../goal-core.ts";
+import { statusLabel, truncateText } from "../goal-core.ts";
 import { promptSafeObjective } from "../goal-contract.ts";
 import type { GoalRecord, GoalTask, TaskStatus } from "../goal-record.ts";
 import { countTaskSubtree } from "../goal-task-count.ts";
 import type { GoalSettings } from "../goal-settings.ts";
 import { budgetLine } from "../goal-accounting.ts";
+import { findTaskInTree } from "../goal-policy.ts";
 
 /** Hard cap for the complete injected prompt fragment (TECH Stage 6). */
 export const MAX_PROMPT_FRAGMENT_CHARS = 10_000;
@@ -65,11 +63,21 @@ export function taskListBlock(goal: GoalRecord, settings?: GoalSettings): string
 	const { total, complete, skipped, pending, pendingTasks } = countTaskSubtree(goal.taskList.tasks, { collectPending: true });
 	const lines: string[] = [];
 	lines.push(`[TASK LIST — ${complete}/${total} tasks complete${skipped > 0 ? ` (${skipped} skipped)` : ""}]`);
+	// §8.1: surface the persisted execution focus (current task), with its
+	// verification contract when present, so the next continuation prompt
+	// carries the contract of the task the agent is working on.
+	if (goal.currentTaskId) {
+		const current = findTaskInTree(goal.taskList.tasks, goal.currentTaskId);
+		if (current) {
+			const contract = current.verificationContract ? ` (contract: ${current.verificationContract})` : "";
+			lines.push(`  Current: ${current.id} · ${current.title}${contract}`);
+		}
+	}
 	const rendered = { count: 0, stop: false };
 	lines.push(...renderPendingTasks(goal.taskList.tasks, 0, rendered));
 	const hiddenPending = (pending ?? 0) - rendered.count;
 	if (hiddenPending > 0) {
-		lines.push(`  (+${hiddenPending} more pending — see the task overlay, Ctrl+Shift+T)`);
+		lines.push(`  (+${hiddenPending} more pending — expand the dashboard with Ctrl+Shift+T)`);
 	}
 	if (goal.taskList.blockCompletion && pending! > 0) {
 		lines.push("  TASK GATE: do not request completion while tasks remain in [ ] pending state");
@@ -144,6 +152,8 @@ function promptCacheKey(goal: GoalRecord, settings?: GoalSettings): string {
 	return JSON.stringify([
 		goal.id, goal.revision, goal.updatedAt, goal.status, goal.autoContinue, goal.sisyphus,
 		goal.usage.tokensUsed, goal.usage.activeSeconds,
+		// §7.1/§8.1: execution focus changes the Current: line in the task block.
+		goal.currentTaskId,
 		settings?.disableTasks, settings?.disableContracts,
 	]);
 }

--- a/extensions/widgets/auditor-dashboard-model.ts
+++ b/extensions/widgets/auditor-dashboard-model.ts
@@ -1,0 +1,174 @@
+/**
+ * Structured audit dashboard model (plan §15).
+ *
+ * Pure derivation from the low-level auditor progress stream: five check
+ * stages (objective, verification, tasks, workspace, decision) with explicit
+ * pending/running/passed/failed states, plus the approval/rejection result
+ * card model. No TUI imports; the renderer and /goal-status share this model.
+ */
+
+import type { AuditorProgress } from "../goal-auditor.ts";
+import { formatDashboardDuration } from "./goal-dashboard-model.ts";
+
+export type AuditCheckState = "pending" | "running" | "passed" | "failed";
+
+export type AuditCheckId = "objective" | "verification" | "tasks" | "workspace" | "decision";
+
+export interface AuditCheck {
+	id: AuditCheckId;
+	label: string;
+	state: AuditCheckState;
+	detail?: string;
+}
+
+export type AuditVerdict = "approved" | "disapproved" | "error";
+
+export interface AuditorDashboardModel {
+	auditorLabel: string;
+	elapsedMs: number;
+	percentage?: number;
+	checks: AuditCheck[];
+	currentTool?: string;
+	currentToolArgs?: string;
+	recentOutput: string[];
+	/** Result verdict when the audit finished (drives the result card). */
+	verdict?: AuditVerdict | null;
+	/** Whether the audit session is still running (false when phase === done). */
+	active: boolean;
+}
+
+export interface AuditResultCard {
+	verdict: AuditVerdict;
+	label: string;
+	lines: string[];
+}
+
+const CHECK_LABELS: Array<{ id: AuditCheckId; label: string }> = [
+	{ id: "objective", label: "Objective and success criteria" },
+	{ id: "verification", label: "Verification contracts" },
+	{ id: "tasks", label: "Tasks and recorded evidence" },
+	{ id: "workspace", label: "Workspace inspection" },
+	{ id: "decision", label: "Final decision" },
+];
+
+export interface DeriveAuditorDashboardOptions {
+	auditorLabel?: string;
+	/** Result verdict when known (set after the audit session finishes). */
+	verdict?: AuditVerdict | null;
+}
+
+/**
+ * Derive the structured audit dashboard from the raw progress stream (§15.2).
+ *
+ * Active audit: checks advance through percentage bands (objective ≥20%,
+ * verification ≥40%, tasks ≥60%, workspace ≥80%, decision ≥80%) so the five
+ * stages light up in order. Finished audit: all checks pass except decision,
+ * which follows the verdict (approved → passed; disapproved/error → failed).
+ */
+export function deriveAuditorDashboardModel(
+	progress: AuditorProgress,
+	options: DeriveAuditorDashboardOptions = {},
+): AuditorDashboardModel {
+	const pct = clampPercentage(progress.percentage);
+	const done = progress.phase === "done";
+	const verdict = options.verdict !== undefined ? options.verdict : null;
+
+	const checks: AuditCheck[] = CHECK_LABELS.map(({ id, label }) => {
+		if (!done) {
+			const state = checkStateActive(id, pct);
+			return { id, label, state };
+		}
+		if (id === "decision") {
+			const state: AuditCheckState = verdict === "approved" ? "passed" : verdict === "disapproved" || verdict === "error" ? "failed" : "passed";
+			return { id, label, state };
+		}
+		return { id, label, state: "passed" };
+	});
+
+	return {
+		auditorLabel: options.auditorLabel ?? progress.label ?? "Independent completion audit",
+		elapsedMs: progress.elapsedMs,
+		...(progress.percentage !== undefined ? { percentage: pct } : {}),
+		checks,
+		currentTool: progress.currentTool,
+		currentToolArgs: progress.currentToolArgs,
+		recentOutput: progress.recentOutput,
+		...(verdict ? { verdict } : {}),
+		active: !done,
+	};
+}
+
+function checkStateActive(id: AuditCheckId, pct: number): AuditCheckState {
+	switch (id) {
+		case "objective":
+			return pct >= 20 ? "passed" : "running";
+		case "verification":
+			return pct >= 40 ? "passed" : pct >= 20 ? "running" : "pending";
+		case "tasks":
+			return pct >= 60 ? "passed" : pct >= 40 ? "running" : "pending";
+		case "workspace":
+			return pct >= 80 ? "passed" : pct >= 60 ? "running" : "pending";
+		case "decision":
+			return pct >= 80 ? "running" : "pending";
+	}
+}
+
+function clampPercentage(value: number | undefined): number {
+	if (value === undefined) return 0;
+	return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+/** Human duration label for the audit header (reused formatter). */
+export function formatAuditElapsed(elapsedMs: number): string {
+	return formatDashboardDuration(Math.floor(elapsedMs / 1000));
+}
+
+/**
+ * Build the result card (§15.4). Approval shows the fixed acceptance lines;
+ * rejection extracts concise findings from the auditor report (bullet-style or
+ * the leading non-marker lines, capped at three); errors state the failure.
+ */
+export function deriveAuditResultCard(verdict: AuditVerdict, report: string): AuditResultCard {
+	if (verdict === "approved") {
+		return {
+			verdict,
+			label: "APPROVED",
+			lines: ["Objective satisfied.", "Verification requirements satisfied.", "Required tasks and evidence accepted."],
+		};
+	}
+	if (verdict === "error") {
+		return {
+			verdict,
+			label: "ERROR",
+			lines: [report.trim() ? oneLine(report) : "The auditor could not finish the review."],
+		};
+	}
+	const findings = extractFindings(report);
+	return {
+		verdict,
+		label: "CHANGES REQUIRED",
+		lines: findings.length > 0 ? findings : [oneLine(report) || "The auditor requested changes — review the report."],
+	};
+}
+
+function extractFindings(report: string): string[] {
+	const lines = report.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+	const findings: string[] = [];
+	for (const line of lines) {
+		if (/^<(approved|disapproved)\s*\/>/.test(line)) continue;
+		const cleaned = line.replace(/^[-*•✗✓]\s*/, "").replace(/^(\d+[.)])\s*/, "").trim();
+		if (!cleaned) continue;
+		// Skip section headers ("Audit report:", "Findings:") and generic
+		// "Auditor: ..." attribution lines — they are not findings.
+		if (/^auditor\s*:/i.test(cleaned)) continue;
+		if (/^[a-z][a-z ]{0,24}:$/i.test(cleaned)) continue;
+		if (cleaned.length > 200) findings.push(`${cleaned.slice(0, 197)}...`);
+		else findings.push(cleaned);
+		if (findings.length >= 3) break;
+	}
+	return findings;
+}
+
+function oneLine(value: string): string {
+	return value.replace(/\s+/g, " ").trim();
+}

--- a/extensions/widgets/goal-dashboard-model.ts
+++ b/extensions/widgets/goal-dashboard-model.ts
@@ -333,6 +333,18 @@ export function compactTaskViewportRows(width: number): number {
 	return 2;
 }
 
+/**
+ * Task-row budget for the expanded dashboard's task-tree window by terminal
+ * width. The widget uses this to keep the expanded panel bounded and
+ * scrollable; callers that want the full tree pass rows = totalRows.
+ */
+export function expandedTaskViewportRows(width: number): number {
+	if (width >= 100) return 20;
+	if (width >= 70) return 16;
+	if (width >= 50) return 12;
+	return 8;
+}
+
 /** PgUp/PgDn step: one viewport (a page) of rows. */
 export function taskViewportPageSize(rows: number): number {
 	return Math.max(1, Math.floor(rows));

--- a/extensions/widgets/goal-dashboard-model.ts
+++ b/extensions/widgets/goal-dashboard-model.ts
@@ -1,0 +1,376 @@
+/**
+ * Shared dashboard view model (plan §6) — the single source of truth for the
+ * persistent compact dashboard, the expanded dashboard, `/goal-status`, audit
+ * transitions, golden tests, and documentation examples.
+ *
+ * Pure data derivation only: this module must never import TUI rendering
+ * components. Width-safe truncation, borders, and color belong to the
+ * renderer; everything factual here is derived from persisted goal state and
+ * the durable ledger.
+ */
+
+import { displayObjectiveTitle, formatDuration } from "../goal-core.ts";
+import type { GoalLedgerEvent } from "../goal-ledger.ts";
+import type { GoalRecord, GoalTask } from "../goal-record.ts";
+import { deriveGoalActivity, type GoalActivityItem } from "../goal-activity.ts";
+
+// ---------------------------------------------------------------------------
+// Types (plan §6)
+// ---------------------------------------------------------------------------
+
+export type DashboardStatusCode = "running" | "idle" | "paused" | "blocked" | "budget_limited" | "complete";
+
+export interface GoalDashboardModel {
+	goalId: string;
+	title: string;
+
+	status: {
+		code: DashboardStatusCode;
+		label: string;
+		reason?: string;
+		suggestedAction?: string;
+	};
+
+	focused: boolean;
+	filePath?: string;
+
+	usage: {
+		activeSeconds: number;
+		elapsedLabel: string;
+		tokens: number;
+		tokenLabel: string;
+	};
+
+	budget?: {
+		used: number;
+		total: number;
+		percentage: number;
+		remaining: number;
+	};
+
+	taskProgress?: {
+		completed: number;
+		total: number;
+		percentage: number;
+	};
+
+	taskTree: DashboardTaskNode[];
+
+	currentTask?: {
+		id: string;
+		title: string;
+		depth: number;
+		completedSubtasks: number;
+		totalSubtasks: number;
+		subtaskPercentage: number;
+		verificationContract?: string;
+		evidence?: string;
+		/**
+		 * True when no valid persisted currentTaskId existed and the current
+		 * task was inferred from the first pending task for display only —
+		 * never persisted (§7.4).
+		 */
+		inferred?: boolean;
+	};
+
+	goalVerificationContract?: string;
+	otherOpenGoals: number;
+	recentActivity: GoalActivityItem[];
+}
+
+export interface DashboardTaskNode {
+	id: string;
+	title: string;
+	status: "pending" | "complete" | "skipped";
+	depth: number;
+	isCurrent: boolean;
+	verificationContract?: string;
+	evidence?: string;
+}
+
+export interface GoalDashboardModelOptions {
+	focused: boolean;
+	otherOpenGoals: number;
+	ledgerEvents?: readonly GoalLedgerEvent[];
+	activityLimit?: number;
+	/** §9.5: omit task sections when tasks are disabled by settings. */
+	tasksDisabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Status derivation
+// ---------------------------------------------------------------------------
+
+export interface DashboardGoalStatus {
+	code: DashboardStatusCode;
+	label: string;
+	reason?: string;
+	suggestedAction?: string;
+}
+
+/**
+ * Map the persisted lifecycle status to a display code. Labels are explicit
+ * words so the dashboard stays understandable without status symbols (§5.2).
+ */
+export function deriveGoalStatus(goal: GoalRecord): DashboardGoalStatus {
+	switch (goal.status) {
+		case "active":
+			return goal.autoContinue
+				? { code: "running", label: "In progress" }
+				: { code: "idle", label: "Idle" };
+		case "paused": {
+			const who = goal.stopReason === "agent" ? " (agent)" : goal.stopReason === "user" ? " (user)" : "";
+			const status: DashboardGoalStatus = { code: "paused", label: `Paused${who}` };
+			if (goal.pauseReason) status.reason = goal.pauseReason;
+			if (goal.pauseSuggestedAction) status.suggestedAction = goal.pauseSuggestedAction;
+			return status;
+		}
+		case "blocked": {
+			const status: DashboardGoalStatus = { code: "blocked", label: "Blocked" };
+			if (goal.pauseReason) status.reason = goal.pauseReason;
+			if (goal.pauseSuggestedAction) status.suggestedAction = goal.pauseSuggestedAction;
+			return status;
+		}
+		case "budget_limited":
+			return { code: "budget_limited", label: "Budget limited" };
+		case "complete":
+			return { code: "complete", label: "Complete" };
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task progress (plan §9)
+// ---------------------------------------------------------------------------
+
+export interface TaskProgress {
+	completed: number;
+	total: number;
+	percentage: number;
+}
+
+/**
+ * Overall progress across TOP-LEVEL tasks only (§9.1): a top-level task
+ * counts as done when it is complete or skipped, keeping the main percentage
+ * aligned with major milestones.
+ */
+export function deriveTopLevelTaskProgress(goal: GoalRecord): TaskProgress | undefined {
+	const tasks = goal.taskList?.tasks;
+	if (!tasks || tasks.length === 0) return undefined;
+	const completed = tasks.filter((t) => t.status === "complete" || t.status === "skipped").length;
+	return { completed, total: tasks.length, percentage: percentageOf(completed, tasks.length) };
+}
+
+function percentageOf(done: number, total: number): number {
+	if (total <= 0) return 0;
+	return Math.min(100, Math.max(0, Math.round((done / total) * 100)));
+}
+
+// ---------------------------------------------------------------------------
+// Task tree (plan §9.2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Flatten the recursive task tree into display rows. `currentTaskId` marks
+ * the current node; pass the EFFECTIVE current id (persisted, or inferred)
+ * so the tree and the current-task block always agree.
+ */
+export function flattenTaskTree(tasks: readonly GoalTask[] | undefined, currentTaskId?: string): DashboardTaskNode[] {
+	const nodes: DashboardTaskNode[] = [];
+	if (!tasks) return nodes;
+	const walk = (list: readonly GoalTask[], depth: number): void => {
+		for (const t of list) {
+			nodes.push({
+				id: t.id,
+				title: t.title,
+				status: t.status,
+				depth,
+				isCurrent: t.id === currentTaskId,
+				verificationContract: t.verificationContract,
+				evidence: t.evidence,
+			});
+			if (t.subtasks && t.subtasks.length > 0) walk(t.subtasks, depth + 1);
+		}
+	};
+	walk(tasks, 0);
+	return nodes;
+}
+
+// ---------------------------------------------------------------------------
+// Current task (plan §7.2, §9.3)
+// ---------------------------------------------------------------------------
+
+export interface CurrentTaskSubtaskProgress {
+	completedSubtasks: number;
+	totalSubtasks: number;
+	subtaskPercentage: number;
+}
+
+/**
+ * Subtask progress for the current task (§9.3 preferred rule): for a parent
+ * task, direct-child completion; for a leaf task, all-zero so the renderer
+ * can omit the ratio rather than show something confusing.
+ */
+export function deriveCurrentTaskSubtaskProgress(current: { id: string }, tasks: readonly GoalTask[]): CurrentTaskSubtaskProgress {
+	const parent = findTask(tasks, current.id);
+	const children = parent?.subtasks;
+	if (!children || children.length === 0) {
+		return { completedSubtasks: 0, totalSubtasks: 0, subtaskPercentage: 0 };
+	}
+	const completed = children.filter((c) => c.status === "complete" || c.status === "skipped").length;
+	return {
+		completedSubtasks: completed,
+		totalSubtasks: children.length,
+		subtaskPercentage: percentageOf(completed, children.length),
+	};
+}
+
+export interface DashboardCurrentTask extends CurrentTaskSubtaskProgress {
+	id: string;
+	title: string;
+	depth: number;
+	verificationContract?: string;
+	evidence?: string;
+	inferred?: boolean;
+}
+
+/**
+ * Resolve the current task: the persisted currentTaskId when it references an
+ * existing pending task; otherwise (missing, invalid, or removed) fall back
+ * to the first pending task in tree order, marked `inferred` so the fallback
+ * is never persisted (§7.4). `currentTaskId` may point at any tree node —
+ * top-level task or subtask (§7.2).
+ */
+export function deriveCurrentTask(goal: GoalRecord, nodes: DashboardTaskNode[]): DashboardCurrentTask | undefined {
+	const tasks = goal.taskList?.tasks;
+	if (!tasks || tasks.length === 0 || nodes.length === 0) return undefined;
+	let node: DashboardTaskNode | undefined;
+	if (goal.currentTaskId) {
+		node = nodes.find((n) => n.id === goal.currentTaskId && n.status === "pending");
+	}
+	const inferred = node === undefined;
+	if (inferred) node = nodes.find((n) => n.status === "pending");
+	if (!node) return undefined;
+	const subtaskProgress = deriveCurrentTaskSubtaskProgress(node, tasks);
+	return {
+		id: node.id,
+		title: node.title,
+		depth: node.depth,
+		...subtaskProgress,
+		verificationContract: node.verificationContract,
+		evidence: node.evidence,
+		...(inferred ? { inferred: true } : {}),
+	};
+}
+
+function findTask(tasks: readonly GoalTask[], id: string): GoalTask | undefined {
+	for (const t of tasks) {
+		if (t.id === id) return t;
+		if (t.subtasks && t.subtasks.length > 0) {
+			const found = findTask(t.subtasks, id);
+			if (found) return found;
+		}
+	}
+	return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Activity (re-exported from the durable-ledger mapping, §12)
+// ---------------------------------------------------------------------------
+
+export { deriveGoalActivity };
+export type { GoalActivityItem, GoalActivityKind } from "../goal-activity.ts";
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+/** Compact elapsed duration, e.g. `12m47s` (shared formatter from goal-core). */
+export function formatDashboardDuration(seconds: number): string {
+	return formatDuration(seconds);
+}
+
+/** Audit header duration label from milliseconds (§15.3). */
+export function formatAuditElapsed(elapsedMs: number): string {
+	return formatDuration(Math.floor(Math.max(0, elapsedMs) / 1000));
+}
+
+/**
+ * Compact token count, e.g. `18.2K`, `2.5M`, `999`. Shared display label for
+ * the dashboard header and budget rows.
+ */
+export function formatCompactTokens(value: number): string {
+	const safe = Math.max(0, Math.floor(value));
+	if (safe >= 1_000_000) return `${trimZero((safe / 1_000_000).toFixed(1))}M`;
+	if (safe >= 1_000) return `${trimZero((safe / 1_000).toFixed(1))}K`;
+	return String(safe);
+}
+
+function trimZero(value: string): string {
+	return value.replace(/\.0$/, "");
+}
+
+/** Budget summary, e.g. `18.2K / 50K · 36%`. */
+export function formatBudget(used: number, total: number): string {
+	const pct = total > 0 ? Math.min(100, Math.max(0, Math.round((used / total) * 100))) : 0;
+	return `${formatCompactTokens(used)} / ${formatCompactTokens(total)} · ${pct}%`;
+}
+
+// ---------------------------------------------------------------------------
+// Whole-model derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the unified dashboard model for one goal. Returns null when there is
+ * no goal record; surfaces that need the "no goal / focus required" panel
+ * (plan §4.3) render that from their own context with `otherOpenGoals`.
+ */
+export function deriveGoalDashboardModel(
+	goal: GoalRecord | null,
+	options: GoalDashboardModelOptions,
+): GoalDashboardModel | null {
+	if (!goal) return null;
+	const { focused, otherOpenGoals, ledgerEvents = [], activityLimit, tasksDisabled = false } = options;
+
+	const status = deriveGoalStatus(goal);
+	// §9.5: with tasks disabled, omit task sections entirely (status,
+	// verification, usage, path, and focus remain).
+	const taskProgress = tasksDisabled ? undefined : deriveTopLevelTaskProgress(goal);
+	const tree = tasksDisabled ? [] : flattenTaskTree(goal.taskList?.tasks, undefined);
+	const currentTask = tasksDisabled ? undefined : deriveCurrentTask(goal, tree);
+	const effectiveCurrentId = currentTask?.id;
+	const taskTree = tree.map((n) => (n.id === effectiveCurrentId ? { ...n, isCurrent: true } : n));
+
+	const budget =
+		goal.tokenBudget !== undefined
+			? {
+					used: goal.usage.tokensUsed,
+					total: goal.tokenBudget,
+					percentage: percentageOf(goal.usage.tokensUsed, goal.tokenBudget),
+					remaining: Math.max(0, goal.tokenBudget - goal.usage.tokensUsed),
+				}
+			: undefined;
+
+	const taskTitles = new Map(taskTree.map((n) => [n.id, n.title]));
+	const recentActivity = deriveGoalActivity(ledgerEvents, goal.id, { taskTitles, limit: activityLimit });
+
+	return {
+		goalId: goal.id,
+		title: displayObjectiveTitle(goal.objective),
+		status,
+		focused,
+		filePath: goal.activePath ?? goal.archivedPath,
+		usage: {
+			activeSeconds: goal.usage.activeSeconds,
+			elapsedLabel: formatDashboardDuration(goal.usage.activeSeconds),
+			tokens: goal.usage.tokensUsed,
+			tokenLabel: `${formatCompactTokens(goal.usage.tokensUsed)} tok`,
+		},
+		budget,
+		taskProgress,
+		taskTree,
+		currentTask,
+		goalVerificationContract: goal.verificationContract,
+		otherOpenGoals,
+		recentActivity,
+	};
+}

--- a/extensions/widgets/goal-dashboard-model.ts
+++ b/extensions/widgets/goal-dashboard-model.ts
@@ -86,6 +86,8 @@ export interface DashboardTaskNode {
 	isCurrent: boolean;
 	verificationContract?: string;
 	evidence?: string;
+	/** Completion timestamp (when status is complete) — the scroll anchor (§9.6). */
+	completedAt?: string;
 }
 
 export interface GoalDashboardModelOptions {
@@ -187,6 +189,7 @@ export function flattenTaskTree(tasks: readonly GoalTask[] | undefined, currentT
 				isCurrent: t.id === currentTaskId,
 				verificationContract: t.verificationContract,
 				evidence: t.evidence,
+				completedAt: t.completedAt,
 			});
 			if (t.subtasks && t.subtasks.length > 0) walk(t.subtasks, depth + 1);
 		}
@@ -259,6 +262,110 @@ export function deriveCurrentTask(goal: GoalRecord, nodes: DashboardTaskNode[]):
 		verificationContract: node.verificationContract,
 		evidence: node.evidence,
 		...(inferred ? { inferred: true } : {}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Task-list viewport / scroll (plan §9.6)
+//
+// The task list is a window over the rendered rows. Pure functions only: the
+// widget owns the mutable offset and the re-anchor rule; the renderer owns
+// the box drawing. Anchoring means the default viewport is positioned so the
+// most recently completed task is visible — "scrolled down" to recent work
+// instead of always showing the earliest tasks.
+// ---------------------------------------------------------------------------
+
+/**
+ * Index of the most recently completed node: the node with status
+ * "complete" and the greatest completedAt; ties resolve to the LAST such
+ * node in plan order. Returns -1 when nothing qualifies (e.g. legacy tasks
+ * without a completion timestamp), in which case the viewport stays at the
+ * top.
+ */
+export function latestCompletedNodeIndex(nodes: readonly DashboardTaskNode[]): number {
+	let bestIndex = -1;
+	let bestAt = "";
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i]!;
+		if (node.status !== "complete" || !node.completedAt) continue;
+		// `>=` keeps the LAST node among equal timestamps (most recent plan
+		// position), matching how a viewer reads "most recently done".
+		if (bestIndex === -1 || node.completedAt >= bestAt) {
+			bestIndex = i;
+			bestAt = node.completedAt;
+		}
+	}
+	return bestIndex;
+}
+
+/** Highest valid scroll offset for a list of totalRows shown in rows rows. */
+export function maxScrollOffset(totalRows: number, rows: number): number {
+	return Math.max(0, totalRows - rows);
+}
+
+/** Clamp an offset into [0, maxScrollOffset]. */
+export function clampScrollOffset(offset: number, totalRows: number, rows: number): number {
+	return Math.min(Math.max(0, Math.floor(offset)), maxScrollOffset(totalRows, rows));
+}
+
+/**
+ * Default viewport offset, bottom-anchored to the most recently completed
+ * task: the anchor is the LAST visible row, so the view shows the recent
+ * completions (and whatever follows them in plan order) instead of the
+ * earliest tasks. With no completed (or timestamped) tasks the viewport
+ * starts at the top.
+ */
+export function anchoredScrollOffset(nodes: readonly DashboardTaskNode[], rows: number): number {
+	const anchor = latestCompletedNodeIndex(nodes);
+	if (anchor < 0 || rows <= 0) return 0;
+	return clampScrollOffset(anchor - (rows - 1), nodes.length, rows);
+}
+
+/**
+ * Task-row budget for the compact viewport by terminal width (§5.5 buckets:
+ * wide ≥100, medium 70–99, narrow 50–69, minimal <50). The expanded view
+ * derives its own rows from the render height.
+ */
+export function compactTaskViewportRows(width: number): number {
+	if (width >= 100) return 5;
+	if (width >= 70) return 4;
+	if (width >= 50) return 3;
+	return 2;
+}
+
+/** PgUp/PgDn step: one viewport (a page) of rows. */
+export function taskViewportPageSize(rows: number): number {
+	return Math.max(1, Math.floor(rows));
+}
+
+export interface TaskListViewport {
+	totalRows: number;
+	rows: number;
+	offset: number;
+	maxOffset: number;
+	/** Rows hidden above the window (offset > 0). */
+	hiddenAbove: number;
+	/** Rows hidden below the window (offset + rows < total). */
+	hiddenBelow: number;
+}
+
+/**
+ * Derive the viewport window for a list of totalRows given a clamped offset
+ * and row budget. The renderer uses hiddenAbove/hiddenBelow to draw the
+ * `↑ N more` / `… +N more` indicator rows.
+ */
+export function deriveTaskListViewport(totalRows: number, rows: number, offset: number): TaskListViewport {
+	const safeRows = Math.max(0, Math.floor(rows));
+	const clamped = clampScrollOffset(offset, totalRows, safeRows);
+	const maxOffset = maxScrollOffset(totalRows, safeRows);
+	const visible = Math.min(safeRows, Math.max(0, totalRows - clamped));
+	return {
+		totalRows,
+		rows: safeRows,
+		offset: clamped,
+		maxOffset,
+		hiddenAbove: clamped,
+		hiddenBelow: Math.max(0, totalRows - (clamped + visible)),
 	};
 }
 

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -27,7 +27,9 @@ import {
 import type { GoalActivityItem } from "../goal-activity.ts";
 import { truncateText } from "../goal-core.ts";
 
-type RenderColor = Extract<ThemeColor, "accent" | "warning" | "success" | "error" | "dim" | "muted" | "text" | "mdHeading" | "mdLink">;
+// mdLink is deliberately excluded: the chrome must stay neutral gray, not
+// blue-tinged ("more grey than blue").
+type RenderColor = Extract<ThemeColor, "accent" | "warning" | "success" | "error" | "dim" | "muted" | "text" | "mdHeading">;
 
 // ── §5.1 border system ──────────────────────────────────────────────────────
 
@@ -35,10 +37,11 @@ const H = "─";
 const V = "│";
 
 /** Box chrome: the entire frame — corners, top/bottom dashes, left/right
- * edges and interior rules — is one tone: light steel gray-blue (mdLink).
- * Only the content inside is colour-coded. */
+ * edges and interior rules — is one tone: the theme's neutral gray (muted).
+ * No blue tinge: the chrome is grey, while the content inside is
+ * colour-coded. */
 function frame(theme: Theme, value: string): string {
-	return theme.fg("mdLink", value);
+	return theme.fg("muted", value);
 }
 
 function fit(value: string, width: number): string {

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -27,14 +27,20 @@ import {
 import type { GoalActivityItem } from "../goal-activity.ts";
 import { truncateText } from "../goal-core.ts";
 
-type RenderColor = Extract<ThemeColor, "accent" | "warning" | "success" | "error" | "dim" | "muted" | "text" | "mdHeading">;
+type RenderColor = Extract<ThemeColor, "accent" | "warning" | "success" | "error" | "dim" | "muted" | "text" | "mdHeading" | "mdLink">;
 
 // ── §5.1 border system ──────────────────────────────────────────────────────
 
 const H = "─";
 const V = "│";
 
-/** Box borders: theme-appropriate gray (muted) instead of dim. */
+/** Outer box frame: light steel gray-blue (mdLink) — clearly lighter than the
+ * interior rules and in the same hue family as pi's own borders. */
+function frame(theme: Theme, value: string): string {
+	return theme.fg("mdLink", value);
+}
+
+/** Interior rules: theme gray (muted) — subtle hierarchy inside the frame. */
 function border(theme: Theme, value: string): string {
 	return theme.fg("muted", value);
 }
@@ -53,10 +59,10 @@ function boxHeader(theme: Theme, width: number, left: string, right = ""): strin
 		const budget = Math.max(4, inner - visibleWidth(r) - 4);
 		const l2 = `${H} ${fit(left, budget)}`;
 		const fill = Math.max(1, inner - visibleWidth(l2) - visibleWidth(r) - 1);
-		return `╭${l2}${border(theme, H.repeat(fill))}${r}╮`;
+		return `╭${l2}${frame(theme, H.repeat(fill))}${r}╮`;
 	}
 	const fill = Math.max(1, inner - fixed);
-	return `╭${l}${border(theme, H.repeat(fill))}${r}╮`;
+	return `╭${l}${frame(theme, H.repeat(fill))}${r}╮`;
 }
 
 function boxLine(theme: Theme, width: number, content: string): string {
@@ -81,11 +87,11 @@ function boxSectionRule(theme: Theme, width: number, label: string): string {
 function boxFooter(theme: Theme, width: number, content: string): string {
 	const inner = Math.max(4, width - 2);
 	if (!content) {
-		return `╰${border(theme, H.repeat(inner))}╯`;
+		return `╰${frame(theme, H.repeat(inner))}╯`;
 	}
 	const l = `${H} ${muted(theme, content)}`;
 	const fill = Math.max(1, inner - visibleWidth(l) - 1);
-	return `╰${l}${border(theme, H.repeat(fill))}╯`;
+	return `╰${l}${frame(theme, H.repeat(fill))}╯`;
 }
 
 // ── §5.2 status symbols / colors ────────────────────────────────────────────
@@ -193,11 +199,12 @@ function renderTaskRow(theme: Theme, node: DashboardTaskNode, indent: number, av
 	const titleBudget = Math.max(4, available - visibleWidth(prefix) - visibleWidth(contractMark));
 	const title = fit(node.title, titleBudget);
 	const markerText = theme.fg(marker.color, marker.symbol);
-	const colored = node.isCurrent
-		? `${markerText} ${accent(theme, `${node.id}  ${title}`)}`
-		: `${markerText} ${amber(theme, `${node.id}  ${title}`)}`;
-	const line = `${indentText}${colored}${contractMark}`;
-	return line;
+	// Colour-coded: the id shares the marker color (amber pending, green
+	// complete, gray skipped, teal current); titles stay amber, the current
+	// task is fully accent.
+	const idText = node.isCurrent ? accent(theme, node.id) : theme.fg(marker.color, node.id);
+	const titleText = node.isCurrent ? accent(theme, title) : amber(theme, title);
+	return `${indentText}${markerText} ${idText}  ${titleText}${contractMark}`;
 }
 
 /**
@@ -211,7 +218,7 @@ function renderTaskRow(theme: Theme, node: DashboardTaskNode, indent: number, av
 function renderCompactTaskRows(theme: Theme, nodes: DashboardTaskNode[], viewport: TaskListViewport, available: number): string[] {
 	const rows: string[] = [];
 	if (viewport.hiddenAbove > 0) {
-		rows.push(dim(theme, `↑ ${viewport.hiddenAbove} more task${viewport.hiddenAbove === 1 ? "" : "s"}`));
+		rows.push(muted(theme, `↑ ${viewport.hiddenAbove} more task${viewport.hiddenAbove === 1 ? "" : "s"}`));
 	}
 	const shown = nodes.slice(viewport.offset, viewport.offset + viewport.rows);
 	const idWidth = shown.length === 0 ? 0 : Math.min(10, Math.max(...shown.map((node) => node.id.length)));
@@ -223,11 +230,13 @@ function renderCompactTaskRows(theme: Theme, nodes: DashboardTaskNode[], viewpor
 		const titleBudget = Math.max(4, available - visibleWidth(prefix) - visibleWidth(contractMark));
 		const title = fit(node.title, titleBudget);
 		const markerText = theme.fg(marker.color, marker.symbol);
-		const body = node.isCurrent ? accent(theme, `${id}  ${title}`) : amber(theme, `${id}  ${title}`);
-		rows.push(`${markerText} ${body}${contractMark}`);
+		// Colour-coded: id shares the marker color; titles amber; current accent.
+		const idText = node.isCurrent ? accent(theme, id) : theme.fg(marker.color, id);
+		const body = node.isCurrent ? accent(theme, title) : amber(theme, title);
+		rows.push(`${markerText} ${idText}  ${body}${contractMark}`);
 	}
 	if (viewport.hiddenBelow > 0) {
-		rows.push(dim(theme, `… +${viewport.hiddenBelow} more task${viewport.hiddenBelow === 1 ? "" : "s"}`));
+		rows.push(muted(theme, `… +${viewport.hiddenBelow} more task${viewport.hiddenBelow === 1 ? "" : "s"}`));
 	}
 	return rows;
 }
@@ -262,7 +271,7 @@ export function renderCompactDashboard(
 	const usageRight = mode !== "minimal" && (model.usage.activeSeconds > 0 || model.usage.tokens > 0)
 		? `${model.usage.elapsedLabel} · ${model.usage.tokenLabel}`
 		: "";
-	lines.push(boxHeader(theme, safeWidth, `pi-goal-x ─ ${model.title}`, muted(theme, usageRight)));
+	lines.push(boxHeader(theme, safeWidth, `${accent(theme, "pi-goal-x")} ─ ${model.title}`, muted(theme, usageRight)));
 
 	// Status line.
 	if (model.status.code === "complete") {
@@ -276,15 +285,17 @@ export function renderCompactDashboard(
 		lines.push(boxLine(theme, safeWidth, bits.join(" · ")));
 	}
 
-	// Budget (when configured).
+	// Budget (when configured): fuel gauge + amount, amber until the budget is
+	// exhausted, then soft red.
 	if (model.budget) {
-		lines.push(boxLine(theme, safeWidth, `${theme.fg("mdHeading", "⛽")} ${muted(theme, `Budget ${formatBudget(model.budget.used, model.budget.total)}`)}`));
+		const fuel = model.budget.used >= model.budget.total ? "error" : "mdHeading";
+		lines.push(boxLine(theme, safeWidth, `${theme.fg(fuel as RenderColor, "⛽")} ${muted(theme, "Budget")} ${theme.fg(fuel as RenderColor, formatBudget(model.budget.used, model.budget.total))}`));
 	}
 
 	// Overall task progress (§9.1).
 	if (model.taskProgress) {
 		const bar = progressBar(theme, model.taskProgress.percentage, spec.barWidth);
-		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Tasks")}  ${bar} ${model.taskProgress.completed}/${model.taskProgress.total} · ${model.taskProgress.percentage}%`));
+		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Tasks")}  ${bar} ${accent(theme, `${model.taskProgress.completed}/${model.taskProgress.total}`)} · ${muted(theme, `${model.taskProgress.percentage}%`)}`));
 	}
 
 	// §9.2/§9.6 compact task list: a window over the top-level tasks, anchored
@@ -312,16 +323,17 @@ export function renderCompactDashboard(
 	// Current task (persisted focus or inferred first pending).
 	if (model.currentTask) {
 		if (mode === "minimal") {
-			lines.push(boxLine(theme, safeWidth, `${accent(theme, "▸")} ${fit(model.currentTask.title, inner - 3)}`));
+			lines.push(boxLine(theme, safeWidth, `${accent(theme, "▸")} ${accent(theme, fit(model.currentTask.title, inner - 3))}`));
 		} else {
-			lines.push(boxLine(theme, safeWidth, `${muted(theme, "Current")}  ${accent(theme, model.currentTask.id)} · ${fit(model.currentTask.title, inner - visibleWidth(`Current  ${model.currentTask.id} · `))}`));
+			const titleBudget = inner - visibleWidth(`Current  ${model.currentTask.id} · `);
+			lines.push(boxLine(theme, safeWidth, `${muted(theme, "Current")}  ${accent(theme, model.currentTask.id)} · ${accent(theme, fit(model.currentTask.title, titleBudget))}`));
 		}
 	}
 
 	// Current-task subtask progress (§9.3).
 	if (model.currentTask && model.currentTask.totalSubtasks > 0 && mode !== "minimal") {
 		const bar = progressBar(theme, model.currentTask.subtaskPercentage, spec.barWidth);
-		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Subtasks")} ${bar} ${model.currentTask.completedSubtasks}/${model.currentTask.totalSubtasks} · ${model.currentTask.subtaskPercentage}%`));
+		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Subtasks")} ${bar} ${accent(theme, `${model.currentTask.completedSubtasks}/${model.currentTask.totalSubtasks}`)} · ${muted(theme, `${model.currentTask.subtaskPercentage}%`)}`));
 	}
 
 	// Goal-level verification (§11.1): truncated first line in compact.
@@ -331,7 +343,7 @@ export function renderCompactDashboard(
 
 	// Blocked details (§4.5).
 	if (model.status.code === "blocked") {
-		if (model.status.reason) lines.push(boxLine(theme, safeWidth, `${theme.fg("error", "Blocker")}  ${fit(model.status.reason, inner - 10)}`));
+		if (model.status.reason) lines.push(boxLine(theme, safeWidth, `${theme.fg("error", "Blocker")}  ${muted(theme, fit(model.status.reason, inner - 10))}`));
 		if (spec.showPauseAction && model.status.suggestedAction) lines.push(boxLine(theme, safeWidth, `${muted(theme, "Action")}   ${fit(model.status.suggestedAction, inner - 9)}`));
 	}
 
@@ -382,7 +394,7 @@ export function renderExpandedDashboard(
 	const usageRight = mode !== "minimal" && (model.usage.activeSeconds > 0 || model.usage.tokens > 0)
 		? `${model.usage.elapsedLabel} · ${model.usage.tokenLabel}`
 		: "";
-	lines.push(boxHeader(theme, safeWidth, `pi-goal-x ─ ${model.title}`, muted(theme, usageRight)));
+	lines.push(boxHeader(theme, safeWidth, `${accent(theme, "pi-goal-x")} ─ ${model.title}`, muted(theme, usageRight)));
 
 	const symbol = STATUS_SYMBOL[model.status.code];
 	const color = STATUS_COLOR[model.status.code];

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -34,15 +34,11 @@ type RenderColor = Extract<ThemeColor, "accent" | "warning" | "success" | "error
 const H = "─";
 const V = "│";
 
-/** Outer box frame: light steel gray-blue (mdLink) — clearly lighter than the
- * interior rules and in the same hue family as pi's own borders. */
+/** Box chrome: the entire frame — corners, top/bottom dashes, left/right
+ * edges and interior rules — is one tone: light steel gray-blue (mdLink).
+ * Only the content inside is colour-coded. */
 function frame(theme: Theme, value: string): string {
 	return theme.fg("mdLink", value);
-}
-
-/** Interior rules: theme gray (muted) — subtle hierarchy inside the frame. */
-function border(theme: Theme, value: string): string {
-	return theme.fg("muted", value);
 }
 
 function fit(value: string, width: number): string {
@@ -51,8 +47,8 @@ function fit(value: string, width: number): string {
 
 function boxHeader(theme: Theme, width: number, left: string, right = ""): string {
 	const inner = Math.max(4, width - 2);
-	// The leading/trailing dashes belong to the frame, so they carry the same
-	// color as the fill; only the corners stay plain.
+	// One-tone frame line: corners, leading/trailing dashes and fill all carry
+	// the frame color; only the brand inside stays accent.
 	const l = `${frame(theme, H)} ${left}`;
 	const r = right ? ` ${right} ${frame(theme, H)}` : "";
 	const fixed = visibleWidth(l) + visibleWidth(r);
@@ -61,41 +57,41 @@ function boxHeader(theme: Theme, width: number, left: string, right = ""): strin
 		const budget = Math.max(4, inner - visibleWidth(r) - 4);
 		const l2 = `${frame(theme, H)} ${fit(left, budget)}`;
 		const fill = Math.max(1, inner - visibleWidth(l2) - visibleWidth(r));
-		return `╭${l2}${frame(theme, H.repeat(fill))}${r}╮`;
+		return `${frame(theme, "╭")}${l2}${frame(theme, H.repeat(fill))}${r}${frame(theme, "╮")}`;
 	}
 	const fill = Math.max(1, inner - fixed);
-	return `╭${l}${frame(theme, H.repeat(fill))}${r}╮`;
+	return `${frame(theme, "╭")}${l}${frame(theme, H.repeat(fill))}${r}${frame(theme, "╮")}`;
 }
 
 function boxLine(theme: Theme, width: number, content: string): string {
 	const inner = Math.max(2, width - 2);
 	const contentFit = fit(content, inner - 1);
 	const pad = Math.max(0, inner - 1 - visibleWidth(contentFit));
-	return `${V} ${contentFit}${" ".repeat(pad)}${V}`;
+	return `${frame(theme, V)} ${contentFit}${" ".repeat(pad)}${frame(theme, V)}`;
 }
 
 function boxRule(theme: Theme, width: number): string {
-	return `├${border(theme, H.repeat(Math.max(1, width - 2)))}┤`;
+	return frame(theme, `├${H.repeat(Math.max(1, width - 2))}┤`);
 }
 
 /** Section separator with a label: `├─ Tasks ──────────┤` (§5.1). */
 function boxSectionRule(theme: Theme, width: number, label: string): string {
 	const inner = Math.max(4, width - 2);
-	const left = border(theme, `${H} ${label} `);
+	const left = frame(theme, `${H} ${label} `);
 	const fill = Math.max(1, inner - visibleWidth(left));
-	return `├${left}${border(theme, H.repeat(fill))}┤`;
+	return `${frame(theme, "├")}${left}${frame(theme, H.repeat(fill))}${frame(theme, "┤")}`;
 }
 
 function boxFooter(theme: Theme, width: number, content: string): string {
 	const inner = Math.max(4, width - 2);
 	if (!content) {
-		return `╰${frame(theme, H.repeat(inner))}╯`;
+		return frame(theme, `╰${H.repeat(inner)}╯`);
 	}
 	// The footer is one frame tone: leading dash, hint text and trailing fill
 	// all carry the frame color, so the blue-gray spans the whole line.
 	const l = frame(theme, `${H} ${fit(content, inner - 4)}`);
 	const fill = Math.max(1, inner - visibleWidth(l));
-	return `╰${l}${frame(theme, H.repeat(fill))}╯`;
+	return `${frame(theme, "╰")}${l}${frame(theme, H.repeat(fill))}${frame(theme, "╯")}`;
 }
 
 // ── §5.2 status symbols / colors ────────────────────────────────────────────

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -242,7 +242,7 @@ export function renderCompactDashboard(
 	model: GoalDashboardModel,
 	theme: Theme,
 	width: number,
-	opts: { footerHint?: string; scrollOffset?: number; scrollFocus?: boolean } = {},
+	opts: { footerHint?: string; scrollOffset?: number } = {},
 ): string[] {
 	const safeWidth = Math.max(10, width);
 	const mode = layoutMode(safeWidth);
@@ -279,14 +279,16 @@ export function renderCompactDashboard(
 	}
 
 	// §9.2/§9.6 compact task list: a window over the top-level tasks, anchored
-	// by default so the most recently completed tasks are visible; ↑/↓ keys
-	// (when the widget holds scroll focus) move the window. Subtasks of the
-	// current task stay inline via the subtask progress line below.
+	// by default so the most recently completed tasks are visible; when the
+	// list overflows the window, the footer advertises Ctrl+Shift+↑↓ to scroll
+	// it. Subtasks of the current task stay inline via the subtask progress
+	// line below.
 	const topLevel = model.taskTree.filter((node) => node.depth === 0);
+	const compactRows = compactTaskViewportRows(safeWidth);
+	const listOverflows = topLevel.length > compactRows;
 	if (topLevel.length > 0) {
-		const rows = compactTaskViewportRows(safeWidth);
-		const offset = opts.scrollOffset ?? anchoredScrollOffset(topLevel, rows);
-		const viewport = deriveTaskListViewport(topLevel.length, rows, offset);
+		const offset = opts.scrollOffset ?? anchoredScrollOffset(topLevel, compactRows);
+		const viewport = deriveTaskListViewport(topLevel.length, compactRows, offset);
 		lines.push(boxSectionRule(theme, safeWidth, "Tasks"));
 		for (const row of renderCompactTaskRows(theme, topLevel, viewport, inner)) {
 			lines.push(boxLine(theme, safeWidth, row));
@@ -334,7 +336,15 @@ export function renderCompactDashboard(
 		lines.push(boxLine(theme, safeWidth, `${dim(theme, `File     ${model.filePath}`)}`));
 	}
 
-	lines.push(boxFooter(theme, safeWidth, opts.footerHint ?? (opts.scrollFocus ? "↑↓/PgUp/PgDn: scroll · Esc done" : spec.footerHint)));
+	const footerHint = opts.footerHint
+		?? (listOverflows
+			? mode === "minimal"
+				? "↑↓: scroll"
+				: mode === "narrow"
+					? "Ctrl+Shift+↑↓: scroll"
+					: "Ctrl+Shift+T: expand · Ctrl+Shift+↑↓: scroll"
+			: spec.footerHint);
+	lines.push(boxFooter(theme, safeWidth, footerHint));
 	return lines;
 }
 

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -14,11 +14,15 @@
 import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import {
+	anchoredScrollOffset,
+	compactTaskViewportRows,
+	deriveTaskListViewport,
 	formatAuditElapsed,
 	formatBudget,
 	type DashboardStatusCode,
 	type DashboardTaskNode,
 	type GoalDashboardModel,
+	type TaskListViewport,
 } from "./goal-dashboard-model.ts";
 import type { GoalActivityItem } from "../goal-activity.ts";
 import { truncateText } from "../goal-core.ts";
@@ -188,18 +192,20 @@ function renderTaskRow(theme: Theme, node: DashboardTaskNode, indent: number, av
 }
 
 /**
- * Compact task-list rows (§9.2): top-level tasks shown by default with colored
- * markers and truncated titles, id column aligned, and a "+N more" overflow
- * line so the widget height stays bounded. The current task's subtasks stay
- * inline via the subtask progress line in the compact dashboard.
+ * Compact task-list rows (§9.2, §9.6): top-level tasks shown in a window over
+ * the plan-ordered list with colored markers and truncated titles, an aligned
+ * id column, and `↑ N more` / `… +N more` indicator rows so the widget height
+ * stays bounded. The window is a viewport (offset + rows) derived from the
+ * shared model — the default (anchored) offset is computed by the caller when
+ * no explicit offset is given.
  */
-function renderCompactTaskRows(theme: Theme, model: GoalDashboardModel, mode: LayoutMode, available: number): string[] {
-	const topLevel = model.taskTree.filter((node) => node.depth === 0);
-	if (topLevel.length === 0) return [];
-	const maxRows = mode === "wide" ? 5 : mode === "medium" ? 4 : mode === "narrow" ? 3 : 2;
-	const shown = topLevel.slice(0, maxRows);
-	const idWidth = Math.min(10, Math.max(...shown.map((node) => node.id.length)));
+function renderCompactTaskRows(theme: Theme, nodes: DashboardTaskNode[], viewport: TaskListViewport, available: number): string[] {
 	const rows: string[] = [];
+	if (viewport.hiddenAbove > 0) {
+		rows.push(dim(theme, `↑ ${viewport.hiddenAbove} more task${viewport.hiddenAbove === 1 ? "" : "s"}`));
+	}
+	const shown = nodes.slice(viewport.offset, viewport.offset + viewport.rows);
+	const idWidth = shown.length === 0 ? 0 : Math.min(10, Math.max(...shown.map((node) => node.id.length)));
 	for (const node of shown) {
 		const marker = taskMarker(node);
 		const contractMark = node.verificationContract ? dim(theme, " ☑") : "";
@@ -211,9 +217,8 @@ function renderCompactTaskRows(theme: Theme, model: GoalDashboardModel, mode: La
 		const body = node.isCurrent ? accent(theme, `${id}  ${title}`) : `${id}  ${title}`;
 		rows.push(`${markerText} ${body}${contractMark}`);
 	}
-	const hidden = topLevel.length - shown.length;
-	if (hidden > 0) {
-		rows.push(dim(theme, `… +${hidden} more task${hidden === 1 ? "" : "s"}`));
+	if (viewport.hiddenBelow > 0) {
+		rows.push(dim(theme, `… +${viewport.hiddenBelow} more task${viewport.hiddenBelow === 1 ? "" : "s"}`));
 	}
 	return rows;
 }
@@ -237,7 +242,7 @@ export function renderCompactDashboard(
 	model: GoalDashboardModel,
 	theme: Theme,
 	width: number,
-	opts: { footerHint?: string } = {},
+	opts: { footerHint?: string; scrollOffset?: number; scrollFocus?: boolean } = {},
 ): string[] {
 	const safeWidth = Math.max(10, width);
 	const mode = layoutMode(safeWidth);
@@ -273,14 +278,19 @@ export function renderCompactDashboard(
 		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Tasks")}  ${bar} ${model.taskProgress.completed}/${model.taskProgress.total} · ${model.taskProgress.percentage}%`));
 	}
 
-	// §9.2 compact task list: top-level tasks shown by default with colored
-	// markers, truncated titles, aligned id column, and a "+N more" overflow
-	// line (height-bounded per layout mode). Subtasks of the current task stay
-	// inline via the subtask progress line below.
-	const compactTasks = renderCompactTaskRows(theme, model, mode, inner);
-	if (compactTasks.length > 0) {
+	// §9.2/§9.6 compact task list: a window over the top-level tasks, anchored
+	// by default so the most recently completed tasks are visible; ↑/↓ keys
+	// (when the widget holds scroll focus) move the window. Subtasks of the
+	// current task stay inline via the subtask progress line below.
+	const topLevel = model.taskTree.filter((node) => node.depth === 0);
+	if (topLevel.length > 0) {
+		const rows = compactTaskViewportRows(safeWidth);
+		const offset = opts.scrollOffset ?? anchoredScrollOffset(topLevel, rows);
+		const viewport = deriveTaskListViewport(topLevel.length, rows, offset);
 		lines.push(boxSectionRule(theme, safeWidth, "Tasks"));
-		for (const row of compactTasks) lines.push(boxLine(theme, safeWidth, row));
+		for (const row of renderCompactTaskRows(theme, topLevel, viewport, inner)) {
+			lines.push(boxLine(theme, safeWidth, row));
+		}
 	}
 
 	// §9.4: all top-level tasks done and no current task → "All tasks complete".
@@ -324,18 +334,26 @@ export function renderCompactDashboard(
 		lines.push(boxLine(theme, safeWidth, `${dim(theme, `File     ${model.filePath}`)}`));
 	}
 
-	lines.push(boxFooter(theme, safeWidth, opts.footerHint ?? spec.footerHint));
+	lines.push(boxFooter(theme, safeWidth, opts.footerHint ?? (opts.scrollFocus ? "↑↓/PgUp/PgDn: scroll · Esc done" : spec.footerHint)));
 	return lines;
 }
 
 // ── EXPANDED DASHBOARD (§4.2) ───────────────────────────────────────────────
 
 /**
- * The full dashboard: goal header, status, usage, progress, complete task
- * tree, current-task details with contract/evidence, verification, and recent
- * activity. Replaces the separate task overlay.
+ * The full dashboard: goal header, status, usage, progress, a window over the
+ * task tree, current-task details with contract/evidence, verification, and
+ * recent activity. Replaces the separate task overlay. The task-tree window
+ * defaults to the whole tree; pass `rows` (and optionally `scrollOffset`) to
+ * bound the panel for interactive scrolling — the default offset anchors to
+ * the most recently completed task.
  */
-export function renderExpandedDashboard(model: GoalDashboardModel, theme: Theme, width: number): string[] {
+export function renderExpandedDashboard(
+	model: GoalDashboardModel,
+	theme: Theme,
+	width: number,
+	opts: { scrollOffset?: number; rows?: number } = {},
+): string[] {
 	const safeWidth = Math.max(10, width);
 	const mode = layoutMode(safeWidth);
 	const spec = specFor(mode);
@@ -368,12 +386,24 @@ export function renderExpandedDashboard(model: GoalDashboardModel, theme: Theme,
 		lines.push(boxLine(theme, safeWidth, `${bar} ${model.taskProgress.completed}/${model.taskProgress.total} tasks · ${model.taskProgress.percentage}%`));
 	}
 
-	// Tasks section: the complete recursive tree (§9.2).
+	// Tasks section: a window over the recursive tree (§9.2, §9.6). With no
+	// explicit rows the whole tree is shown (backward compatible); with a row
+	// budget the panel stays bounded and ↑/↓ keys move the window.
 	if (model.taskTree.length > 0) {
 		lines.push(boxSectionRule(theme, safeWidth, "Tasks"));
-		for (const node of model.taskTree) {
+		const totalRows = model.taskTree.length;
+		const rows = opts.rows ?? totalRows;
+		const offset = opts.scrollOffset ?? anchoredScrollOffset(model.taskTree, rows);
+		const viewport = deriveTaskListViewport(totalRows, rows, offset);
+		if (viewport.hiddenAbove > 0) {
+			lines.push(boxLine(theme, safeWidth, dim(theme, `↑ ${viewport.hiddenAbove} more task${viewport.hiddenAbove === 1 ? "" : "s"}`)));
+		}
+		for (const node of model.taskTree.slice(viewport.offset, viewport.offset + viewport.rows)) {
 			const indent = Math.min(node.depth, 6);
 			lines.push(boxLine(theme, safeWidth, renderTaskRow(theme, node, indent, inner)));
+		}
+		if (viewport.hiddenBelow > 0) {
+			lines.push(boxLine(theme, safeWidth, dim(theme, `… +${viewport.hiddenBelow} more task${viewport.hiddenBelow === 1 ? "" : "s"}`)));
 		}
 	}
 

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -81,7 +81,7 @@ function boxRule(theme: Theme, width: number): string {
 /** Section separator with a label: `├─ Tasks ──────────┤` (§5.1). */
 function boxSectionRule(theme: Theme, width: number, label: string): string {
 	const inner = Math.max(4, width - 2);
-	const left = `${border(theme, H)} ${label} `;
+	const left = border(theme, `${H} ${label} `);
 	const fill = Math.max(1, inner - visibleWidth(left));
 	return `├${left}${border(theme, H.repeat(fill))}┤`;
 }
@@ -91,7 +91,9 @@ function boxFooter(theme: Theme, width: number, content: string): string {
 	if (!content) {
 		return `╰${frame(theme, H.repeat(inner))}╯`;
 	}
-	const l = `${frame(theme, H)} ${muted(theme, fit(content, inner - 4))}`;
+	// The footer is one frame tone: leading dash, hint text and trailing fill
+	// all carry the frame color, so the blue-gray spans the whole line.
+	const l = frame(theme, `${H} ${fit(content, inner - 4)}`);
 	const fill = Math.max(1, inner - visibleWidth(l));
 	return `╰${l}${frame(theme, H.repeat(fill))}╯`;
 }
@@ -273,7 +275,7 @@ export function renderCompactDashboard(
 	const usageRight = mode !== "minimal" && (model.usage.activeSeconds > 0 || model.usage.tokens > 0)
 		? `${model.usage.elapsedLabel} · ${model.usage.tokenLabel}`
 		: "";
-	lines.push(boxHeader(theme, safeWidth, `${accent(theme, "pi-goal-x")} ─ ${model.title}`, muted(theme, usageRight)));
+	lines.push(boxHeader(theme, safeWidth, `${accent(theme, "pi-goal-x")} ${frame(theme, `─ ${model.title}`)}`, usageRight ? frame(theme, usageRight) : ""));
 
 	// Status line.
 	if (model.status.code === "complete") {
@@ -294,10 +296,11 @@ export function renderCompactDashboard(
 		lines.push(boxLine(theme, safeWidth, `${theme.fg(fuel as RenderColor, "⛽")} ${muted(theme, "Budget")} ${theme.fg(fuel as RenderColor, formatBudget(model.budget.used, model.budget.total))}`));
 	}
 
-	// Overall task progress (§9.1).
+	// Overall task progress (§9.1). The fraction is muted like the percent:
+	// only the bar itself stays colourful.
 	if (model.taskProgress) {
 		const bar = progressBar(theme, model.taskProgress.percentage, spec.barWidth);
-		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Tasks")}  ${bar} ${accent(theme, `${model.taskProgress.completed}/${model.taskProgress.total}`)} · ${muted(theme, `${model.taskProgress.percentage}%`)}`));
+		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Tasks")}  ${bar} ${muted(theme, `${model.taskProgress.completed}/${model.taskProgress.total} · ${model.taskProgress.percentage}%`)}`));
 	}
 
 	// §9.2/§9.6 compact task list: a window over the top-level tasks, anchored
@@ -396,7 +399,7 @@ export function renderExpandedDashboard(
 	const usageRight = mode !== "minimal" && (model.usage.activeSeconds > 0 || model.usage.tokens > 0)
 		? `${model.usage.elapsedLabel} · ${model.usage.tokenLabel}`
 		: "";
-	lines.push(boxHeader(theme, safeWidth, `${accent(theme, "pi-goal-x")} ─ ${model.title}`, muted(theme, usageRight)));
+	lines.push(boxHeader(theme, safeWidth, `${accent(theme, "pi-goal-x")} ${frame(theme, `─ ${model.title}`)}`, usageRight ? frame(theme, usageRight) : ""));
 
 	const symbol = STATUS_SYMBOL[model.status.code];
 	const color = STATUS_COLOR[model.status.code];
@@ -418,7 +421,7 @@ export function renderExpandedDashboard(
 	if (model.taskProgress) {
 		lines.push(boxSectionRule(theme, safeWidth, "Progress"));
 		const bar = progressBar(theme, model.taskProgress.percentage, Math.max(10, spec.barWidth + 8));
-		lines.push(boxLine(theme, safeWidth, `${bar} ${model.taskProgress.completed}/${model.taskProgress.total} tasks · ${model.taskProgress.percentage}%`));
+		lines.push(boxLine(theme, safeWidth, `${bar} ${muted(theme, `${model.taskProgress.completed}/${model.taskProgress.total} tasks · ${model.taskProgress.percentage}%`)}`));
 	}
 
 	// Tasks section: a window over the recursive tree (§9.2, §9.6). With no
@@ -531,7 +534,7 @@ function wrappedBlock(theme: Theme, width: number, label: string, text: string):
 export function renderUnfocusedDashboard(openGoalCount: number, theme: Theme, width: number): string[] {
 	const safeWidth = Math.max(10, width);
 	const lines: string[] = [];
-	lines.push(boxHeader(theme, safeWidth, "pi-goal-x ─ Goal focus required"));
+	lines.push(boxHeader(theme, safeWidth, frame(theme, "pi-goal-x ─ Goal focus required")));
 	const goals = openGoalCount === 1 ? "1 open goal is available." : `${openGoalCount} open goals are available.`;
 	lines.push(boxLine(theme, safeWidth, muted(theme, goals)));
 	lines.push(boxLine(theme, safeWidth, muted(theme, "Run /goal-focus to choose the goal for this session.")));
@@ -569,7 +572,7 @@ export function renderAuditorDashboard(
 	const inner = safeWidth - 2;
 	const lines: string[] = [];
 	const duration = formatAuditElapsed(model.elapsedMs);
-	lines.push(boxHeader(theme, safeWidth, `Independent completion audit ─ ${model.auditorLabel}`, duration));
+	lines.push(boxHeader(theme, safeWidth, frame(theme, `Independent completion audit ─ ${model.auditorLabel}`), frame(theme, duration)));
 
 	for (const check of model.checks) {
 		const symbol = CHECK_SYMBOL[check.state];
@@ -608,7 +611,7 @@ export function renderAuditResultCard(card: AuditResultCard, theme: Theme, width
 	const lines: string[] = [];
 	const success = card.verdict === "approved";
 	const accentColor = success ? "success" : "error";
-	lines.push(boxHeader(theme, safeWidth, `Audit result ─ ${card.label}`));
+	lines.push(boxHeader(theme, safeWidth, frame(theme, `Audit result ─ ${card.label}`)));
 	for (const line of card.lines) {
 		const symbol = success ? "✓" : "✗";
 		lines.push(boxLine(theme, safeWidth, `${theme.fg(accentColor as RenderColor, symbol)} ${fit(line, inner - 4)}`));

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -27,12 +27,17 @@ import {
 import type { GoalActivityItem } from "../goal-activity.ts";
 import { truncateText } from "../goal-core.ts";
 
-type RenderColor = Extract<ThemeColor, "accent" | "warning" | "success" | "error" | "dim" | "muted" | "text">;
+type RenderColor = Extract<ThemeColor, "accent" | "warning" | "success" | "error" | "dim" | "muted" | "text" | "mdHeading">;
 
 // ── §5.1 border system ──────────────────────────────────────────────────────
 
 const H = "─";
 const V = "│";
+
+/** Box borders: theme-appropriate gray (muted) instead of dim. */
+function border(theme: Theme, value: string): string {
+	return theme.fg("muted", value);
+}
 
 function fit(value: string, width: number): string {
 	return visibleWidth(value) > width ? truncateToWidth(value, width, "…") : value;
@@ -48,10 +53,10 @@ function boxHeader(theme: Theme, width: number, left: string, right = ""): strin
 		const budget = Math.max(4, inner - visibleWidth(r) - 4);
 		const l2 = `${H} ${fit(left, budget)}`;
 		const fill = Math.max(1, inner - visibleWidth(l2) - visibleWidth(r) - 1);
-		return `╭${l2}${theme.fg("dim", H.repeat(fill))}${r}╮`;
+		return `╭${l2}${border(theme, H.repeat(fill))}${r}╮`;
 	}
 	const fill = Math.max(1, inner - fixed);
-	return `╭${l}${theme.fg("dim", H.repeat(fill))}${r}╮`;
+	return `╭${l}${border(theme, H.repeat(fill))}${r}╮`;
 }
 
 function boxLine(theme: Theme, width: number, content: string): string {
@@ -62,7 +67,7 @@ function boxLine(theme: Theme, width: number, content: string): string {
 }
 
 function boxRule(theme: Theme, width: number): string {
-	return `├${theme.fg("dim", H.repeat(Math.max(1, width - 2)))}┤`;
+	return `├${border(theme, H.repeat(Math.max(1, width - 2)))}┤`;
 }
 
 /** Section separator with a label: `├─ Tasks ──────────┤` (§5.1). */
@@ -70,17 +75,17 @@ function boxSectionRule(theme: Theme, width: number, label: string): string {
 	const inner = Math.max(4, width - 2);
 	const left = `${H} ${label} `;
 	const fill = Math.max(1, inner - visibleWidth(left) - 1);
-	return `├${left}${theme.fg("dim", H.repeat(fill))}┤`;
+	return `├${left}${border(theme, H.repeat(fill))}┤`;
 }
 
 function boxFooter(theme: Theme, width: number, content: string): string {
 	const inner = Math.max(4, width - 2);
 	if (!content) {
-		return `╰${theme.fg("dim", H.repeat(inner))}╯`;
+		return `╰${border(theme, H.repeat(inner))}╯`;
 	}
-	const l = `${H} ${content}`;
+	const l = `${H} ${muted(theme, content)}`;
 	const fill = Math.max(1, inner - visibleWidth(l) - 1);
-	return `╰${l}${theme.fg("dim", H.repeat(fill))}╯`;
+	return `╰${l}${border(theme, H.repeat(fill))}╯`;
 }
 
 // ── §5.2 status symbols / colors ────────────────────────────────────────────
@@ -98,8 +103,8 @@ const STATUS_COLOR: Record<DashboardStatusCode, RenderColor> = {
 	running: "accent",
 	idle: "muted",
 	paused: "muted",
-	blocked: "warning",
-	budget_limited: "warning",
+	blocked: "error",
+	budget_limited: "mdHeading",
 	complete: "success",
 };
 
@@ -163,17 +168,21 @@ function success(theme: Theme, value: string): string {
 	return theme.fg("success", value);
 }
 
-function warning(theme: Theme, value: string): string {
-	return theme.fg("warning", value);
+/** Pastel accent helpers (§5): amber for tasks, teal for current/progress,
+ * muted gray for chrome, soft red for blockers, muted green for complete. */
+function amber(theme: Theme, value: string): string {
+	return theme.fg("mdHeading", value);
 }
 
 // ── task tree rows (§9.2) ───────────────────────────────────────────────────
 
+/** Task rows: pending amber ·, complete muted-green ✓, skipped gray ~, and
+ * the current task teal ▸ with accent text; row text is pastel amber. */
 function taskMarker(node: DashboardTaskNode): { symbol: string; color: RenderColor } {
 	if (node.isCurrent) return { symbol: "▸", color: "accent" };
 	if (node.status === "complete") return { symbol: "✓", color: "success" };
-	if (node.status === "skipped") return { symbol: "~", color: "warning" };
-	return { symbol: "·", color: "muted" };
+	if (node.status === "skipped") return { symbol: "~", color: "muted" };
+	return { symbol: "·", color: "mdHeading" };
 }
 
 function renderTaskRow(theme: Theme, node: DashboardTaskNode, indent: number, available: number): string {
@@ -186,7 +195,7 @@ function renderTaskRow(theme: Theme, node: DashboardTaskNode, indent: number, av
 	const markerText = theme.fg(marker.color, marker.symbol);
 	const colored = node.isCurrent
 		? `${markerText} ${accent(theme, `${node.id}  ${title}`)}`
-		: `${markerText} ${node.id}  ${title}`;
+		: `${markerText} ${amber(theme, `${node.id}  ${title}`)}`;
 	const line = `${indentText}${colored}${contractMark}`;
 	return line;
 }
@@ -214,7 +223,7 @@ function renderCompactTaskRows(theme: Theme, nodes: DashboardTaskNode[], viewpor
 		const titleBudget = Math.max(4, available - visibleWidth(prefix) - visibleWidth(contractMark));
 		const title = fit(node.title, titleBudget);
 		const markerText = theme.fg(marker.color, marker.symbol);
-		const body = node.isCurrent ? accent(theme, `${id}  ${title}`) : `${id}  ${title}`;
+		const body = node.isCurrent ? accent(theme, `${id}  ${title}`) : amber(theme, `${id}  ${title}`);
 		rows.push(`${markerText} ${body}${contractMark}`);
 	}
 	if (viewport.hiddenBelow > 0) {
@@ -228,7 +237,7 @@ function renderCompactTaskRows(theme: Theme, nodes: DashboardTaskNode[], viewpor
 function activityMarker(item: GoalActivityItem): { symbol: string; color: RenderColor } {
 	if (item.marker === "done") return { symbol: "✓", color: "success" };
 	if (item.marker === "current") return { symbol: "▸", color: "accent" };
-	if (item.marker === "skipped") return { symbol: "~", color: "warning" };
+	if (item.marker === "skipped") return { symbol: "~", color: "mdHeading" };
 	return { symbol: "·", color: "muted" };
 }
 
@@ -253,7 +262,7 @@ export function renderCompactDashboard(
 	const usageRight = mode !== "minimal" && (model.usage.activeSeconds > 0 || model.usage.tokens > 0)
 		? `${model.usage.elapsedLabel} · ${model.usage.tokenLabel}`
 		: "";
-	lines.push(boxHeader(theme, safeWidth, `pi-goal-x ─ ${model.title}`, usageRight));
+	lines.push(boxHeader(theme, safeWidth, `pi-goal-x ─ ${model.title}`, muted(theme, usageRight)));
 
 	// Status line.
 	if (model.status.code === "complete") {
@@ -262,14 +271,14 @@ export function renderCompactDashboard(
 		const symbol = STATUS_SYMBOL[model.status.code];
 		const color = STATUS_COLOR[model.status.code];
 		const bits = [`${theme.fg(color, symbol)} ${theme.fg(color, model.status.label)}`];
-		if (spec.showFocused) bits.push(`Focused: ${model.focused ? "yes" : "no"}`);
-		if (spec.showOtherGoals && model.otherOpenGoals > 0) bits.push(`Other goals: ${model.otherOpenGoals}`);
+		if (spec.showFocused) bits.push(muted(theme, `Focused: ${model.focused ? "yes" : "no"}`));
+		if (spec.showOtherGoals && model.otherOpenGoals > 0) bits.push(muted(theme, `Other goals: ${model.otherOpenGoals}`));
 		lines.push(boxLine(theme, safeWidth, bits.join(" · ")));
 	}
 
 	// Budget (when configured).
 	if (model.budget) {
-		lines.push(boxLine(theme, safeWidth, `${theme.fg("warning", "⛽")} ${muted(theme, `Budget ${formatBudget(model.budget.used, model.budget.total)}`)}`));
+		lines.push(boxLine(theme, safeWidth, `${theme.fg("mdHeading", "⛽")} ${muted(theme, `Budget ${formatBudget(model.budget.used, model.budget.total)}`)}`));
 	}
 
 	// Overall task progress (§9.1).
@@ -322,7 +331,7 @@ export function renderCompactDashboard(
 
 	// Blocked details (§4.5).
 	if (model.status.code === "blocked") {
-		if (model.status.reason) lines.push(boxLine(theme, safeWidth, `${warning(theme, "Blocker")}  ${fit(model.status.reason, inner - 10)}`));
+		if (model.status.reason) lines.push(boxLine(theme, safeWidth, `${theme.fg("error", "Blocker")}  ${fit(model.status.reason, inner - 10)}`));
 		if (spec.showPauseAction && model.status.suggestedAction) lines.push(boxLine(theme, safeWidth, `${muted(theme, "Action")}   ${fit(model.status.suggestedAction, inner - 9)}`));
 	}
 
@@ -373,20 +382,22 @@ export function renderExpandedDashboard(
 	const usageRight = mode !== "minimal" && (model.usage.activeSeconds > 0 || model.usage.tokens > 0)
 		? `${model.usage.elapsedLabel} · ${model.usage.tokenLabel}`
 		: "";
-	lines.push(boxHeader(theme, safeWidth, `pi-goal-x ─ ${model.title}`, usageRight));
+	lines.push(boxHeader(theme, safeWidth, `pi-goal-x ─ ${model.title}`, muted(theme, usageRight)));
 
 	const symbol = STATUS_SYMBOL[model.status.code];
 	const color = STATUS_COLOR[model.status.code];
-	const statusBits = [`Status: ${theme.fg(color, symbol)} ${theme.fg(color, model.status.label)}`];
-	if (spec.showFocused) statusBits.push(`Focused: ${model.focused ? "yes" : "no"}`);
-	if (spec.showOtherGoals && model.otherOpenGoals > 0) statusBits.push(`Other goals: ${model.otherOpenGoals}`);
+	const statusBits = [
+		`Status: ${theme.fg(color, symbol)} ${theme.fg(color, model.status.label)}`,
+		...((spec.showFocused ? [muted(theme, `Focused: ${model.focused ? "yes" : "no"}`)] : []) as string[]),
+		...((spec.showOtherGoals && model.otherOpenGoals > 0 ? [muted(theme, `Other goals: ${model.otherOpenGoals}`)] : []) as string[]),
+	];
 	lines.push(boxLine(theme, safeWidth, statusBits.join(" · ")));
 
 	if (spec.showPath && model.filePath) {
 		lines.push(boxLine(theme, safeWidth, dim(theme, `File: ${model.filePath}`)));
 	}
 	if (model.budget) {
-		lines.push(boxLine(theme, safeWidth, `${theme.fg("warning", "⛽")} ${muted(theme, `Budget ${formatBudget(model.budget.used, model.budget.total)}`)}`));
+		lines.push(boxLine(theme, safeWidth, `${theme.fg("mdHeading", "⛽")} ${muted(theme, `Budget ${formatBudget(model.budget.used, model.budget.total)}`)}`));
 	}
 
 	// Progress section (§4.2).
@@ -526,7 +537,7 @@ export function clampLinesToWidth(lines: string[], width: number): string[] {
 import type { AuditorDashboardModel, AuditResultCard } from "./auditor-dashboard-model.ts";
 
 const CHECK_SYMBOL = { passed: "✓", running: "◌", pending: "·", failed: "✗" } as const;
-const CHECK_COLOR = { passed: "success", running: "accent", pending: "muted", failed: "warning" } as const;
+const CHECK_COLOR = { passed: "success", running: "accent", pending: "muted", failed: "error" } as const;
 
 /**
  * Structured audit dashboard (§15.3): five check stages, a progress bar, and
@@ -582,7 +593,7 @@ export function renderAuditResultCard(card: AuditResultCard, theme: Theme, width
 	const inner = safeWidth - 2;
 	const lines: string[] = [];
 	const success = card.verdict === "approved";
-	const accentColor = success ? "success" : "warning";
+	const accentColor = success ? "success" : "error";
 	lines.push(boxHeader(theme, safeWidth, `Audit result ─ ${card.label}`));
 	for (const line of card.lines) {
 		const symbol = success ? "✓" : "✗";

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -1,0 +1,553 @@
+/**
+ * Unified dashboard renderer (plan §5, §4).
+ *
+ * Renders the shared dashboard view model (goal-dashboard-model.ts) as the
+ * compact above-editor widget, the expanded full dashboard (which replaces the
+ * task overlay), and the unfocused panel. Pure presentation: all data comes
+ * from the model; this file owns the §5 visual spec (borders, status symbols,
+ * progress bars, responsive layouts, width-safe ANSI/Unicode handling) and
+ * must never emit a line wider than the requested terminal width.
+ *
+ * Layout modes (§5.5): wide ≥100, medium 70–99, narrow 50–69, minimal <50.
+ */
+
+import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import {
+	formatAuditElapsed,
+	formatBudget,
+	type DashboardStatusCode,
+	type DashboardTaskNode,
+	type GoalDashboardModel,
+} from "./goal-dashboard-model.ts";
+import type { GoalActivityItem } from "../goal-activity.ts";
+import { truncateText } from "../goal-core.ts";
+
+type RenderColor = Extract<ThemeColor, "accent" | "warning" | "success" | "error" | "dim" | "muted" | "text">;
+
+// ── §5.1 border system ──────────────────────────────────────────────────────
+
+const H = "─";
+const V = "│";
+
+function fit(value: string, width: number): string {
+	return visibleWidth(value) > width ? truncateToWidth(value, width, "…") : value;
+}
+
+function boxHeader(theme: Theme, width: number, left: string, right = ""): string {
+	const inner = Math.max(4, width - 2);
+	const l = `${H} ${left}`;
+	const r = right ? ` ${right} ${H}` : "";
+	const fixed = visibleWidth(l) + visibleWidth(r);
+	if (fixed > inner - 2) {
+		// Too tight: truncate the title so the right-side meta survives.
+		const budget = Math.max(4, inner - visibleWidth(r) - 4);
+		const l2 = `${H} ${fit(left, budget)}`;
+		const fill = Math.max(1, inner - visibleWidth(l2) - visibleWidth(r) - 1);
+		return `╭${l2}${theme.fg("dim", H.repeat(fill))}${r}╮`;
+	}
+	const fill = Math.max(1, inner - fixed);
+	return `╭${l}${theme.fg("dim", H.repeat(fill))}${r}╮`;
+}
+
+function boxLine(theme: Theme, width: number, content: string): string {
+	const inner = Math.max(2, width - 2);
+	const contentFit = fit(content, inner - 1);
+	const pad = Math.max(0, inner - 1 - visibleWidth(contentFit));
+	return `${V} ${contentFit}${" ".repeat(pad)}${V}`;
+}
+
+function boxRule(theme: Theme, width: number): string {
+	return `├${theme.fg("dim", H.repeat(Math.max(1, width - 2)))}┤`;
+}
+
+/** Section separator with a label: `├─ Tasks ──────────┤` (§5.1). */
+function boxSectionRule(theme: Theme, width: number, label: string): string {
+	const inner = Math.max(4, width - 2);
+	const left = `${H} ${label} `;
+	const fill = Math.max(1, inner - visibleWidth(left) - 1);
+	return `├${left}${theme.fg("dim", H.repeat(fill))}┤`;
+}
+
+function boxFooter(theme: Theme, width: number, content: string): string {
+	const inner = Math.max(4, width - 2);
+	if (!content) {
+		return `╰${theme.fg("dim", H.repeat(inner))}╯`;
+	}
+	const l = `${H} ${content}`;
+	const fill = Math.max(1, inner - visibleWidth(l) - 1);
+	return `╰${l}${theme.fg("dim", H.repeat(fill))}╯`;
+}
+
+// ── §5.2 status symbols / colors ────────────────────────────────────────────
+
+const STATUS_SYMBOL: Record<DashboardStatusCode, string> = {
+	running: "●",
+	idle: "○",
+	paused: "◐",
+	blocked: "⊘",
+	budget_limited: "⛽",
+	complete: "✓",
+};
+
+const STATUS_COLOR: Record<DashboardStatusCode, RenderColor> = {
+	running: "accent",
+	idle: "muted",
+	paused: "muted",
+	blocked: "warning",
+	budget_limited: "warning",
+	complete: "success",
+};
+
+// ── §5.3 progress bars ──────────────────────────────────────────────────────
+
+function progressBar(theme: Theme, pct: number, barWidth: number): string {
+	const safeBar = Math.max(2, barWidth);
+	const filled = Math.min(safeBar, Math.max(0, Math.round((pct / 100) * safeBar)));
+	return `[${theme.fg("accent", "█".repeat(filled))}${theme.fg("dim", "░".repeat(safeBar - filled))}]`;
+}
+
+// ── Layout modes (§5.5) ─────────────────────────────────────────────────────
+
+type LayoutMode = "wide" | "medium" | "narrow" | "minimal";
+
+function layoutMode(width: number): LayoutMode {
+	if (width >= 100) return "wide";
+	if (width >= 70) return "medium";
+	if (width >= 50) return "narrow";
+	return "minimal";
+}
+
+interface LayoutSpec {
+	barWidth: number;
+	showFocused: boolean;
+	showOtherGoals: boolean;
+	showPath: boolean;
+	showPauseAction: boolean;
+	footerHint: string;
+	statusLine: "full" | "brief";
+}
+
+function specFor(mode: LayoutMode): LayoutSpec {
+	switch (mode) {
+		case "wide":
+			return { barWidth: 26, showFocused: true, showOtherGoals: true, showPath: true, showPauseAction: true, footerHint: "Ctrl+Shift+T: expand tasks", statusLine: "full" };
+		case "medium":
+			return { barWidth: 18, showFocused: true, showOtherGoals: true, showPath: true, showPauseAction: true, footerHint: "Ctrl+Shift+T: expand tasks", statusLine: "full" };
+		case "narrow":
+			return { barWidth: 12, showFocused: true, showOtherGoals: true, showPath: false, showPauseAction: false, footerHint: "Ctrl+Shift+T: expand", statusLine: "brief" };
+		case "minimal":
+			return { barWidth: 8, showFocused: false, showOtherGoals: false, showPath: false, showPauseAction: false, footerHint: "Ctrl+Shift+T: expand", statusLine: "brief" };
+	}
+}
+
+// ── shared row helpers ──────────────────────────────────────────────────────
+
+function muted(theme: Theme, value: string): string {
+	return theme.fg("muted", value);
+}
+
+function dim(theme: Theme, value: string): string {
+	return theme.fg("dim", value);
+}
+
+function accent(theme: Theme, value: string): string {
+	return theme.fg("accent", value);
+}
+
+function success(theme: Theme, value: string): string {
+	return theme.fg("success", value);
+}
+
+function warning(theme: Theme, value: string): string {
+	return theme.fg("warning", value);
+}
+
+// ── task tree rows (§9.2) ───────────────────────────────────────────────────
+
+function taskMarker(node: DashboardTaskNode): { symbol: string; color: RenderColor } {
+	if (node.isCurrent) return { symbol: "▸", color: "accent" };
+	if (node.status === "complete") return { symbol: "✓", color: "success" };
+	if (node.status === "skipped") return { symbol: "~", color: "warning" };
+	return { symbol: "·", color: "muted" };
+}
+
+function renderTaskRow(theme: Theme, node: DashboardTaskNode, indent: number, available: number): string {
+	const marker = taskMarker(node);
+	const indentText = "  ".repeat(indent);
+	const prefix = `${indentText}${marker.symbol} ${node.id}  `;
+	const contractMark = node.verificationContract ? dim(theme, " ☑") : "";
+	const titleBudget = Math.max(4, available - visibleWidth(prefix) - visibleWidth(contractMark));
+	const title = fit(node.title, titleBudget);
+	const markerText = theme.fg(marker.color, marker.symbol);
+	const colored = node.isCurrent
+		? `${markerText} ${accent(theme, `${node.id}  ${title}`)}`
+		: `${markerText} ${node.id}  ${title}`;
+	const line = `${indentText}${colored}${contractMark}`;
+	return line;
+}
+
+/**
+ * Compact task-list rows (§9.2): top-level tasks shown by default with colored
+ * markers and truncated titles, id column aligned, and a "+N more" overflow
+ * line so the widget height stays bounded. The current task's subtasks stay
+ * inline via the subtask progress line in the compact dashboard.
+ */
+function renderCompactTaskRows(theme: Theme, model: GoalDashboardModel, mode: LayoutMode, available: number): string[] {
+	const topLevel = model.taskTree.filter((node) => node.depth === 0);
+	if (topLevel.length === 0) return [];
+	const maxRows = mode === "wide" ? 5 : mode === "medium" ? 4 : mode === "narrow" ? 3 : 2;
+	const shown = topLevel.slice(0, maxRows);
+	const idWidth = Math.min(10, Math.max(...shown.map((node) => node.id.length)));
+	const rows: string[] = [];
+	for (const node of shown) {
+		const marker = taskMarker(node);
+		const contractMark = node.verificationContract ? dim(theme, " ☑") : "";
+		const id = node.id.padEnd(idWidth);
+		const prefix = `${marker.symbol} ${id}  `;
+		const titleBudget = Math.max(4, available - visibleWidth(prefix) - visibleWidth(contractMark));
+		const title = fit(node.title, titleBudget);
+		const markerText = theme.fg(marker.color, marker.symbol);
+		const body = node.isCurrent ? accent(theme, `${id}  ${title}`) : `${id}  ${title}`;
+		rows.push(`${markerText} ${body}${contractMark}`);
+	}
+	const hidden = topLevel.length - shown.length;
+	if (hidden > 0) {
+		rows.push(dim(theme, `… +${hidden} more task${hidden === 1 ? "" : "s"}`));
+	}
+	return rows;
+}
+
+// ── activity rows ───────────────────────────────────────────────────────────
+
+function activityMarker(item: GoalActivityItem): { symbol: string; color: RenderColor } {
+	if (item.marker === "done") return { symbol: "✓", color: "success" };
+	if (item.marker === "current") return { symbol: "▸", color: "accent" };
+	if (item.marker === "skipped") return { symbol: "~", color: "warning" };
+	return { symbol: "·", color: "muted" };
+}
+
+// ── COMPACT DASHBOARD (§4.1) ────────────────────────────────────────────────
+
+/**
+ * Persistent summary above the editor while a goal is focused. Visually rich
+ * but compact; the footer hints at the expansion shortcut.
+ */
+export function renderCompactDashboard(
+	model: GoalDashboardModel,
+	theme: Theme,
+	width: number,
+	opts: { footerHint?: string } = {},
+): string[] {
+	const safeWidth = Math.max(10, width);
+	const mode = layoutMode(safeWidth);
+	const spec = specFor(mode);
+	const inner = safeWidth - 2;
+	const lines: string[] = [];
+
+	const usageRight = mode !== "minimal" && (model.usage.activeSeconds > 0 || model.usage.tokens > 0)
+		? `${model.usage.elapsedLabel} · ${model.usage.tokenLabel}`
+		: "";
+	lines.push(boxHeader(theme, safeWidth, `pi-goal-x ─ ${model.title}`, usageRight));
+
+	// Status line.
+	if (model.status.code === "complete") {
+		lines.push(boxLine(theme, safeWidth, `${success(theme, "✓")} ${success(theme, "All required work is complete.")}`));
+	} else {
+		const symbol = STATUS_SYMBOL[model.status.code];
+		const color = STATUS_COLOR[model.status.code];
+		const bits = [`${theme.fg(color, symbol)} ${theme.fg(color, model.status.label)}`];
+		if (spec.showFocused) bits.push(`Focused: ${model.focused ? "yes" : "no"}`);
+		if (spec.showOtherGoals && model.otherOpenGoals > 0) bits.push(`Other goals: ${model.otherOpenGoals}`);
+		lines.push(boxLine(theme, safeWidth, bits.join(" · ")));
+	}
+
+	// Budget (when configured).
+	if (model.budget) {
+		lines.push(boxLine(theme, safeWidth, `${theme.fg("warning", "⛽")} ${muted(theme, `Budget ${formatBudget(model.budget.used, model.budget.total)}`)}`));
+	}
+
+	// Overall task progress (§9.1).
+	if (model.taskProgress) {
+		const bar = progressBar(theme, model.taskProgress.percentage, spec.barWidth);
+		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Tasks")}  ${bar} ${model.taskProgress.completed}/${model.taskProgress.total} · ${model.taskProgress.percentage}%`));
+	}
+
+	// §9.2 compact task list: top-level tasks shown by default with colored
+	// markers, truncated titles, aligned id column, and a "+N more" overflow
+	// line (height-bounded per layout mode). Subtasks of the current task stay
+	// inline via the subtask progress line below.
+	const compactTasks = renderCompactTaskRows(theme, model, mode, inner);
+	if (compactTasks.length > 0) {
+		lines.push(boxSectionRule(theme, safeWidth, "Tasks"));
+		for (const row of compactTasks) lines.push(boxLine(theme, safeWidth, row));
+	}
+
+	// §9.4: all top-level tasks done and no current task → "All tasks complete".
+	if (!model.currentTask && model.taskProgress && model.taskProgress.completed === model.taskProgress.total && model.status.code !== "complete") {
+		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Current")}  ${accent(theme, "All tasks complete")}`));
+	}
+
+	// Current task (persisted focus or inferred first pending).
+	if (model.currentTask) {
+		if (mode === "minimal") {
+			lines.push(boxLine(theme, safeWidth, `${accent(theme, "▸")} ${fit(model.currentTask.title, inner - 3)}`));
+		} else {
+			lines.push(boxLine(theme, safeWidth, `${muted(theme, "Current")}  ${accent(theme, model.currentTask.id)} · ${fit(model.currentTask.title, inner - visibleWidth(`Current  ${model.currentTask.id} · `))}`));
+		}
+	}
+
+	// Current-task subtask progress (§9.3).
+	if (model.currentTask && model.currentTask.totalSubtasks > 0 && mode !== "minimal") {
+		const bar = progressBar(theme, model.currentTask.subtaskPercentage, spec.barWidth);
+		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Subtasks")} ${bar} ${model.currentTask.completedSubtasks}/${model.currentTask.totalSubtasks} · ${model.currentTask.subtaskPercentage}%`));
+	}
+
+	// Goal-level verification (§11.1): truncated first line in compact.
+	if (model.goalVerificationContract && mode !== "minimal") {
+		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Verify")}   ${fit(model.goalVerificationContract.replace(/\s+/g, " "), inner - 9)}`));
+	}
+
+	// Blocked details (§4.5).
+	if (model.status.code === "blocked") {
+		if (model.status.reason) lines.push(boxLine(theme, safeWidth, `${warning(theme, "Blocker")}  ${fit(model.status.reason, inner - 10)}`));
+		if (spec.showPauseAction && model.status.suggestedAction) lines.push(boxLine(theme, safeWidth, `${muted(theme, "Action")}   ${fit(model.status.suggestedAction, inner - 9)}`));
+	}
+
+	// Paused details (§4.4).
+	if (model.status.code === "paused" && model.status.reason) {
+		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Reason")}   ${fit(model.status.reason, inner - 9)}`));
+	}
+
+	// File path (§4.1 example shows the active file).
+	if (spec.showPath && model.filePath) {
+		lines.push(boxLine(theme, safeWidth, `${dim(theme, `File     ${model.filePath}`)}`));
+	}
+
+	lines.push(boxFooter(theme, safeWidth, opts.footerHint ?? spec.footerHint));
+	return lines;
+}
+
+// ── EXPANDED DASHBOARD (§4.2) ───────────────────────────────────────────────
+
+/**
+ * The full dashboard: goal header, status, usage, progress, complete task
+ * tree, current-task details with contract/evidence, verification, and recent
+ * activity. Replaces the separate task overlay.
+ */
+export function renderExpandedDashboard(model: GoalDashboardModel, theme: Theme, width: number): string[] {
+	const safeWidth = Math.max(10, width);
+	const mode = layoutMode(safeWidth);
+	const spec = specFor(mode);
+	const inner = safeWidth - 2;
+	const lines: string[] = [];
+
+	const usageRight = mode !== "minimal" && (model.usage.activeSeconds > 0 || model.usage.tokens > 0)
+		? `${model.usage.elapsedLabel} · ${model.usage.tokenLabel}`
+		: "";
+	lines.push(boxHeader(theme, safeWidth, `pi-goal-x ─ ${model.title}`, usageRight));
+
+	const symbol = STATUS_SYMBOL[model.status.code];
+	const color = STATUS_COLOR[model.status.code];
+	const statusBits = [`Status: ${theme.fg(color, symbol)} ${theme.fg(color, model.status.label)}`];
+	if (spec.showFocused) statusBits.push(`Focused: ${model.focused ? "yes" : "no"}`);
+	if (spec.showOtherGoals && model.otherOpenGoals > 0) statusBits.push(`Other goals: ${model.otherOpenGoals}`);
+	lines.push(boxLine(theme, safeWidth, statusBits.join(" · ")));
+
+	if (spec.showPath && model.filePath) {
+		lines.push(boxLine(theme, safeWidth, dim(theme, `File: ${model.filePath}`)));
+	}
+	if (model.budget) {
+		lines.push(boxLine(theme, safeWidth, `${theme.fg("warning", "⛽")} ${muted(theme, `Budget ${formatBudget(model.budget.used, model.budget.total)}`)}`));
+	}
+
+	// Progress section (§4.2).
+	if (model.taskProgress) {
+		lines.push(boxSectionRule(theme, safeWidth, "Progress"));
+		const bar = progressBar(theme, model.taskProgress.percentage, Math.max(10, spec.barWidth + 8));
+		lines.push(boxLine(theme, safeWidth, `${bar} ${model.taskProgress.completed}/${model.taskProgress.total} tasks · ${model.taskProgress.percentage}%`));
+	}
+
+	// Tasks section: the complete recursive tree (§9.2).
+	if (model.taskTree.length > 0) {
+		lines.push(boxSectionRule(theme, safeWidth, "Tasks"));
+		for (const node of model.taskTree) {
+			const indent = Math.min(node.depth, 6);
+			lines.push(boxLine(theme, safeWidth, renderTaskRow(theme, node, indent, inner)));
+		}
+	}
+
+	// Current-task section (§4.2).
+	if (model.currentTask) {
+		lines.push(...renderCurrentTaskBlock(model, theme, safeWidth, spec.barWidth));
+	}
+
+	// Goal-level verification section (§11.1).
+	if (model.goalVerificationContract) {
+		lines.push(boxSectionRule(theme, safeWidth, "Verification"));
+		lines.push(...wrappedBlock(theme, safeWidth, "", model.goalVerificationContract));
+	}
+
+	// Recent activity section (§12).
+	if (model.recentActivity.length > 0) {
+		lines.push(...renderActivityBlock(model.recentActivity, theme, safeWidth));
+	}
+
+	lines.push(boxFooter(theme, safeWidth, "Esc/Ctrl+Shift+T: collapse"));
+	return lines;
+}
+
+/**
+ * The current-task detail block (§4.2): title, subtask progress, contract,
+ * evidence, and the inferred-focus note. Shared by the expanded dashboard and
+ * the standard /goal-status output (§13.3).
+ */
+export function renderCurrentTaskBlock(
+	model: GoalDashboardModel,
+	theme: Theme,
+	width: number,
+	barWidth = 16,
+): string[] {
+	const safeWidth = Math.max(10, width);
+	const inner = safeWidth - 2;
+	const lines: string[] = [];
+	lines.push(boxSectionRule(theme, safeWidth, "Current task"));
+	lines.push(boxLine(theme, safeWidth, `${accent(theme, model.currentTask!.id)} · ${fit(model.currentTask!.title, inner - visibleWidth(`${model.currentTask!.id} · `))}`));
+	if (model.currentTask!.totalSubtasks > 0) {
+		const bar = progressBar(theme, model.currentTask!.subtaskPercentage, Math.max(8, barWidth));
+		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Subtasks")} ${bar} ${model.currentTask!.completedSubtasks}/${model.currentTask!.totalSubtasks} · ${model.currentTask!.subtaskPercentage}%`));
+	}
+	if (model.currentTask!.verificationContract) {
+		lines.push(...wrappedBlock(theme, safeWidth, "Contract", model.currentTask!.verificationContract));
+	}
+	if (model.currentTask!.evidence) {
+		lines.push(...wrappedBlock(theme, safeWidth, "Evidence", model.currentTask!.evidence));
+	}
+	if (model.currentTask!.inferred) {
+		lines.push(boxLine(theme, safeWidth, dim(theme, "Inferred from the first pending task — no persisted current task.")));
+	}
+	return lines;
+}
+
+/** The recent-activity block (§12), shared by the expanded dashboard and /goal-status. */
+export function renderActivityBlock(items: GoalActivityItem[], theme: Theme, width: number): string[] {
+	const safeWidth = Math.max(10, width);
+	const inner = safeWidth - 2;
+	const lines: string[] = [];
+	lines.push(boxSectionRule(theme, safeWidth, "Recent activity"));
+	for (const item of items) {
+		const marker = activityMarker(item);
+		const text = fit(item.text, inner - 4);
+		lines.push(boxLine(theme, safeWidth, `${theme.fg(marker.color, marker.symbol)} ${text}`));
+	}
+	return lines;
+}
+
+/** Wrap long contract/evidence text safely at the inner width (§11.1). */
+function wrappedBlock(theme: Theme, width: number, label: string, text: string): string[] {
+	const inner = Math.max(4, width - 2);
+	const prefix = label ? `${label}: ` : "";
+	const indent = " ".repeat(visibleWidth(prefix));
+	const wrapped = wrapTextWithAnsi(text.replace(/\s+/g, " ").trim(), Math.max(8, inner - visibleWidth(prefix)));
+	const lines: string[] = [];
+	for (const [index, segment] of wrapped.entries()) {
+		const content = index === 0 ? `${prefix}${segment}` : `${indent}${segment}`;
+		lines.push(boxLine(theme, width, muted(theme, content)));
+	}
+	return lines;
+}
+
+// ── UNFOCUSED PANEL (§4.3) ──────────────────────────────────────────────────
+
+/**
+ * Shown when open goals exist but none is focused. The widget's default
+ * no-goal branch renders nothing (surfaces without goals).
+ */
+export function renderUnfocusedDashboard(openGoalCount: number, theme: Theme, width: number): string[] {
+	const safeWidth = Math.max(10, width);
+	const lines: string[] = [];
+	lines.push(boxHeader(theme, safeWidth, "pi-goal-x ─ Goal focus required"));
+	const goals = openGoalCount === 1 ? "1 open goal is available." : `${openGoalCount} open goals are available.`;
+	lines.push(boxLine(theme, safeWidth, muted(theme, goals)));
+	lines.push(boxLine(theme, safeWidth, muted(theme, "Run /goal-focus to choose the goal for this session.")));
+	lines.push(boxFooter(theme, safeWidth, ""));
+	return lines;
+}
+
+// ── width safety net (defense in depth) ─────────────────────────────────────
+
+/** Clamp every rendered line to the terminal width (used by the component). */
+export function clampLinesToWidth(lines: string[], width: number): string[] {
+	return lines.map((line) => (visibleWidth(line) > width ? truncateToWidth(line, width, "…") : line));
+}
+
+// ── AUDIT DASHBOARD (§15) ───────────────────────────────────────────────────
+
+import type { AuditorDashboardModel, AuditResultCard } from "./auditor-dashboard-model.ts";
+
+const CHECK_SYMBOL = { passed: "✓", running: "◌", pending: "·", failed: "✗" } as const;
+const CHECK_COLOR = { passed: "success", running: "accent", pending: "muted", failed: "warning" } as const;
+
+/**
+ * Structured audit dashboard (§15.3): five check stages, a progress bar, and
+ * the elapsed duration, using the same visual system as the goal dashboard.
+ * Raw tools and recent output appear only when showToolDetails is set
+ * (expanded/debug audit mode) or when the audit finished with a failure.
+ */
+export function renderAuditorDashboard(
+	model: AuditorDashboardModel,
+	theme: Theme,
+	width: number,
+	opts: { showToolDetails?: boolean } = {},
+): string[] {
+	const safeWidth = Math.max(10, width);
+	const inner = safeWidth - 2;
+	const lines: string[] = [];
+	const duration = formatAuditElapsed(model.elapsedMs);
+	lines.push(boxHeader(theme, safeWidth, `Independent completion audit ─ ${model.auditorLabel}`, duration));
+
+	for (const check of model.checks) {
+		const symbol = CHECK_SYMBOL[check.state];
+		const color = CHECK_COLOR[check.state];
+		lines.push(boxLine(theme, safeWidth, `${theme.fg(color as RenderColor, symbol)} ${check.label}`));
+	}
+
+	if (model.percentage !== undefined) {
+		const barWidth = Math.max(8, Math.min(inner - 12, 30));
+		const bar = progressBar(theme, model.percentage, barWidth);
+		lines.push(boxLine(theme, safeWidth, `${bar} ${theme.fg("muted", `${model.percentage}%`)}`));
+	}
+
+	const showDiagnostics = opts.showToolDetails === true || model.verdict === "disapproved" || model.verdict === "error";
+	if (showDiagnostics) {
+		if (model.currentTool) {
+			const args = model.currentToolArgs ? ` ${dim(theme, truncateText(model.currentToolArgs, Math.max(10, inner - 20)))}` : "";
+			lines.push(boxLine(theme, safeWidth, `${accent(theme, "tool")} ${model.currentTool}${args}`));
+		}
+		if (model.recentOutput.length > 0) {
+			lines.push(boxLine(theme, safeWidth, dim(theme, "─".repeat(Math.max(4, inner - 8)))));
+			for (const output of model.recentOutput.slice(0, 3)) {
+				lines.push(boxLine(theme, safeWidth, dim(theme, truncateText(output, Math.max(8, inner - 4)))));
+			}
+		}
+	}
+
+	lines.push(boxFooter(theme, safeWidth, model.active ? "Esc: stop audit" : ""));
+	return lines;
+}
+
+/** Audit result card (§15.4): APPROVED or CHANGES REQUIRED / ERROR. */
+export function renderAuditResultCard(card: AuditResultCard, theme: Theme, width: number): string[] {
+	const safeWidth = Math.max(10, width);
+	const inner = safeWidth - 2;
+	const lines: string[] = [];
+	const success = card.verdict === "approved";
+	const accentColor = success ? "success" : "warning";
+	lines.push(boxHeader(theme, safeWidth, `Audit result ─ ${card.label}`));
+	for (const line of card.lines) {
+		const symbol = success ? "✓" : "✗";
+		lines.push(boxLine(theme, safeWidth, `${theme.fg(accentColor as RenderColor, symbol)} ${fit(line, inner - 4)}`));
+	}
+	lines.push(boxFooter(theme, safeWidth, ""));
+	return lines;
+}

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -51,14 +51,16 @@ function fit(value: string, width: number): string {
 
 function boxHeader(theme: Theme, width: number, left: string, right = ""): string {
 	const inner = Math.max(4, width - 2);
-	const l = `${H} ${left}`;
-	const r = right ? ` ${right} ${H}` : "";
+	// The leading/trailing dashes belong to the frame, so they carry the same
+	// color as the fill; only the corners stay plain.
+	const l = `${frame(theme, H)} ${left}`;
+	const r = right ? ` ${right} ${frame(theme, H)}` : "";
 	const fixed = visibleWidth(l) + visibleWidth(r);
 	if (fixed > inner - 2) {
 		// Too tight: truncate the title so the right-side meta survives.
 		const budget = Math.max(4, inner - visibleWidth(r) - 4);
-		const l2 = `${H} ${fit(left, budget)}`;
-		const fill = Math.max(1, inner - visibleWidth(l2) - visibleWidth(r) - 1);
+		const l2 = `${frame(theme, H)} ${fit(left, budget)}`;
+		const fill = Math.max(1, inner - visibleWidth(l2) - visibleWidth(r));
 		return `╭${l2}${frame(theme, H.repeat(fill))}${r}╮`;
 	}
 	const fill = Math.max(1, inner - fixed);
@@ -79,8 +81,8 @@ function boxRule(theme: Theme, width: number): string {
 /** Section separator with a label: `├─ Tasks ──────────┤` (§5.1). */
 function boxSectionRule(theme: Theme, width: number, label: string): string {
 	const inner = Math.max(4, width - 2);
-	const left = `${H} ${label} `;
-	const fill = Math.max(1, inner - visibleWidth(left) - 1);
+	const left = `${border(theme, H)} ${label} `;
+	const fill = Math.max(1, inner - visibleWidth(left));
 	return `├${left}${border(theme, H.repeat(fill))}┤`;
 }
 
@@ -89,8 +91,8 @@ function boxFooter(theme: Theme, width: number, content: string): string {
 	if (!content) {
 		return `╰${frame(theme, H.repeat(inner))}╯`;
 	}
-	const l = `${H} ${muted(theme, content)}`;
-	const fill = Math.max(1, inner - visibleWidth(l) - 1);
+	const l = `${frame(theme, H)} ${muted(theme, fit(content, inner - 4))}`;
+	const fill = Math.max(1, inner - visibleWidth(l));
 	return `╰${l}${frame(theme, H.repeat(fill))}╯`;
 }
 

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -122,7 +122,9 @@ const STATUS_COLOR: Record<DashboardStatusCode, RenderColor> = {
 function progressBar(theme: Theme, pct: number, barWidth: number): string {
 	const safeBar = Math.max(2, barWidth);
 	const filled = Math.min(safeBar, Math.max(0, Math.round((pct / 100) * safeBar)));
-	return `[${theme.fg("accent", "█".repeat(filled))}${theme.fg("dim", "░".repeat(safeBar - filled))}]`;
+	// The bar is muted like the rest of the progress info: neutral-gray fill
+	// with dim empty cells — no accent teal anywhere in the progress element.
+	return `[${theme.fg("muted", "█".repeat(filled))}${theme.fg("dim", "░".repeat(safeBar - filled))}]`;
 }
 
 // ── Layout modes (§5.5) ─────────────────────────────────────────────────────
@@ -337,7 +339,7 @@ export function renderCompactDashboard(
 	// Current-task subtask progress (§9.3).
 	if (model.currentTask && model.currentTask.totalSubtasks > 0 && mode !== "minimal") {
 		const bar = progressBar(theme, model.currentTask.subtaskPercentage, spec.barWidth);
-		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Subtasks")} ${bar} ${accent(theme, `${model.currentTask.completedSubtasks}/${model.currentTask.totalSubtasks}`)} · ${muted(theme, `${model.currentTask.subtaskPercentage}%`)}`));
+		lines.push(boxLine(theme, safeWidth, `${muted(theme, "Subtasks")} ${bar} ${muted(theme, `${model.currentTask.completedSubtasks}/${model.currentTask.totalSubtasks}`)} · ${muted(theme, `${model.currentTask.subtaskPercentage}%`)}`));
 	}
 
 	// Goal-level verification (§11.1): truncated first line in compact.

--- a/extensions/widgets/goal-widget.ts
+++ b/extensions/widgets/goal-widget.ts
@@ -190,7 +190,7 @@ export function renderAuditResultCardView(
 	return renderAuditResultCard(deriveAuditResultCard(view.verdict, view.report), theme, width);
 }
 
-export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Theme, width: number, options: { openGoalCount?: number; auditorProgress?: AuditorWidgetProgress | null; disableTasks?: boolean; stalled?: boolean; ledgerEvents?: GoalLedgerEvent[]; expanded?: boolean; debug?: boolean; model?: GoalDashboardModel | null; compactScrollOffset?: number; expandedScrollOffset?: number; expandedTaskRows?: number; scrollFocus?: boolean } = {}): string[] {
+export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Theme, width: number, options: { openGoalCount?: number; auditorProgress?: AuditorWidgetProgress | null; disableTasks?: boolean; stalled?: boolean; ledgerEvents?: GoalLedgerEvent[]; expanded?: boolean; debug?: boolean; model?: GoalDashboardModel | null; compactScrollOffset?: number; expandedScrollOffset?: number; expandedTaskRows?: number } = {}): string[] {
 	// When auditor progress is active, show the structured audit dashboard
 	// instead of the normal goal widget (§15.3).
 	if (options.auditorProgress) {
@@ -214,7 +214,7 @@ export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Them
 	if (!model) return [];
 	const lines = options.expanded
 		? renderExpandedDashboard(model, theme, safeWidth, { scrollOffset: options.expandedScrollOffset, rows: options.expandedTaskRows })
-		: renderCompactDashboard(model, theme, safeWidth, { scrollOffset: options.compactScrollOffset, scrollFocus: options.scrollFocus });
+		: renderCompactDashboard(model, theme, safeWidth, { scrollOffset: options.compactScrollOffset });
 	return clampLinesToWidth(lines, width);
 }
 
@@ -236,7 +236,6 @@ export class GoalWidgetComponent implements Component {
 	// bookkeeping (a new completion re-anchors to the latest completed task).
 	private compactScrollOffset = 0;
 	private expandedScrollOffset = 0;
-	private compactScrollFocus = false;
 	private lastRenderWidth = 100;
 	private lastSeenGoalId: string | undefined;
 	private lastSeenLatestCompletedAt: string | undefined;
@@ -345,7 +344,6 @@ export class GoalWidgetComponent implements Component {
 			compactScrollOffset: this.compactScrollOffset,
 			expandedScrollOffset: this.expandedScrollOffset,
 			expandedTaskRows: expandedTaskViewportRows(this.lastRenderWidth),
-			scrollFocus: this.compactScrollFocus,
 		});
 		if (this.getDebugMode()) {
 			lines.push(...this.renderDebugPanel(width));
@@ -376,54 +374,48 @@ export class GoalWidgetComponent implements Component {
 		this.expandedScrollOffset = anchoredScrollOffset(model.taskTree, expandedTaskViewportRows(this.lastRenderWidth));
 	}
 
-	/** Whether the compact widget currently holds scroll focus (F6). */
-	isCompactScrollFocusActive(): boolean {
-		return this.compactScrollFocus;
-	}
-
 	/**
-	 * Toggle compact scroll focus (F6). Engages only when a compact task list
-	 * with overflow is visible; returns the new focus state.
+	 * Scroll the compact task list with a Ctrl+Shift chord (§9.6). The chords
+	 * are free in pi (the editor owns the plain arrows), so no focus state is
+	 * needed — but they are consumed only when the compact list actually
+	 * overflows its viewport, so they never swallow keystrokes for a short
+	 * list. Returns true when the key was consumed.
 	 */
-	toggleCompactScrollFocus(): boolean {
-		const goal = this.getGoal();
+	handleCompactScrollKey(key: "up" | "down" | "pageUp" | "pageDown" | "home" | "end"): boolean {
 		const settings = this.getSettings();
+		const goal = this.getGoal();
 		const model = goal ? deriveGoalDashboardModel(goal as GoalRecord | null, {
 			focused: true,
 			otherOpenGoals: Math.max(0, this.getOpenGoalCount() - 1),
 			ledgerEvents: this.getLedgerEvents(),
 			tasksDisabled: settings.disableTasks === true,
 		}) : null;
-		const topLevel = model?.taskTree.filter((n) => n.depth === 0) ?? [];
+		const list = model?.taskTree.filter((n) => n.depth === 0) ?? [];
 		const rows = compactTaskViewportRows(this.lastRenderWidth);
-		if (topLevel.length <= rows) {
-			this.compactScrollFocus = false;
-			return false;
-		}
-		this.compactScrollFocus = !this.compactScrollFocus;
-		if (!this.compactScrollFocus) this.compactScrollOffset = anchoredScrollOffset(topLevel, rows);
+		if (list.length <= rows) return false;
+		let offset = clampScrollOffset(this.compactScrollOffset, list.length, rows);
+		if (key === "up") offset -= 1;
+		else if (key === "down") offset += 1;
+		else if (key === "pageUp") offset -= taskViewportPageSize(rows);
+		else if (key === "pageDown") offset += taskViewportPageSize(rows);
+		else if (key === "home") offset = 0;
+		else if (key === "end") offset = maxScrollOffset(list.length, rows);
+		offset = clampScrollOffset(offset, list.length, rows);
+		this.compactScrollOffset = offset;
 		this.tui.requestRender();
-		return this.compactScrollFocus;
-	}
-
-	/** Drop compact scroll focus (Esc while engaged, or expanding). */
-	clearScrollFocus(): void {
-		if (!this.compactScrollFocus) return;
-		this.compactScrollFocus = false;
-		this.tui.requestRender();
+		return true;
 	}
 
 	/**
-	 * Handle a navigation key for the focused dashboard. Returns true when the
-	 * key was consumed (dashboard focused and a scrollable list exists). The
-	 * expanded dashboard is always focused; the compact widget only while
-	 * scroll focus is engaged. Clamps at both ends; Home/End jump to the
-	 * edges; PgUp/PgDn page by one viewport.
+	 * Handle a navigation key for the expanded dashboard. The expanded
+	 * dashboard is modal — while it is open it owns the arrow keys (like the
+	 * session tree or model selector), so plain ↑/↓/PgUp/PgDn scroll the task
+	 * tree and Esc collapses. Returns true when the key was consumed.
+	 * Clamps at both ends; Home/End jump to the edges; PgUp/PgDn page by one
+	 * viewport.
 	 */
 	handleNavigationKey(key: "up" | "down" | "pageUp" | "pageDown" | "home" | "end"): boolean {
-		const expanded = this.getExpanded();
-		const focused = expanded || this.compactScrollFocus;
-		if (!focused) return false;
+		if (!this.getExpanded()) return false;
 		const settings = this.getSettings();
 		const goal = this.getGoal();
 		const model = goal ? deriveGoalDashboardModel(goal as GoalRecord | null, {
@@ -432,16 +424,12 @@ export class GoalWidgetComponent implements Component {
 			ledgerEvents: this.getLedgerEvents(),
 			tasksDisabled: settings.disableTasks === true,
 		}) : null;
-		const list = expanded
-			? model?.taskTree ?? []
-			: model?.taskTree.filter((n) => n.depth === 0) ?? [];
+		const list = model?.taskTree ?? [];
 		if (list.length === 0) return false;
-		const rows = expanded
-			? expandedTaskViewportRows(this.lastRenderWidth)
-			: compactTaskViewportRows(this.lastRenderWidth);
+		const rows = expandedTaskViewportRows(this.lastRenderWidth);
 		const maxO = maxScrollOffset(list.length, rows);
 		if (maxO <= 0) return false;
-		let offset = expanded ? this.expandedScrollOffset : this.compactScrollOffset;
+		let offset = clampScrollOffset(this.expandedScrollOffset, list.length, rows);
 		if (key === "up") offset -= 1;
 		else if (key === "down") offset += 1;
 		else if (key === "pageUp") offset -= taskViewportPageSize(rows);
@@ -449,8 +437,7 @@ export class GoalWidgetComponent implements Component {
 		else if (key === "home") offset = 0;
 		else if (key === "end") offset = maxO;
 		offset = clampScrollOffset(offset, list.length, rows);
-		if (expanded) this.expandedScrollOffset = offset;
-		else this.compactScrollOffset = offset;
+		this.expandedScrollOffset = offset;
 		this.tui.requestRender();
 		return true;
 	}

--- a/extensions/widgets/goal-widget.ts
+++ b/extensions/widgets/goal-widget.ts
@@ -12,7 +12,17 @@ import type { GoalRecord, GoalTask, GoalTaskList, TaskStatus } from "../goal-rec
 import type { GoalSettings } from "../goal-settings.ts";
 import { sisyphusStepProgress } from "../goal-policy.ts";
 import type { GoalLedgerEvent } from "../goal-ledger.ts";
-import { deriveGoalDashboardModel } from "./goal-dashboard-model.ts";
+import {
+	anchoredScrollOffset,
+	clampScrollOffset,
+	compactTaskViewportRows,
+	deriveGoalDashboardModel,
+	expandedTaskViewportRows,
+	latestCompletedNodeIndex,
+	maxScrollOffset,
+	taskViewportPageSize,
+	type GoalDashboardModel,
+} from "./goal-dashboard-model.ts";
 import {
 	clampLinesToWidth,
 	renderAuditResultCard,
@@ -180,7 +190,7 @@ export function renderAuditResultCardView(
 	return renderAuditResultCard(deriveAuditResultCard(view.verdict, view.report), theme, width);
 }
 
-export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Theme, width: number, options: { openGoalCount?: number; auditorProgress?: AuditorWidgetProgress | null; disableTasks?: boolean; stalled?: boolean; ledgerEvents?: GoalLedgerEvent[]; expanded?: boolean; debug?: boolean } = {}): string[] {
+export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Theme, width: number, options: { openGoalCount?: number; auditorProgress?: AuditorWidgetProgress | null; disableTasks?: boolean; stalled?: boolean; ledgerEvents?: GoalLedgerEvent[]; expanded?: boolean; debug?: boolean; model?: GoalDashboardModel | null; compactScrollOffset?: number; expandedScrollOffset?: number; expandedTaskRows?: number; scrollFocus?: boolean } = {}): string[] {
 	// When auditor progress is active, show the structured audit dashboard
 	// instead of the normal goal widget (§15.3).
 	if (options.auditorProgress) {
@@ -195,7 +205,7 @@ export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Them
 	}
 	const safeWidth = Math.max(1, width);
 	const otherCount = Math.max(0, openGoalCount - 1);
-	const model = deriveGoalDashboardModel(goal as GoalRecord | null, {
+	const model = options.model ?? deriveGoalDashboardModel(goal as GoalRecord | null, {
 		focused: true,
 		otherOpenGoals: otherCount,
 		ledgerEvents: options.ledgerEvents ?? [],
@@ -203,8 +213,8 @@ export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Them
 	});
 	if (!model) return [];
 	const lines = options.expanded
-		? renderExpandedDashboard(model, theme, safeWidth)
-		: renderCompactDashboard(model, theme, safeWidth);
+		? renderExpandedDashboard(model, theme, safeWidth, { scrollOffset: options.expandedScrollOffset, rows: options.expandedTaskRows })
+		: renderCompactDashboard(model, theme, safeWidth, { scrollOffset: options.compactScrollOffset, scrollFocus: options.scrollFocus });
 	return clampLinesToWidth(lines, width);
 }
 
@@ -220,6 +230,16 @@ export class GoalWidgetComponent implements Component {
 	private getExpanded: () => boolean;
 	private getLedgerEvents: () => GoalLedgerEvent[];
 	private getAuditResult: () => AuditResultView | null;
+
+	// §9.6 scroll state: viewport offsets for the compact top-level list and
+	// the expanded tree, compact scroll-focus engagement, and the re-anchor
+	// bookkeeping (a new completion re-anchors to the latest completed task).
+	private compactScrollOffset = 0;
+	private expandedScrollOffset = 0;
+	private compactScrollFocus = false;
+	private lastRenderWidth = 100;
+	private lastSeenGoalId: string | undefined;
+	private lastSeenLatestCompletedAt: string | undefined;
 
 	constructor(options: GoalWidgetOptions) {
 		this.theme = options.theme;
@@ -298,11 +318,21 @@ export class GoalWidgetComponent implements Component {
 
 	render(width: number): string[] {
 		const settings = this.getSettings();
+		this.lastRenderWidth = Math.max(1, width);
 		// §15.4: a finished audit shows its result card until cleared.
 		const auditResult = this.getAuditResult();
 		if (auditResult) {
 			return clampLinesToWidth(renderAuditResultCardView(auditResult, this.theme, width), width);
 		}
+		const goal = this.getGoal();
+		const otherCount = Math.max(0, this.getOpenGoalCount() - 1);
+		const model = goal ? deriveGoalDashboardModel(goal as GoalRecord | null, {
+			focused: true,
+			otherOpenGoals: otherCount,
+			ledgerEvents: this.getLedgerEvents(),
+			tasksDisabled: settings.disableTasks === true,
+		}) : null;
+		this.maybeReanchor(model);
 		let lines = renderGoalWidgetLines(this.getGoal(), this.theme, width, {
 			openGoalCount: this.getOpenGoalCount(),
 			auditorProgress: this.getAuditorProgress(),
@@ -311,11 +341,118 @@ export class GoalWidgetComponent implements Component {
 			expanded: this.getExpanded(),
 			ledgerEvents: this.getLedgerEvents(),
 			debug: this.getDebugMode(),
+			model,
+			compactScrollOffset: this.compactScrollOffset,
+			expandedScrollOffset: this.expandedScrollOffset,
+			expandedTaskRows: expandedTaskViewportRows(this.lastRenderWidth),
+			scrollFocus: this.compactScrollFocus,
 		});
 		if (this.getDebugMode()) {
 			lines.push(...this.renderDebugPanel(width));
 		}
 		return clampLinesToWidth(lines, width);
+	}
+
+	/**
+	 * §9.6 re-anchor rule: when the goal changes or a new task completes (the
+	 * latest completedAt moves), reset both viewports to the anchored defaults
+	 * so the most recently completed work stays visible. Between such events
+	 * the user's manual scroll position is preserved.
+	 */
+	private maybeReanchor(model: GoalDashboardModel | null): void {
+		const latestAt = latestCompletedNodeIndex(model?.taskTree ?? []) >= 0
+			? model!.taskTree[latestCompletedNodeIndex(model!.taskTree)]!.completedAt
+			: undefined;
+		if (model?.goalId === this.lastSeenGoalId && latestAt === this.lastSeenLatestCompletedAt) return;
+		this.lastSeenGoalId = model?.goalId;
+		this.lastSeenLatestCompletedAt = latestAt;
+		if (!model || model.taskTree.length === 0) {
+			this.compactScrollOffset = 0;
+			this.expandedScrollOffset = 0;
+			return;
+		}
+		const topLevel = model.taskTree.filter((n) => n.depth === 0);
+		this.compactScrollOffset = anchoredScrollOffset(topLevel, compactTaskViewportRows(this.lastRenderWidth));
+		this.expandedScrollOffset = anchoredScrollOffset(model.taskTree, expandedTaskViewportRows(this.lastRenderWidth));
+	}
+
+	/** Whether the compact widget currently holds scroll focus (F6). */
+	isCompactScrollFocusActive(): boolean {
+		return this.compactScrollFocus;
+	}
+
+	/**
+	 * Toggle compact scroll focus (F6). Engages only when a compact task list
+	 * with overflow is visible; returns the new focus state.
+	 */
+	toggleCompactScrollFocus(): boolean {
+		const goal = this.getGoal();
+		const settings = this.getSettings();
+		const model = goal ? deriveGoalDashboardModel(goal as GoalRecord | null, {
+			focused: true,
+			otherOpenGoals: Math.max(0, this.getOpenGoalCount() - 1),
+			ledgerEvents: this.getLedgerEvents(),
+			tasksDisabled: settings.disableTasks === true,
+		}) : null;
+		const topLevel = model?.taskTree.filter((n) => n.depth === 0) ?? [];
+		const rows = compactTaskViewportRows(this.lastRenderWidth);
+		if (topLevel.length <= rows) {
+			this.compactScrollFocus = false;
+			return false;
+		}
+		this.compactScrollFocus = !this.compactScrollFocus;
+		if (!this.compactScrollFocus) this.compactScrollOffset = anchoredScrollOffset(topLevel, rows);
+		this.tui.requestRender();
+		return this.compactScrollFocus;
+	}
+
+	/** Drop compact scroll focus (Esc while engaged, or expanding). */
+	clearScrollFocus(): void {
+		if (!this.compactScrollFocus) return;
+		this.compactScrollFocus = false;
+		this.tui.requestRender();
+	}
+
+	/**
+	 * Handle a navigation key for the focused dashboard. Returns true when the
+	 * key was consumed (dashboard focused and a scrollable list exists). The
+	 * expanded dashboard is always focused; the compact widget only while
+	 * scroll focus is engaged. Clamps at both ends; Home/End jump to the
+	 * edges; PgUp/PgDn page by one viewport.
+	 */
+	handleNavigationKey(key: "up" | "down" | "pageUp" | "pageDown" | "home" | "end"): boolean {
+		const expanded = this.getExpanded();
+		const focused = expanded || this.compactScrollFocus;
+		if (!focused) return false;
+		const settings = this.getSettings();
+		const goal = this.getGoal();
+		const model = goal ? deriveGoalDashboardModel(goal as GoalRecord | null, {
+			focused: true,
+			otherOpenGoals: Math.max(0, this.getOpenGoalCount() - 1),
+			ledgerEvents: this.getLedgerEvents(),
+			tasksDisabled: settings.disableTasks === true,
+		}) : null;
+		const list = expanded
+			? model?.taskTree ?? []
+			: model?.taskTree.filter((n) => n.depth === 0) ?? [];
+		if (list.length === 0) return false;
+		const rows = expanded
+			? expandedTaskViewportRows(this.lastRenderWidth)
+			: compactTaskViewportRows(this.lastRenderWidth);
+		const maxO = maxScrollOffset(list.length, rows);
+		if (maxO <= 0) return false;
+		let offset = expanded ? this.expandedScrollOffset : this.compactScrollOffset;
+		if (key === "up") offset -= 1;
+		else if (key === "down") offset += 1;
+		else if (key === "pageUp") offset -= taskViewportPageSize(rows);
+		else if (key === "pageDown") offset += taskViewportPageSize(rows);
+		else if (key === "home") offset = 0;
+		else if (key === "end") offset = maxO;
+		offset = clampScrollOffset(offset, list.length, rows);
+		if (expanded) this.expandedScrollOffset = offset;
+		else this.compactScrollOffset = offset;
+		this.tui.requestRender();
+		return true;
 	}
 
 	invalidate(): void {

--- a/extensions/widgets/goal-widget.ts
+++ b/extensions/widgets/goal-widget.ts
@@ -11,6 +11,17 @@ import {
 import type { GoalRecord, GoalTask, GoalTaskList, TaskStatus } from "../goal-record.ts";
 import type { GoalSettings } from "../goal-settings.ts";
 import { sisyphusStepProgress } from "../goal-policy.ts";
+import type { GoalLedgerEvent } from "../goal-ledger.ts";
+import { deriveGoalDashboardModel } from "./goal-dashboard-model.ts";
+import {
+	clampLinesToWidth,
+	renderAuditResultCard,
+	renderAuditorDashboard,
+	renderCompactDashboard,
+	renderExpandedDashboard,
+	renderUnfocusedDashboard,
+} from "./goal-dashboard-renderer.ts";
+import { deriveAuditResultCard, deriveAuditorDashboardModel } from "./auditor-dashboard-model.ts";
 
 type GoalWidgetColor = Extract<ThemeColor, "accent" | "warning" | "success" | "error" | "dim" | "muted" | "text">;
 
@@ -25,6 +36,7 @@ export interface GoalWidgetRecord extends GoalDisplayRecordLike {
 	taskList?: GoalTaskList | null;
 	verificationContract?: string;
 	tokenBudget?: number;
+	currentTaskId?: string;
 }
 
 export const GOAL_WIDGET_KEY = "goal";
@@ -56,6 +68,9 @@ export function makeGoalWidgetFactory(opts: {
 	getSettings: () => GoalSettings;
 	getDebugMode: () => boolean;
 	getStalled: () => boolean;
+	getExpanded?: () => boolean;
+	getLedgerEvents?: () => GoalLedgerEvent[];
+	getAuditResult?: () => AuditResultView | null;
 }) {
 	return (tui: TUI, theme: Theme) => new GoalWidgetComponent({
 		tui,
@@ -66,6 +81,9 @@ export function makeGoalWidgetFactory(opts: {
 		getSettings: opts.getSettings,
 		getDebugMode: opts.getDebugMode,
 		getStalled: opts.getStalled,
+		getExpanded: opts.getExpanded,
+		getLedgerEvents: opts.getLedgerEvents,
+		getAuditResult: opts.getAuditResult,
 	});
 }
 
@@ -80,6 +98,8 @@ export interface AuditorWidgetProgress {
 	label?: string;
 	/** Completion percentage from 0 to 100 */
 	percentage?: number;
+	/** §15: auditor identity (provider/model) for the audit dashboard header. */
+	auditorLabel?: string;
 }
 
 export interface GoalWidgetOptions {
@@ -92,6 +112,12 @@ export interface GoalWidgetOptions {
 	getDebugMode?: () => boolean;
 	/** F5: stalled badge (active auto-continue goal with no recent activity). */
 	getStalled?: () => boolean;
+	/** §10: dashboard expansion state (compact vs expanded task view). */
+	getExpanded?: () => boolean;
+	/** §12: durable ledger events for the recent-activity feed. */
+	getLedgerEvents?: () => GoalLedgerEvent[];
+	/** §15.4: finished audit result card (cleared after a short display). */
+	getAuditResult?: () => AuditResultView | null;
 }
 
 function fit(value: string, width: number): string {
@@ -117,96 +143,6 @@ function progressBar(pct: number, barWidth: number, theme: Theme): string {
 	return `[${theme.fg("accent", "█".repeat(filled))}${theme.fg("dim", "░".repeat(empty))}]`;
 }
 
-function displayIcon(goal: GoalWidgetRecord): { icon: string; color: GoalWidgetColor; label: string } {
-	if (goal.status === "complete") return { icon: "✓", color: "success", label: "complete" };
-	if (goal.status === "paused") {
-		return goal.stopReason === "agent"
-			? { icon: "⊘", color: "warning", label: "blocked" }
-			: { icon: "◐", color: "muted", label: "paused" };
-	}
-	if (goal.sisyphus) return { icon: "◆", color: "accent", label: goal.autoContinue ? "sisyphus running" : "sisyphus idle" };
-	return goal.autoContinue ? { icon: "●", color: "accent", label: "goal running" } : { icon: "○", color: "muted", label: "goal idle" };
-}
-
-function countFlatTasks(tasks: GoalTask[]): { total: number; done: number } {
-	let total = 0;
-	let done = 0;
-	for (const t of tasks) {
-		total++;
-		if (t.status === "complete" || t.status === "skipped") done++;
-		if (t.subtasks && t.subtasks.length > 0) {
-			const child = countFlatTasks(t.subtasks);
-			total += child.total;
-			done += child.done;
-		}
-	}
-	return { total, done };
-}
-
-/** F1: collect pending tasks in tree order with their depth. */
-function collectPendingWithDepth(tasks: GoalTask[], depth = 0): Array<{ task: GoalTask; depth: number }> {
-	const out: Array<{ task: GoalTask; depth: number }> = [];
-	for (const t of tasks) {
-		if (t.status === "pending") out.push({ task: t, depth });
-		if (t.subtasks && t.subtasks.length > 0) out.push(...collectPendingWithDepth(t.subtasks, depth + 1));
-	}
-	return out;
-}
-
-/** F1: most recent completed tasks carrying evidence (tree order, capped). */
-function recentCompletedWithEvidence(tasks: GoalTask[], cap: number): Array<{ id: string; evidence?: string; title: string }> {
-	const out: Array<{ id: string; evidence?: string; title: string }> = [];
-	for (const t of tasks) {
-		if (t.status === "complete") out.push({ id: t.id, evidence: t.evidence, title: t.title });
-		if (t.subtasks && t.subtasks.length > 0) out.push(...recentCompletedWithEvidence(t.subtasks, cap - out.length));
-		if (out.length >= cap) break;
-	}
-	return out.slice(0, cap);
-}
-
-/** F4: first N ordered-step titles from the objective. */
-function orderedStepTitles(objective: string, count: number): string[] {
-	const titles: string[] = [];
-	const lines = objective.split(/\r?\n/);
-	for (const raw of lines) {
-		const line = raw.trim();
-		const numbered = line.match(/^(\d{1,2})\s*[.):]\s*(.*)$/);
-		const step = line.match(/^step\s+(\d+)\s*:?\s*(.*)$/i);
-		const m = numbered ?? step;
-		if (!m) continue;
-		const no = Number(m[1]);
-		titles[no - 1] = (m[2] || "").trim();
-	}
-	return titles.slice(0, count);
-}
-
-function findFirstPending(tasks: GoalTask[]): GoalTask | undefined {
-	const queue = [...tasks];
-	while (queue.length > 0) {
-		const t = queue.shift()!;
-		if (t.status === "pending") return t;
-		if (t.subtasks) queue.push(...t.subtasks);
-	}
-	return undefined;
-}
-
-function headingMeta(goal: GoalWidgetRecord, otherOpenGoalCount = 0, disableTasks = false, stalled = false): string {
-	const bits: string[] = [];
-	if (stalled) bits.push("⏱ stalled");
-	if (goal.sisyphus) {
-		const steps = sisyphusStepProgress(goal);
-		if (steps) bits.push(`Step ${steps.current}/${steps.total}`);
-	}
-	if (goal.status === "active" && goal.autoContinue) bits.push("auto");
-	if (goal.usage.activeSeconds > 0) bits.push(formatDuration(goal.usage.activeSeconds));
-	if (goal.usage.tokensUsed > 0) bits.push(formatTokenValue(goal.usage.tokensUsed));
-	if (!disableTasks && goal.taskList && goal.taskList.tasks.length > 0) {
-		const { total, done } = countFlatTasks(goal.taskList.tasks);
-		bits.push(`${done}/${total} tasks`);
-	}
-	if (otherOpenGoalCount > 0) bits.push(`+${otherOpenGoalCount} open`);
-	return bits.join(" · ");
-}
 
 const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -214,199 +150,62 @@ function spinnerFrame(): string {
 	return SPINNER[Math.floor(Date.now() / 80) % SPINNER.length]!;
 }
 
-export function renderAuditorWidgetLines(progress: AuditorWidgetProgress, theme: Theme, width: number): string[] {
-	const safeWidth = Math.max(1, width);
-	const isActive = progress.phase !== "done";
-	const isThinking = progress.phase === "thinking";
-	const icon = isActive
-		? isThinking
-			? theme.fg("muted", "⟡")
-			: theme.fg("accent", spinnerFrame())
-		: theme.fg("success", "✓");
-	const label = isActive
-		? isThinking
-			? "thinking..."
-			: "auditing"
-		: "audit complete";
-	// formatDuration expects seconds, progress.elapsedMs is in milliseconds
-	const duration = formatDuration(Math.floor(progress.elapsedMs / 1000));
-	const lines: string[] = [
-		heading(
-			theme,
-			safeWidth,
-			`${icon} ${theme.fg("accent", theme.bold("Audit"))} ${theme.fg("muted", label)}`,
-			theme.fg("muted", duration),
-		),
-	];
-
-	// Show step label when available
-	if (progress.label) {
-		lines.push(branchLine(
-			theme,
-			safeWidth,
-			false,
-			`${theme.fg("text", truncateText(progress.label, Math.max(8, safeWidth - 6)))}`,
-		));
-	}
-
-	// Show progress bar when percentage is available
-	if (typeof progress.percentage === "number") {
-		const barWidth = Math.max(6, Math.min(safeWidth - 10, 30));
-		const bar = progressBar(progress.percentage, barWidth, theme);
-		const pct = `${theme.fg("muted", `${Math.round(progress.percentage)}%`)}`;
-		lines.push(branchLine(
-			theme,
-			safeWidth,
-			isActive && !progress.currentTool && progress.recentOutput.length === 0 && !isThinking,
-			`${bar} ${pct}`,
-		));
-	}
-
-	if (isActive && !isThinking && progress.currentTool) {
-		const argText = progress.currentToolArgs
-			? truncateText(progress.currentToolArgs, Math.max(10, safeWidth - 24))
-			: "";
-		const toolDuration = progress.currentToolStartedAt
-			? ` ${theme.fg("dim", formatDuration(Math.floor((Date.now() - progress.currentToolStartedAt) / 1000)))}`
-			: "";
-		lines.push(branchLine(
-			theme,
-			safeWidth,
-			false,
-			`${theme.fg("accent", "tool")} ${theme.fg("text", progress.currentTool)}${argText ? ` ${theme.fg("dim", argText)}` : ""}${toolDuration}`,
-		));
-	}
-
-	if (progress.recentOutput.length > 0) {
-		// Show separator
-		lines.push(branchLine(
-			theme,
-			safeWidth,
-			!isActive,
-			theme.fg("dim", "─".repeat(Math.max(4, safeWidth - 6))),
-		));
-		for (const [index, line] of progress.recentOutput.entries()) {
-			const isLast = index === progress.recentOutput.length - 1 && !isActive;
-			lines.push(branchLine(
-				theme,
-				safeWidth,
-				isLast,
-				theme.fg("dim", truncateText(line, Math.max(8, safeWidth - 6))),
-			));
-		}
-	}
-
-	// Show skip hint when audit is actively running
-	if (isActive && !isThinking) {
-		lines.push(branchLine(
-			theme,
-			safeWidth,
-			true,
-			theme.fg("warning", "Esc to skip") + theme.fg("dim", " — abort the audit and let the user decide"),
-		));
-	}
-
-	return lines;
+export interface AuditResultView {
+	verdict: "approved" | "disapproved" | "error";
+	report: string;
 }
 
-export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Theme, width: number, options: { openGoalCount?: number; auditorProgress?: AuditorWidgetProgress | null; disableTasks?: boolean; stalled?: boolean } = {}): string[] {
-	// When auditor progress is active, show auditor display instead of normal goal widget
+/**
+ * Structured audit dashboard (§15): five check stages, elapsed duration, and a
+ * progress bar, derived from the raw auditor progress stream. Raw tools and
+ * recent output appear only with showToolDetails (expanded/debug audit mode)
+ * or after a failed audit.
+ */
+export function renderAuditorWidgetLines(
+	progress: AuditorWidgetProgress,
+	theme: Theme,
+	width: number,
+	opts: { showToolDetails?: boolean; verdict?: "approved" | "disapproved" | "error" | null } = {},
+): string[] {
+	const model = deriveAuditorDashboardModel(progress, { auditorLabel: progress.auditorLabel, verdict: opts.verdict });
+	return renderAuditorDashboard(model, theme, width, { showToolDetails: opts.showToolDetails });
+}
+
+/** §15.4: approval / rejection result card for a finished audit. */
+export function renderAuditResultCardView(
+	view: AuditResultView,
+	theme: Theme,
+	width: number,
+): string[] {
+	return renderAuditResultCard(deriveAuditResultCard(view.verdict, view.report), theme, width);
+}
+
+export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Theme, width: number, options: { openGoalCount?: number; auditorProgress?: AuditorWidgetProgress | null; disableTasks?: boolean; stalled?: boolean; ledgerEvents?: GoalLedgerEvent[]; expanded?: boolean; debug?: boolean } = {}): string[] {
+	// When auditor progress is active, show the structured audit dashboard
+	// instead of the normal goal widget (§15.3).
 	if (options.auditorProgress) {
-		return renderAuditorWidgetLines(options.auditorProgress, theme, width);
+		return renderAuditorWidgetLines(options.auditorProgress, theme, width, {
+			showToolDetails: options.expanded === true || options.debug === true,
+		});
 	}
+	const openGoalCount = options.openGoalCount ?? 0;
 	if (!goal) {
-		const openGoalCount = options.openGoalCount ?? 0;
-		if (openGoalCount <= 0) return [];
-		const safeWidth = Math.max(1, width);
-		return [
-			heading(theme, safeWidth, `${theme.fg("warning", "◇")} ${theme.fg("warning", theme.bold("Goal"))} ${theme.fg("muted", "unfocused")}`, theme.fg("muted", `${openGoalCount} open`)),
-			branchLine(theme, safeWidth, true, `${theme.fg("muted", "Run /goal-focus to choose this session's goal")}`),
-		];
+		// Unfocused panel when open goals exist; nothing when the pool is empty.
+		return openGoalCount > 0 ? renderUnfocusedDashboard(openGoalCount, theme, width) : [];
 	}
 	const safeWidth = Math.max(1, width);
-	const { icon, color, label } = displayIcon(goal);
-	const mode = goal.sisyphus ? "Sisyphus" : "Goal";
-	const headingLeft = `${theme.fg(color, icon)} ${theme.fg(color, theme.bold(mode))} ${theme.fg("muted", label.replace(/^sisyphus |^goal /, ""))}`;
-	const otherOpenGoalCount = Math.max(0, (options.openGoalCount ?? (goal ? 1 : 0)) - 1);
-	const headingRight = theme.fg("muted", headingMeta(goal, otherOpenGoalCount, options.disableTasks, options.stalled === true));
-	const lines: string[] = [heading(theme, safeWidth, headingLeft, headingRight)];
-	const body: string[] = [];
-
-	const titleWidth = Math.max(12, safeWidth - 8);
-	const objective = truncateText(displayObjectiveTitle(goal.objective), titleWidth);
-	body.push(`${theme.fg("accent", "⟡")} ${theme.fg("text", objective)}`);
-
-	// E4: live budget progress (used/total, remaining) once a budget is set.
-	if (typeof goal.tokenBudget === "number" && goal.tokenBudget > 0) {
-		const used = Math.max(0, goal.usage.tokensUsed);
-		const pct = Math.max(0, Math.round((used / goal.tokenBudget) * 100));
-		const remaining = Math.max(0, goal.tokenBudget - used);
-		const color = pct >= 90 ? "warning" : pct >= 50 ? "accent" : "muted";
-		body.push(`${theme.fg(color, "⛽")} ${theme.fg("muted", `Budget: ${formatTokenValue(used)}/${formatTokenValue(goal.tokenBudget)} (${pct}% used · ${formatTokenValue(remaining)} remaining)`)}`);
-	}
-
-	if (!options.disableTasks && goal.taskList && goal.taskList.tasks.length > 0) {
-		const { total, done } = countFlatTasks(goal.taskList.tasks);
-		if (done === total) {
-			body.push(`${theme.fg("success", "✓")} ${theme.fg("muted", "All tasks complete")}`);
-		} else {
-			// F1: task-progress block — counts, next pending with depth-aware
-			// indentation + contract snippets, evidence for recent completions.
-			body.push(`${theme.fg("muted", `Tasks: ${done}/${total} done`)}`);
-			const pending = collectPendingWithDepth(goal.taskList.tasks);
-			for (const entry of pending.slice(0, 3)) {
-				const indent = "  ".repeat(entry.depth);
-				body.push(`${theme.fg("warning", "◻")} ${indent}${theme.fg("muted", `${entry.task.id}: ${truncateText(entry.task.title, Math.max(8, safeWidth - 24))}`)}`);
-				if (entry.task.verificationContract) {
-					body.push(`${indent}  ${theme.fg("dim", `contract: ${truncateText(entry.task.verificationContract, Math.max(8, safeWidth - 32))}`)}`);
-				}
-			}
-			const hidden = pending.length - 3;
-			if (hidden > 0) {
-				body.push(`${theme.fg("dim", `(+${hidden} more pending — Ctrl+Shift+T)`)}`);
-			}
-			const recent = recentCompletedWithEvidence(goal.taskList.tasks, 2);
-			for (const entry of recent) {
-				body.push(`${theme.fg("success", "✓")} ${theme.fg("dim", `${entry.id}: ${truncateText(entry.evidence ?? entry.title, Math.max(8, safeWidth - 18))}`)}`);
-			}
-		}
-	}
-
-	// F4: sisyphus ordered-step progress (uses the E6 step detector).
-	if (goal.sisyphus) {
-		const steps = sisyphusStepProgress(goal);
-		if (steps && steps.total <= 6) {
-			const ordered = orderedStepTitles(goal.objective, steps.total);
-			ordered.forEach((title, index) => {
-				const stepNo = index + 1;
-				const isCurrent = stepNo === steps.current;
-				const isDone = stepNo < steps.current;
-				const marker = isDone ? theme.fg("success", "✓") : isCurrent ? theme.fg("accent", "▸") : theme.fg("dim", "·");
-				const line = isCurrent
-					? theme.fg("text", `${marker} Step ${stepNo}: ${truncateText(title, Math.max(8, safeWidth - 20))}`)
-					: theme.fg("muted", `${marker} Step ${stepNo}: ${truncateText(title, Math.max(8, safeWidth - 20))}`);
-				body.push(line);
-			});
-		}
-	}
-
-	if (goal.status === "paused" && goal.stopReason === "agent" && goal.pauseReason) {
-		body.push(`${theme.fg("warning", "blocker")} ${theme.fg("warning", truncateText(goal.pauseReason, Math.max(12, safeWidth - 14)))}`);
-		if (goal.pauseSuggestedAction) {
-			body.push(`${theme.fg("dim", "next")} ${theme.fg("muted", truncateText(goal.pauseSuggestedAction, Math.max(12, safeWidth - 10)))}`);
-		}
-	}
-
-	const path = goal.status === "complete" ? goal.archivedPath : goal.activePath;
-	if (path) {
-		body.push(theme.fg("dim", path));
-	}
-
-	for (const [index, content] of body.entries()) {
-		lines.push(branchLine(theme, safeWidth, index === body.length - 1, content));
-	}
-
-	return lines;
+	const otherCount = Math.max(0, openGoalCount - 1);
+	const model = deriveGoalDashboardModel(goal as GoalRecord | null, {
+		focused: true,
+		otherOpenGoals: otherCount,
+		ledgerEvents: options.ledgerEvents ?? [],
+		tasksDisabled: options.disableTasks === true,
+	});
+	if (!model) return [];
+	const lines = options.expanded
+		? renderExpandedDashboard(model, theme, safeWidth)
+		: renderCompactDashboard(model, theme, safeWidth);
+	return clampLinesToWidth(lines, width);
 }
 
 export class GoalWidgetComponent implements Component {
@@ -418,6 +217,9 @@ export class GoalWidgetComponent implements Component {
 	private getSettings: () => GoalSettings;
 	private getDebugMode: () => boolean;
 	private getStalled: () => boolean;
+	private getExpanded: () => boolean;
+	private getLedgerEvents: () => GoalLedgerEvent[];
+	private getAuditResult: () => AuditResultView | null;
 
 	constructor(options: GoalWidgetOptions) {
 		this.theme = options.theme;
@@ -428,6 +230,14 @@ export class GoalWidgetComponent implements Component {
 		this.getSettings = options.getSettings ?? (() => ({}));
 		this.getDebugMode = options.getDebugMode ?? (() => false);
 		this.getStalled = options.getStalled ?? (() => false);
+		this.getExpanded = options.getExpanded ?? (() => false);
+		this.getLedgerEvents = options.getLedgerEvents ?? (() => []);
+		this.getAuditResult = options.getAuditResult ?? (() => null);
+	}
+
+	/** Whether the dashboard is currently in expanded mode (§10). */
+	isExpanded(): boolean {
+		return this.getExpanded();
 	}
 
 	update(): void {
@@ -463,12 +273,13 @@ export class GoalWidgetComponent implements Component {
 			if (goal.archivedPath) lines.push(t.fg("dim", `  archivedPath: ${goal.archivedPath}`));
 			if (goal.verificationContract) lines.push(t.fg("dim", `  vContract: ${truncateText(goal.verificationContract, 60)}`));
 
-			// Task tree summary
-			if (goal.taskList && goal.taskList.tasks.length > 0) {
-				const { total, done } = countFlatTasks(goal.taskList.tasks);
-				lines.push(t.fg("dim", `  tasks: ${done}/${total}`));
-				const firstPending = findFirstPending(goal.taskList.tasks);
-				if (firstPending) lines.push(t.fg("dim", `  next: ${firstPending.id} (${truncateText(firstPending.title, 40)})`));
+			// Task tree summary (from the shared dashboard model).
+			const model = deriveGoalDashboardModel(goal as GoalRecord | null, { focused: true, otherOpenGoals: 0 });
+			if (model?.taskProgress) {
+				lines.push(t.fg("dim", `  tasks: ${model.taskProgress.completed}/${model.taskProgress.total}`));
+			}
+			if (model?.currentTask) {
+				lines.push(t.fg("dim", `  next: ${model.currentTask.id} (${truncateText(model.currentTask.title, 40)})`));
 			}
 		} else {
 			lines.push(t.fg("dim", "  (no goal)"));
@@ -487,22 +298,24 @@ export class GoalWidgetComponent implements Component {
 
 	render(width: number): string[] {
 		const settings = this.getSettings();
+		// §15.4: a finished audit shows its result card until cleared.
+		const auditResult = this.getAuditResult();
+		if (auditResult) {
+			return clampLinesToWidth(renderAuditResultCardView(auditResult, this.theme, width), width);
+		}
 		let lines = renderGoalWidgetLines(this.getGoal(), this.theme, width, {
 			openGoalCount: this.getOpenGoalCount(),
 			auditorProgress: this.getAuditorProgress(),
 			disableTasks: settings.disableTasks,
 			stalled: this.getStalled(),
+			expanded: this.getExpanded(),
+			ledgerEvents: this.getLedgerEvents(),
+			debug: this.getDebugMode(),
 		});
 		if (this.getDebugMode()) {
 			lines.push(...this.renderDebugPanel(width));
 		}
-		// Safety net: ensure no returned line exceeds the terminal width
-		for (let i = 0; i < lines.length; i++) {
-			if (visibleWidth(lines[i]) > width) {
-				lines[i] = truncateToWidth(lines[i], width);
-			}
-		}
-		return lines;
+		return clampLinesToWidth(lines, width);
 	}
 
 	invalidate(): void {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "test:all": "node scripts/run-unit-tests.mjs all",
     "test:selfcheck": "node scripts/run-unit-tests.mjs --selfcheck",
     "bench": "node --import ./experiments/bench/bench-adapter-hooks.mjs --experimental-strip-types ./experiments/bench/run-bench.mjs",
-    "bench:gate": "node --experimental-strip-types ./experiments/bench/b6-gate.mjs"
+    "bench:gate": "node --experimental-strip-types ./experiments/bench/b6-gate.mjs",
+    "test:e2e": "node scripts/run-unit-tests.mjs e2e"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/scripts/run-unit-tests.mjs
+++ b/scripts/run-unit-tests.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 const projectRoot = fileURLToPath(new URL("../", import.meta.url));
 const testsRoot = join(projectRoot, "tests");
 const integrationRoot = join(testsRoot, "integration");
+const e2eRoot = join(testsRoot, "e2e");
 const manifestPath = join(testsRoot, ".test-manifest.json");
 const suite = process.argv[2] ?? "unit";
 const wantSelfCheck = process.argv.includes("--selfcheck");
@@ -20,11 +21,14 @@ function discover(directory) {
 
 const unitFiles = discover(testsRoot);
 const integrationFiles = discover(integrationRoot);
+const e2eFiles = discover(e2eRoot);
 const testFiles = suite === "integration"
 	? integrationFiles
-	: suite === "all"
-		? [...unitFiles, ...integrationFiles]
-		: unitFiles;
+	: suite === "e2e"
+		? e2eFiles
+		: suite === "all"
+			? [...unitFiles, ...integrationFiles, ...e2eFiles]
+			: unitFiles;
 
 if (testFiles.length === 0) {
 	throw new Error("No " + suite + " test files were discovered.");
@@ -40,8 +44,9 @@ if (wantWriteManifest) {
 		note: "Expected test-entry manifest for the runner self-check (npm run test:selfcheck). Regenerate with: node scripts/run-unit-tests.mjs --write-manifest",
 		unitFiles: unitFiles.map((file) => file.replace(projectRoot, ".")),
 		integrationFiles: integrationFiles.map((file) => file.replace(projectRoot, ".")),
+		e2eFiles: e2eFiles.map((file) => file.replace(projectRoot, ".")),
 	}, null, 2) + "\n");
-	console.log("Wrote " + manifestPath + " (" + unitFiles.length + " unit, " + integrationFiles.length + " integration entries).");
+	console.log("Wrote " + manifestPath + " (" + unitFiles.length + " unit, " + integrationFiles.length + " integration, " + e2eFiles.length + " e2e entries).");
 	process.exit(0);
 }
 
@@ -53,18 +58,21 @@ if (wantSelfCheck) {
 	const rel = (file) => file.replace(projectRoot, ".");
 	const expectedUnit = new Set(manifest.unitFiles ?? []);
 	const expectedIntegration = new Set(manifest.integrationFiles ?? []);
+	const expectedE2e = new Set(manifest.e2eFiles ?? []);
 	const problems = [];
 	for (const file of unitFiles) if (!expectedUnit.has(rel(file))) problems.push("unexpected unit entry: " + rel(file));
 	for (const file of integrationFiles) if (!expectedIntegration.has(rel(file))) problems.push("unexpected integration entry: " + rel(file));
+	for (const file of e2eFiles) if (!expectedE2e.has(rel(file))) problems.push("unexpected e2e entry: " + rel(file));
 	for (const file of manifest.unitFiles ?? []) if (!unitFiles.map(rel).includes(file)) problems.push("missing unit entry: " + file);
 	for (const file of manifest.integrationFiles ?? []) if (!integrationFiles.map(rel).includes(file)) problems.push("missing integration entry: " + file);
+	for (const file of manifest.e2eFiles ?? []) if (!e2eFiles.map(rel).includes(file)) problems.push("missing e2e entry: " + file);
 	if (problems.length > 0) {
 		console.error("Runner self-check FAILED:");
 		for (const problem of problems) console.error("  - " + problem);
 		console.error("Refresh the manifest with: node scripts/run-unit-tests.mjs --write-manifest");
 		process.exit(1);
 	}
-	console.log("Runner self-check OK: " + unitFiles.length + " unit + " + integrationFiles.length + " integration entries match " + manifestPath + ".");
+	console.log("Runner self-check OK: " + unitFiles.length + " unit + " + integrationFiles.length + " integration + " + e2eFiles.length + " e2e entries match " + manifestPath + ".");
 }
 
 // ---- Execution ---------------------------------------------------------

--- a/tests/.test-manifest.json
+++ b/tests/.test-manifest.json
@@ -3,6 +3,8 @@
   "note": "Expected test-entry manifest for the runner self-check (npm run test:selfcheck). Regenerate with: node scripts/run-unit-tests.mjs --write-manifest",
   "unitFiles": [
     ".tests/goal-accounting-runtime.test.ts",
+    ".tests/goal-activity.test.ts",
+    ".tests/goal-audit-dashboard.test.ts",
     ".tests/goal-auditor-selector.test.ts",
     ".tests/goal-auditor.test.ts",
     ".tests/goal-budget.test.ts",
@@ -10,6 +12,8 @@
     ".tests/goal-compaction.test.ts",
     ".tests/goal-core-tools.test.ts",
     ".tests/goal-core.test.ts",
+    ".tests/goal-dashboard-golden.test.ts",
+    ".tests/goal-dashboard-model.test.ts",
     ".tests/goal-deferred-archival.test.ts",
     ".tests/goal-draft.test.ts",
     ".tests/goal-drafting.test.ts",
@@ -32,7 +36,9 @@
     ".tests/goal-service.test.ts",
     ".tests/goal-settings.test.ts",
     ".tests/goal-stale-continuation-golden.test.ts",
+    ".tests/goal-status.test.ts",
     ".tests/goal-surface-baseline.test.ts",
+    ".tests/goal-task-lifecycle.test.ts",
     ".tests/goal-task-tools.test.ts",
     ".tests/goal-tasks.test.ts",
     ".tests/goal-tool-names.test.ts",
@@ -49,5 +55,8 @@
   ],
   "integrationFiles": [
     ".tests/integration/extension.test.ts"
+  ],
+  "e2eFiles": [
+    ".tests/e2e/goal-lifecycle-dashboard.test.ts"
   ]
 }

--- a/tests/e2e/goal-lifecycle-dashboard.test.ts
+++ b/tests/e2e/goal-lifecycle-dashboard.test.ts
@@ -1,0 +1,351 @@
+/**
+ * End-to-end goal lifecycle test (plan §19.9): guided creation → clarification
+ * → confirmation → auto-start → task focus → dashboard states → completion →
+ * staged audit → approval → deferred archival → reload.
+ *
+ * Runs the REAL extension (goalExtension) with a mock auditor; the dashboard
+ * assertions derive from the persisted goal through the shared pure model
+ * (the same pipeline the widget uses), so the visible dashboard is proven to
+ * reflect real persisted state (§2.2).
+ */
+
+import { mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import goalExtension from "../../extensions/goal.ts";
+import { readGoalLedger } from "../../extensions/goal-ledger.ts";
+import type { GoalRecord } from "../../extensions/goal-record.ts";
+import { parseGoalFile, readActiveGoalFiles } from "../../extensions/storage/goal-files.ts";
+import { deriveGoalDashboardModel } from "../../extensions/widgets/goal-dashboard-model.ts";
+import { renderCompactDashboard, renderExpandedDashboard } from "../../extensions/widgets/goal-dashboard-renderer.ts";
+import { deriveAuditorDashboardModel } from "../../extensions/widgets/auditor-dashboard-model.ts";
+
+const theme = {
+	fg: (_color: string, value: string) => value,
+	bold: (value: string) => value,
+} as never;
+
+const CONFIRM_ANSWER = "Confirm — create this goal now";
+
+interface StageRecord {
+	label: string;
+	percentage: number;
+}
+
+function createHarness(cwd: string, opts: { runCompletionAuditor?: (...args: any[]) => Promise<any> } = {}) {
+	const handlers = new Map<string, Function>();
+	const commands = new Map<string, any>();
+	const tools = new Map<string, any>();
+	const notifications: string[] = [];
+	const entries: unknown[] = [];
+	let dialogResolve: ((result: any) => void) | null = null;
+	let hasDialogPending = false;
+	const pi = {
+		registerTool: (def: any) => { tools.set(def.name, def); },
+		registerCommand: (name: string, def: any) => { commands.set(name, def); },
+		on: (event: string, handler: Function) => { handlers.set(event, handler); },
+		appendEntry: (customType: string, data: unknown) => { entries.push({ type: "custom", customType, data }); },
+		registerMessageRenderer: () => {},
+		sendUserMessage: () => {},
+		sendMessage: () => {},
+		getActiveTools: () => ["read", "bash", "edit", "write"],
+		setActiveTools: () => {},
+		hasUI: true,
+	};
+	const ctx = {
+		cwd,
+		hasUI: true,
+		sessionManager: {
+			getBranch: () => [...entries],
+			getCwd: () => cwd,
+			getSessionId: () => "lifecycle-e2e-session",
+			getRoot: () => cwd,
+		},
+		ui: {
+			notify: (message: string) => { notifications.push(message); },
+			setStatus: () => {},
+			setWidget: () => {},
+			onTerminalInput: () => () => {},
+			select: async () => undefined,
+			confirm: async () => true,
+			custom: async () => new Promise((resolve) => { dialogResolve = resolve; hasDialogPending = true; }),
+		},
+		getSystemPrompt: () => "base",
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		abort: () => {},
+	} as unknown as ExtensionContext;
+	goalExtension(pi as any, { runCompletionAuditor: opts.runCompletionAuditor });
+	return {
+		ctx,
+		commands,
+		tools,
+		handlers,
+		notifications,
+		get core() { return (pi as unknown as { _goalCore: any })._goalCore; },
+		dialogResult: (result: unknown) => { hasDialogPending = false; dialogResolve?.(result); },
+		hasDialog: () => hasDialogPending,
+		sessionStart: async () => { await handlers.get("session_start")?.({ reason: "start" }, ctx); },
+		beforeAgentStart: async () => { await handlers.get("before_agent_start")?.({ systemPrompt: "base", prompt: "go", systemPromptOptions: {} }, ctx); },
+		turnEnd: async (message: unknown = { role: "assistant", stopReason: "stop", usage: { input: 0, output: 0 } }) => {
+			await handlers.get("turn_end")?.(message, ctx);
+		},
+	};
+}
+
+function activeGoalFiles(cwd: string): string[] {
+	try {
+		return readdirSync(path.join(cwd, ".pi", "goals")).filter((n) => n.startsWith("active_goal_"));
+	} catch {
+		return [];
+	}
+}
+
+function archivedGoalFiles(cwd: string): string[] {
+	try {
+		return readdirSync(path.join(cwd, ".pi", "goals", "archived")).filter((n) => n.startsWith("goal_"));
+	} catch {
+		return [];
+	}
+}
+
+function currentGoal(cwd: string): GoalRecord | null {
+	const files = activeGoalFiles(cwd);
+	if (files.length === 0) return null;
+	return parseGoalFile(path.join(cwd, ".pi", "goals", files[0]!));
+}
+
+function ledgerEvents(cwd: string): any[] {
+	return readGoalLedger({ cwd }).events as any[];
+}
+
+async function callTool(h: ReturnType<typeof createHarness>, name: string, callId: string, params: Record<string, unknown>) {
+	const tool = h.tools.get(name)!;
+	assert.ok(tool, `${name} tool must be registered`);
+	return tool.execute(callId, params, undefined, undefined, h.ctx);
+}
+
+function dashboardText(goal: GoalRecord, expanded: boolean, cwd: string): string {
+	const events = readGoalLedger({ cwd }).events.filter((e: any) => e.goalId === goal.id);
+	const model = deriveGoalDashboardModel(goal, { focused: true, otherOpenGoals: 0, ledgerEvents: events });
+	assert.ok(model, "dashboard model derives from the persisted goal");
+	const lines = expanded ? renderExpandedDashboard(model, theme, 100) : renderCompactDashboard(model, theme, 100);
+	return lines.join("\n");
+}
+
+test("full guided lifecycle: create → focus → tasks → audit → archive (§19.9)", async () => {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-lifecycle-e2e-"));
+	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
+	const staged: StageRecord[] = [];
+	const h = createHarness(cwd, {
+		runCompletionAuditor: async (args: any) => {
+			// §19.9 step 12: report all five audit stages through onProgress.
+			const stages: StageRecord[] = [
+				{ label: "Starting audit...", percentage: 0 },
+				{ label: "Inspecting files...", percentage: 25 },
+				{ label: "Verifying success criteria...", percentage: 50 },
+				{ label: "Evaluating evidence...", percentage: 75 },
+				{ label: "Producing report...", percentage: 95 },
+			];
+			for (const s of stages) {
+				staged.push(s);
+				args.onProgress?.({ recentOutput: [], phase: "running", elapsedMs: 1000, label: s.label, percentage: s.percentage });
+			}
+			args.onProgress?.({ recentOutput: [], phase: "done", elapsedMs: 2000, label: "Audit complete.", percentage: 100 });
+			return { approved: true, disapproved: false, output: "All requirements verified.\n<approved/>", model: "mock/auditor" };
+		},
+	});
+	try {
+		await h.sessionStart();
+		await h.beforeAgentStart();
+
+		// ── Step 1: guided goal creation ────────────────────────────────────
+		await h.commands.get("goal")!.handler("Add CSV export to the reports page", h.ctx);
+
+		// ── Step 2: clarification questions ─────────────────────────────────
+		const q = callTool(h, "goal_questionnaire", "q-1", {
+			questions: [{ id: "filters", question: "Which filters apply?", options: ["Active filters", "All rows"] }],
+		});
+		assert.ok(h.hasDialog(), "questionnaire dialog opens");
+		h.dialogResult({
+			questions: [{ id: "filters", question: "Which filters apply?", options: ["Active filters", "All rows"], allowCustom: true }],
+			answers: [{ id: "filters", question: "Which filters apply?", answer: "Active filters", wasCustom: false }],
+			cancelled: false,
+		});
+		const qResult = await q;
+		assert.ok(JSON.stringify(qResult.content[0].text).includes("Active filters"), "answer recorded");
+
+		// ── Step 3: confirm a five-task plan ────────────────────────────────
+		const objective = "Add CSV export to the reports page using active filters.\nSuccess criteria: exports match the visible columns.\nVerification contract: Run npm test (0 failures)";
+		const tasks = [
+			{ id: "t1", title: "Review reports page and data source" },
+			{ id: "t2", title: "Implement filtered CSV export" },
+			{ id: "t3", title: "Add the download button", subtasks: undefined as unknown as never },
+			{ id: "t4", title: "Add documentation" },
+			{ id: "t5", title: "Add and run tests" },
+		];
+		// Build the flat task list including t3's subtasks.
+		const flatTasks = [
+			{ id: "t1", title: "Review reports page and data source" },
+			{ id: "t2", title: "Implement filtered CSV export" },
+			{ id: "t3", title: "Add the download button", verification_contract: "The button downloads a CSV using the active filters." },
+			{ id: "t3.1", title: "Add loading state", parent_id: "t3" },
+			{ id: "t3.2", title: "Generate timestamped filename", parent_id: "t3" },
+			{ id: "t3.3", title: "Add error handling", parent_id: "t3" },
+			{ id: "t4", title: "Add documentation" },
+			{ id: "t5", title: "Add and run tests" },
+		];
+		const pending = callTool(h, "propose_goal_draft", "prop-1", { objective, sisyphus: false, tasks: flatTasks });
+		assert.ok(h.hasDialog(), "confirmation dialog opens");
+		h.dialogResult({ questions: [], answers: [{ id: "confirm", question: "Confirm Goal Draft", answer: CONFIRM_ANSWER, wasCustom: false }], cancelled: false });
+		await pending;
+		void tasks;
+
+		// ── Step 4: creation, focus, persistence, auto-continuation ─────────
+		let goal = currentGoal(cwd);
+		assert.ok(goal, "goal persisted to the active file");
+		assert.equal(goal.status, "active");
+		assert.equal(goal.autoContinue, true);
+		assert.ok(goal.verificationContract?.includes("npm test"), "verification contract extracted");
+		assert.equal(goal.taskList?.tasks.length, 5, "five top-level tasks");
+		const t3 = goal.taskList?.tasks.find((t) => t.id === "t3");
+		assert.deepEqual(t3?.subtasks?.map((s) => s.id), ["t3.1", "t3.2", "t3.3"], "nested tasks persisted");
+		assert.ok(h.core.focusedGoalId === goal.id, "goal is focused");
+		assert.ok(ledgerEvents(cwd).some((e) => e.type === "goal_created"), "goal_created ledger event");
+
+		// ── Step 5: start the first task ────────────────────────────────────
+		await callTool(h, "update_goal_task", "start-1", { task_id: "t1", status: "start" });
+		goal = currentGoal(cwd)!;
+		assert.equal(goal.currentTaskId, "t1", "start sets the persisted current task");
+
+		// ── Step 6: complete three of five top-level tasks ──────────────────
+		await callTool(h, "update_goal_task", "comp-1", { task_id: "t1", status: "complete", evidence: "Source reviewed" });
+		await callTool(h, "update_goal_task", "start-2", { task_id: "t2", status: "start" });
+		await callTool(h, "update_goal_task", "comp-2", { task_id: "t2", status: "complete", evidence: "Export implemented" });
+		await callTool(h, "update_goal_task", "start-3", { task_id: "t3", status: "start" });
+		await callTool(h, "update_goal_task", "comp-3", { task_id: "t3.1", status: "complete", evidence: "Loading state" });
+		await callTool(h, "update_goal_task", "comp-4", { task_id: "t3.2", status: "complete", evidence: "Filename" });
+		// §9.1: a skipped top-level task counts as done toward the main bar.
+		await callTool(h, "update_goal_task", "skip-1", { task_id: "t5", status: "skipped", reason: "Covered by t2" });
+
+		// ── Step 7: compact dashboard shows 3/5 · 60% + current + subtasks + contract ──
+		goal = currentGoal(cwd)!;
+		const compact = dashboardText(goal, false, cwd);
+		assert.match(compact, /3\/5 · 60%/, "compact dashboard shows 3/5 · 60%");
+		assert.match(compact, /Current  t3 · Add the download button/, "current task shown");
+		assert.match(compact, /Subtasks \[.*\] 2\/3 · 67%/, "subtask progress shown");
+		assert.match(compact, /Verify   Run npm test \(0 failures\)/, "verification contract shown");
+		assert.match(compact, /File     \.pi\/goals\/active_goal_/, "file path shown");
+
+		// ── Steps 8-9: expanded dashboard shows the full tree + current block ──
+		const expanded = dashboardText(goal, true, cwd);
+		assert.match(expanded, /├─ Tasks /);
+		for (const id of ["t1", "t2", "t3", "t4", "t5", "t3.1", "t3.2", "t3.3"]) {
+			assert.ok(expanded.includes(id), `task tree contains ${id}`);
+		}
+		assert.match(expanded, /▸ t3  Add the download button/, "current task highlighted");
+		assert.match(expanded, /~ t5  Add and run tests/, "skipped task marked");
+		assert.match(expanded, /├─ Current task /);
+		assert.match(expanded, /Subtasks \[.*\] 2\/3 · 67%/);
+		assert.match(expanded, /Contract: The button downloads a CSV/, "current-task contract shown");
+		assert.match(expanded, /├─ Verification /);
+
+		// ── Step 10: complete all tasks ─────────────────────────────────────
+		await callTool(h, "update_goal_task", "comp-5", { task_id: "t3.3", status: "complete", evidence: "Error handling" });
+		await callTool(h, "update_goal_task", "comp-6", { task_id: "t3", status: "complete", evidence: "Button works" });
+		await callTool(h, "update_goal_task", "comp-7", { task_id: "t4", status: "complete", evidence: "Docs written" });
+		goal = currentGoal(cwd)!;
+		assert.match(dashboardText(goal, false, cwd), /5\/5 · 100%/, "all tasks done");
+
+		// ── Step 11: request completion ─────────────────────────────────────
+		const completion = await callTool(h, "update_goal", "complete-1", { status: "complete" });
+		assert.ok(ledgerEvents(cwd).some((e) => e.type === "completion_requested"), "completion_requested ledger event");
+		assert.ok(ledgerEvents(cwd).some((e) => e.type === "audit_started"), "audit_started ledger event");
+
+		// ── Steps 12-13: staged audit + approval ────────────────────────────
+		assert.equal(staged.length, 5, "all five audit stages reported");
+		const lastStage = staged[staged.length - 1]!;
+		assert.equal(lastStage.label, "Producing report...");
+		// The structured dashboard at 72% would show workspace running (the
+		// stage derivation used by the audit widget).
+		const auditModel = deriveAuditorDashboardModel(
+			{ recentOutput: [], phase: "running", elapsedMs: 1000, label: "Evaluating evidence...", percentage: 72 },
+			{ auditorLabel: "mock/auditor" },
+		);
+		assert.deepEqual(auditModel.checks.map((c) => c.state), ["passed", "passed", "passed", "running", "pending"]);
+		assert.equal(h.core.auditResult?.verdict, "approved", "approval sets the result card");
+
+		// ── Step 14: deferred completion ────────────────────────────────────
+		goal = currentGoal(cwd)!;
+		assert.equal(goal.status, "complete", "goal marked complete but NOT archived yet");
+		assert.equal(archivedGoalFiles(cwd).length, 0, "deferred: not archived yet");
+		assert.ok(ledgerEvents(cwd).some((e) => e.type === "audit_result" && e.verdict === "approved"), "approved audit recorded");
+
+		// ── Steps 15-16: archive creation + final archive path ──────────────
+		await h.turnEnd();
+		const archived = archivedGoalFiles(cwd);
+		assert.equal(archived.length, 1, "archive created at turn_end");
+		const archivePath = `.pi/goals/archived/${archived[0]}`;
+		assert.ok(ledgerEvents(cwd).some((e) => e.type === "goal_archived" && e.archivePath === archivePath), "goal_archived ledger event with the real path");
+		assert.ok(ledgerEvents(cwd).some((e) => e.type === "goal_completed" && e.archivePath === archivePath), "goal_completed kept for compatibility");
+		assert.ok(h.notifications.some((n) => n.includes("Goal archived.") && n.includes(archivePath)), "success message emits the archive path");
+		assert.equal(activeGoalFiles(cwd).length, 0, "active record retired");
+
+		// ── Step 17: reload — the goal is no longer active ──────────────────
+		const reloaded = readActiveGoalFiles({ cwd });
+		assert.equal(reloaded.length, 0, "no active goals after reload");
+		const archivedRecord = parseGoalFile(path.join(cwd, ".pi", "goals", "archived", archived[0]!));
+		assert.equal(archivedRecord?.status, "complete", "archived record is complete and durable");
+	} finally {
+		try { rmSync(cwd, { recursive: true, force: true }); } catch {}
+	}
+});
+
+test("archive failure never reports success; the complete record stays recoverable (§16.6)", async () => {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-archive-fail-"));
+	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
+	const h = createHarness(cwd, {
+		runCompletionAuditor: async () => ({ approved: true, disapproved: false, output: "ok\n<approved/>", model: "mock/auditor" }),
+	});
+	try {
+		await h.sessionStart();
+		await h.beforeAgentStart();
+		await h.commands.get("goal-direct")!.handler("Ship the report feature.\nVerification contract: Run npm test (0 failures)", h.ctx);
+		let goal = currentGoal(cwd);
+		assert.ok(goal);
+		// Complete it through the normal deferred flow (approval).
+		await callTool(h, "update_goal", "c-1", { status: "complete" });
+		goal = currentGoal(cwd)!;
+		assert.equal(goal.status, "complete", "deferred completion before archive");
+
+		// Make the archive directory unwritable so the archive write fails.
+		const archiveDir = path.join(cwd, ".pi", "goals", "archived");
+		// eslint-disable-next-line n/no-unsupported-features/node-builtins
+		await import("node:fs/promises").then(async (fs) => { await fs.chmod(archiveDir, 0o555); });
+
+		await h.turnEnd();
+
+		// Failure behavior (§16.6): never claim success, keep the record
+		// recoverable at its active path, and write a diagnostic ledger event.
+		assert.equal(h.notifications.some((n) => n.includes("Goal archived.")), false, "failure must never report success");
+		assert.ok(
+			h.notifications.some((n) => n.includes("Failed to archive completed goal") && n.includes("remains at")),
+			"failure reports the remaining active path",
+		);
+		const events = ledgerEvents(cwd);
+		assert.ok(events.some((e) => e.type === "goal_archive_failed"), "diagnostic goal_archive_failed ledger event");
+		assert.equal(events.some((e) => e.type === "goal_archived"), false, "no goal_archived on failure");
+		// The complete record stays recoverable in the active directory.
+		const remaining = currentGoal(cwd);
+		assert.ok(remaining, "complete record remains recoverable");
+		assert.equal(remaining.status, "complete");
+	} finally {
+		// eslint-disable-next-line n/no-unsupported-features/node-builtins
+		await import("node:fs/promises").then(async (fs) => { await fs.chmod(path.join(cwd, ".pi", "goals", "archived"), 0o755).catch(() => {}); });
+		try { rmSync(cwd, { recursive: true, force: true }); } catch {}
+	}
+});

--- a/tests/goal-activity.test.ts
+++ b/tests/goal-activity.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Activity feed tests (plan §19.3): durable ledger events map to readable,
+ * capped, deduplicated activity items with task titles preferred over ids.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { deriveGoalActivity } from "../extensions/goal-activity.ts";
+import type { GoalLedgerEvent } from "../extensions/goal-ledger.ts";
+
+function ev(type: string, at: string, extra: Record<string, unknown> = {}): GoalLedgerEvent {
+	return { type, goalId: "g1", at, ...extra } as unknown as GoalLedgerEvent;
+}
+
+const TITLES = new Map<string, string>([
+	["t1", "Review reports page and data source"],
+	["t2", "Implement filtered CSV export"],
+	["t3", "Add the download button"],
+]);
+
+// ---------------------------------------------------------------------------
+// Event → readable text mapping
+// ---------------------------------------------------------------------------
+
+test("lifecycle events map to readable activity text", () => {
+	const events = [
+		ev("goal_created", "2026-01-01T09:00:00.000Z", { objective: "x", sisyphus: false, autoContinue: true }),
+		ev("goal_tweaked", "2026-01-01T09:01:00.000Z", { changeSummary: "plan" }),
+		ev("goal_paused", "2026-01-01T09:02:00.000Z", { reason: "User away", suggestedAction: "Resume later" }),
+		ev("goal_resumed", "2026-01-01T09:03:00.000Z", { reason: "Back" }),
+		ev("goal_blocked", "2026-01-01T09:04:00.000Z", { reason: "Missing API key", source: "agent" }),
+		ev("goal_budget_limited", "2026-01-01T09:05:00.000Z", { budget: 10000, tokensUsed: 10000 }),
+		ev("completion_requested", "2026-01-01T09:06:00.000Z", { summary: "done" }),
+		ev("audit_started", "2026-01-01T09:07:00.000Z", { provider: "anthropic", model: "x" }),
+		ev("audit_result", "2026-01-01T09:08:00.000Z", { verdict: "approved", report: "ok" }),
+		ev("goal_completed", "2026-01-01T09:09:00.000Z", { archivePath: ".pi/goals/archived/goal_g1.md" }),
+		ev("goal_archived", "2026-01-01T09:10:00.000Z", { archivePath: ".pi/goals/archived/goal_g1.md" }),
+	];
+	const texts = deriveGoalActivity(events, "g1", { limit: 20 }).map((a) => a.text);
+	assert.deepEqual(texts, [
+		"Created and focused the goal.",
+		"Updated the goal objective and task plan.",
+		"Paused the goal — User away",
+		"Resumed the goal.",
+		"Blocked — Missing API key",
+		"Reached the configured token budget.",
+		"Requested completion review.",
+		"Started independent completion review.",
+		"Independent auditor approved completion.",
+		"Completed the goal.",
+		"Archived the completed goal.",
+	]);
+});
+
+test("audit rejection and error verdicts map distinctly", () => {
+	const rejected = deriveGoalActivity([ev("audit_result", "2026-01-01T09:00:00.000Z", { verdict: "disapproved", report: "tests missing" })], "g1");
+	assert.equal(rejected[0].text, "Completion review requested additional work.");
+	const errored = deriveGoalActivity([ev("audit_result", "2026-01-01T09:00:00.000Z", { verdict: "error", report: "boom" })], "g1");
+	assert.equal(errored[0].text, "Completion review could not finish.");
+});
+
+test("audit-skipped distinguishes disabled from user-aborted", () => {
+	const disabled = deriveGoalActivity([ev("audit_skipped", "2026-01-01T09:00:00.000Z", { reason: "disabled" })], "g1");
+	assert.equal(disabled[0].text, "Skipped independent completion review (auditor disabled).");
+	const aborted = deriveGoalActivity([ev("audit_skipped", "2026-01-01T09:00:00.000Z", { reason: "user_aborted" })], "g1");
+	assert.equal(aborted[0].text, "Completion review was aborted by the user.");
+});
+
+test("task events prefer task titles over ids", () => {
+	const events = [
+		ev("task_started", "2026-01-01T09:00:00.000Z", { taskId: "t3" }),
+		ev("task_complete", "2026-01-01T09:05:00.000Z", { taskId: "t2", evidence: "All tests pass" }),
+		ev("task_skipped", "2026-01-01T09:06:00.000Z", { taskId: "t1", reason: "out of scope" }),
+		ev("task_reopened", "2026-01-01T09:07:00.000Z", { taskId: "t1" }),
+	];
+	const texts = deriveGoalActivity(events, "g1", { taskTitles: TITLES, limit: 20 }).map((a) => a.text);
+	assert.deepEqual(texts, [
+		"Started “Add the download button”.",
+		"Completed “Implement filtered CSV export”. — All tests pass",
+		"Skipped “Review reports page and data source” — out of scope.",
+		"Reopened “Review reports page and data source”.",
+	]);
+});
+
+test("unknown task ids fall back to the id in quotes", () => {
+	const items = deriveGoalActivity([ev("task_started", "2026-01-01T09:00:00.000Z", { taskId: "t9" })], "g1");
+	assert.equal(items[0].text, "Started “t9”.");
+});
+
+test("evidence is included only when concise", () => {
+	const short = deriveGoalActivity([ev("task_complete", "2026-01-01T09:00:00.000Z", { taskId: "t1", evidence: "Done" })], "g1", {
+		taskTitles: TITLES,
+	});
+	assert.equal(short[0].text, "Completed “Review reports page and data source”. — Done");
+	const longEvidence = "x".repeat(200);
+	const long = deriveGoalActivity([ev("task_complete", "2026-01-01T09:00:00.000Z", { taskId: "t1", evidence: longEvidence })], "g1", {
+		taskTitles: TITLES,
+	});
+	assert.equal(long[0].text, "Completed “Review reports page and data source”.");
+	assert.ok(!long[0].text.includes(longEvidence));
+});
+
+test("long reasons are truncated safely", () => {
+	const reason = "because ".repeat(60);
+	const items = deriveGoalActivity([ev("task_skipped", "2026-01-01T09:00:00.000Z", { taskId: "t1", reason })], "g1", {
+		taskTitles: TITLES,
+	});
+	assert.ok(items[0].text.length < 200);
+	assert.ok(items[0].text.endsWith("..."));
+});
+
+// ---------------------------------------------------------------------------
+// Ordering, dedupe, capping, filtering
+// ---------------------------------------------------------------------------
+
+test("items are ordered chronologically (oldest first)", () => {
+	const events = [
+		ev("task_complete", "2026-01-01T09:05:00.000Z", { taskId: "t2" }),
+		ev("task_started", "2026-01-01T09:00:00.000Z", { taskId: "t3" }),
+		ev("goal_created", "2026-01-01T08:59:00.000Z", { objective: "x", sisyphus: false, autoContinue: true }),
+	];
+	const ats = deriveGoalActivity(events, "g1", { limit: 20 }).map((a) => a.at);
+	assert.deepEqual(ats, ["2026-01-01T08:59:00.000Z", "2026-01-01T09:00:00.000Z", "2026-01-01T09:05:00.000Z"]);
+});
+
+test("duplicate lifecycle events are merged", () => {
+	const events = [
+		ev("goal_paused", "2026-01-01T09:00:00.000Z", { reason: "away" }),
+		ev("goal_paused", "2026-01-01T09:01:00.000Z", { reason: "away" }),
+		ev("goal_resumed", "2026-01-01T09:02:00.000Z", { reason: "back" }),
+		ev("goal_paused", "2026-01-01T09:03:00.000Z", { reason: "away again" }),
+	];
+	const texts = deriveGoalActivity(events, "g1", { limit: 20 }).map((a) => a.text);
+	assert.deepEqual(texts, ["Paused the goal — away", "Resumed the goal.", "Paused the goal — away again"]);
+});
+
+test("checkpoint noise is excluded", () => {
+	const events = [
+		ev("goal_created", "2026-01-01T09:00:00.000Z", { objective: "x", sisyphus: false, autoContinue: true }),
+		ev("goal_focused", "2026-01-01T09:00:01.000Z", { reason: "selected" }),
+		ev("goal_unfocused", "2026-01-01T09:00:02.000Z", { reason: "cleared" }),
+		ev("task_list_set", "2026-01-01T09:00:03.000Z", { taskCount: 5, blockCompletion: false }),
+		ev("goal_stalled", "2026-01-01T09:00:04.000Z", { reason: "no work" }),
+		ev("goal_budget_warning", "2026-01-01T09:00:05.000Z", { budget: 10000, tokensUsed: 9000, pct: 90 }),
+	];
+	const texts = deriveGoalActivity(events, "g1", { limit: 20 }).map((a) => a.text);
+	assert.deepEqual(texts, ["Created and focused the goal."]);
+});
+
+test("default cap is the latest five entries; full history is available on request", () => {
+	const events = [1, 2, 3, 4, 5, 6, 7].map((n) =>
+		ev("task_complete", `2026-01-01T09:0${n}:00.000Z`, { taskId: `t${n}` }),
+	);
+	const capped = deriveGoalActivity(events, "g1");
+	assert.equal(capped.length, 5);
+	assert.equal(capped[0].at, "2026-01-01T09:03:00.000Z");
+	const full = deriveGoalActivity(events, "g1", { limit: 100 });
+	assert.equal(full.length, 7);
+});
+
+test("only events for the requested goal are included", () => {
+	const events = [
+		ev("goal_created", "2026-01-01T09:00:00.000Z", { objective: "x", sisyphus: false, autoContinue: true }),
+		{ ...ev("goal_created", "2026-01-01T09:01:00.000Z", { objective: "other", sisyphus: false, autoContinue: true }), goalId: "g2" },
+	];
+	const items = deriveGoalActivity(events, "g1");
+	assert.equal(items.length, 1);
+	assert.equal(items[0].at, "2026-01-01T09:00:00.000Z");
+});

--- a/tests/goal-audit-dashboard.test.ts
+++ b/tests/goal-audit-dashboard.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Audit dashboard tests (plan §19.7): the five check stages transition
+ * pending → running → passed (decision → passed or failed), the auditor
+ * identity is shown, percentages clamp, expanded diagnostics retain tool
+ * details, the result cards render, and the normal dashboard returns after a
+ * finished audit (rejection keeps the goal open; approval shows the card).
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { AuditorProgress } from "../extensions/goal-auditor.ts";
+import {
+	deriveAuditResultCard,
+	deriveAuditorDashboardModel,
+	type AuditCheck,
+} from "../extensions/widgets/auditor-dashboard-model.ts";
+import { renderAuditResultCard, renderAuditorDashboard } from "../extensions/widgets/goal-dashboard-renderer.ts";
+import { GoalWidgetComponent, type AuditResultView } from "../extensions/widgets/goal-widget.ts";
+import { createMockTUI, createMockTheme } from "./tui-test-utils.ts";
+
+const theme = {
+	fg: (_color: string, value: string) => value,
+	bold: (value: string) => value,
+} as never;
+
+function progress(overrides: Partial<AuditorProgress> = {}): AuditorProgress {
+	return {
+		recentOutput: [],
+		phase: "running",
+		elapsedMs: 138000,
+		...overrides,
+	};
+}
+
+function checkState(model: ReturnType<typeof deriveAuditorDashboardModel>, id: string): AuditCheck["state"] {
+	return model.checks.find((c) => c.id === id)?.state ?? "pending";
+}
+
+test("objective: pending → running → passed as the audit advances", () => {
+	// No percentage yet: objective runs, everything else pending.
+	const start = deriveAuditorDashboardModel(progress({ percentage: undefined, label: "Starting audit..." }));
+	assert.equal(checkState(start, "objective"), "running");
+	assert.equal(checkState(start, "verification"), "pending");
+	assert.equal(checkState(start, "decision"), "pending");
+
+	// At 10% objective still runs.
+	const early = deriveAuditorDashboardModel(progress({ percentage: 10 }));
+	assert.equal(checkState(early, "objective"), "running");
+
+	// At 20% objective passes, verification starts.
+	const mid = deriveAuditorDashboardModel(progress({ percentage: 20 }));
+	assert.equal(checkState(mid, "objective"), "passed");
+	assert.equal(checkState(mid, "verification"), "running");
+});
+
+test("all five stages advance in order through percentage bands (§15.2)", () => {
+	const cases: Array<[number, string[]]> = [
+		[0, ["running", "pending", "pending", "pending", "pending"]],
+		[30, ["passed", "running", "pending", "pending", "pending"]],
+		[50, ["passed", "passed", "running", "pending", "pending"]],
+		[72, ["passed", "passed", "passed", "running", "pending"]],
+		[90, ["passed", "passed", "passed", "passed", "running"]],
+	];
+	for (const [pct, expected] of cases) {
+		const model = deriveAuditorDashboardModel(progress({ percentage: pct }));
+		const states = model.checks.map((c) => c.state);
+		assert.deepEqual(states, expected, `states at ${pct}%`);
+	}
+});
+
+test("decision passes on approval and fails on disapproval/error", () => {
+	const approved = deriveAuditorDashboardModel(progress({ phase: "done", percentage: 100 }), { verdict: "approved" });
+	assert.deepEqual(approved.checks.map((c) => c.state), ["passed", "passed", "passed", "passed", "passed"]);
+	assert.equal(approved.active, false);
+
+	const rejected = deriveAuditorDashboardModel(progress({ phase: "done", percentage: 100 }), { verdict: "disapproved" });
+	assert.equal(checkState(rejected, "decision"), "failed");
+	assert.deepEqual(rejected.checks.slice(0, 4).map((c) => c.state), ["passed", "passed", "passed", "passed"], "rejection keeps prior stages passed");
+
+	const errored = deriveAuditorDashboardModel(progress({ phase: "done", percentage: 100 }), { verdict: "error" });
+	assert.equal(checkState(errored, "decision"), "failed");
+});
+
+test("auditor identity is shown in the model and the rendered header", () => {
+	const model = deriveAuditorDashboardModel(progress(), { auditorLabel: "anthropic/claude-sonnet:high" });
+	assert.equal(model.auditorLabel, "anthropic/claude-sonnet:high");
+	const lines = renderAuditorDashboard(model, theme, 100);
+	assert.match(lines[0], /anthropic\/claude-sonnet:high/);
+	assert.match(lines[0], /2m18s/, "elapsed duration shown");
+});
+
+test("percentage clamps to [0, 100]", () => {
+	const negative = deriveAuditorDashboardModel(progress({ percentage: -20 }));
+	assert.equal(negative.percentage, 0);
+	const over = deriveAuditorDashboardModel(progress({ percentage: 150 }));
+	assert.equal(over.percentage, 100);
+});
+
+test("expanded diagnostics retain tool details only when requested", () => {
+	const p = progress({ currentTool: "read", currentToolArgs: '{"path":"src/parser.ts"}', recentOutput: ["checking file exists..."] });
+	const compact = renderAuditorDashboard(deriveAuditorDashboardModel(p), theme, 100).join("\n");
+	assert.doesNotMatch(compact, /tool read/);
+	assert.doesNotMatch(compact, /checking file exists/);
+	const expanded = renderAuditorDashboard(deriveAuditorDashboardModel(p), theme, 100, { showToolDetails: true }).join("\n");
+	assert.match(expanded, /tool read/);
+	assert.match(expanded, /src\/parser\.ts/);
+	assert.match(expanded, /checking file exists/);
+});
+
+test("failed audits show diagnostics automatically", () => {
+	const p = progress({ phase: "done", recentOutput: ["ERROR: cannot read package.json"] });
+	const model = deriveAuditorDashboardModel(p, { verdict: "error" });
+	const text = renderAuditorDashboard(model, theme, 100).join("\n");
+	assert.match(text, /ERROR: cannot read package.json/);
+});
+
+test("no rendered line exceeds the terminal width at 40..140 cols", () => {
+	const p = progress({ percentage: 72, currentTool: "read", currentToolArgs: "x".repeat(80), recentOutput: ["y".repeat(120)] });
+	for (const width of [40, 50, 60, 80, 100, 140]) {
+		for (const showToolDetails of [false, true]) {
+			const lines = renderAuditorDashboard(deriveAuditorDashboardModel(p), theme, width, { showToolDetails });
+			for (const line of lines) {
+				assert.ok(visibleWidth(line) <= width, `line exceeds ${width}: ${JSON.stringify(line.slice(0, 50))}`);
+			}
+		}
+		const card = renderAuditResultCard(deriveAuditResultCard("disapproved", "fix the tests".repeat(30)), theme, width);
+		for (const line of card) {
+			assert.ok(visibleWidth(line) <= width, `card line exceeds ${width}: ${JSON.stringify(line.slice(0, 50))}`);
+		}
+	}
+});
+
+test("result cards: approval, changes-required, error (§15.4)", () => {
+	const approved = deriveAuditResultCard("approved", "ok");
+	assert.equal(approved.label, "APPROVED");
+	assert.deepEqual(approved.lines, ["Objective satisfied.", "Verification requirements satisfied.", "Required tasks and evidence accepted."]);
+	const approvedText = renderAuditResultCard(approved, theme, 100).join("\n");
+	assert.match(approvedText, /Audit result ─ APPROVED/);
+
+	const rejected = deriveAuditResultCard("disapproved", [
+		"Audit report:",
+		"- Tests were not run after the final implementation change.",
+		"- Task \"Update documentation\" has no completion evidence.",
+		"<disapproved/>",
+	].join("\n"));
+	assert.equal(rejected.label, "CHANGES REQUIRED");
+	assert.deepEqual(rejected.lines, [
+		"Tests were not run after the final implementation change.",
+		"Task \"Update documentation\" has no completion evidence.",
+	]);
+	const rejectedText = renderAuditResultCard(rejected, theme, 100).join("\n");
+	assert.match(rejectedText, /✗ Tests were not run after the final implementation change[.]/);
+
+	const errored = deriveAuditResultCard("error", "timeout");
+	assert.equal(errored.label, "ERROR");
+});
+
+test("the normal dashboard returns after the audit result card clears", () => {
+	const { tui } = createMockTUI();
+	let auditResult: AuditResultView | null = { verdict: "disapproved", report: "- Tests were not run." };
+	const component = new GoalWidgetComponent({
+		tui,
+		theme: createMockTheme(),
+		getGoal: () => ({
+			id: "g1",
+			createdAt: "2026-01-01T00:00:00.000Z",
+			updatedAt: "2026-01-01T00:00:00.000Z",
+			objective: "=== Goal ===\nObjective: Fix the parser",
+			status: "active",
+			autoContinue: true,
+			usage: { activeSeconds: 10, tokensUsed: 100 },
+			sisyphus: false,
+			activePath: ".pi/goals/active_goal_g1.md",
+		}),
+		getOpenGoalCount: () => 1,
+		getAuditResult: () => auditResult,
+		getSettings: () => ({}),
+	});
+	const cardText = component.render(100).join("\n");
+	assert.match(cardText, /Audit result ─ CHANGES REQUIRED/);
+	assert.match(cardText, /✗ Tests were not run/);
+	// The goal stays open: clearing the card restores the normal dashboard.
+	auditResult = null;
+	const normal = component.render(100).join("\n");
+	assert.match(normal, /pi-goal-x ─ Fix the parser/);
+	assert.doesNotMatch(normal, /Audit result/);
+});

--- a/tests/goal-core-tools.test.ts
+++ b/tests/goal-core-tools.test.ts
@@ -76,7 +76,14 @@ function createHarness(options: HarnessOptions) {
 		abort: () => {},
 	} as unknown as ExtensionContext;
 	goalExtension(pi as any, { runCompletionAuditor: options.runCompletionAuditor });
-	return { handlers, commands, tools, ctx, get activeTools() { return [...activeTools]; } };
+	return {
+		handlers,
+		commands,
+		tools,
+		ctx,
+		get activeTools() { return [...activeTools]; },
+		get core() { return (pi as unknown as { _goalCore: any })._goalCore; },
+	};
 }
 
 function makeFixture(opts: { objective?: string; tokenBudget?: number; pauseReason?: string; status?: string } = {}) {
@@ -268,6 +275,8 @@ test("update_goal(complete) runs the auditor without a verification-summary para
 		const events = ledgerEvents(f.cwd);
 		assert.ok(events.some((e) => e.type === "audit_result" && (e as any).verdict === "approved"), "audit_result ledger event");
 		assert.ok(events.some((e) => e.type === "goal_completed"), "goal_completed ledger event");
+		// §15.4: approval shows the result card during deferred completion.
+		assert.equal(h.core.auditResult?.verdict, "approved", "approval sets the result card verdict");
 	} finally {
 		f.cleanup();
 	}
@@ -290,6 +299,10 @@ test("update_goal(complete) with a rejection keeps the goal open with feedback",
 		assert.equal(activeGoalFiles(f.cwd).length, 1, "goal stays open");
 		const events = ledgerEvents(f.cwd);
 		assert.ok(events.some((e) => e.type === "audit_result" && (e as any).verdict === "disapproved"), "disapproved audit recorded");
+		// §15.4: the result card state is set for the widget, then clears.
+		assert.deepEqual(h.core.auditResult?.verdict, "disapproved", "rejection sets the result card verdict");
+		h.core.clearAuditResult();
+		assert.equal(h.core.auditResult, null, "clearAuditResult restores the normal dashboard state");
 	} finally {
 		f.cleanup();
 	}

--- a/tests/goal-dashboard-golden.test.ts
+++ b/tests/goal-dashboard-golden.test.ts
@@ -189,7 +189,7 @@ test("unfocused panel is width-safe at every width", () => {
 	}
 });
 
-test("palette: gray borders, pastel task rows, accent current task (§5)", () => {
+test("palette: light frame, gray rules, colour-coded compact rows (§5)", () => {
 	const captured: Array<[string, string]> = [];
 	const colorTheme = {
 		fg: (color: string, value: string) => { captured.push([color, value]); return value; },
@@ -199,16 +199,25 @@ test("palette: gray borders, pastel task rows, accent current task (§5)", () =>
 	assert.ok(model);
 	renderCompactDashboard(model, colorTheme, 100);
 	renderExpandedDashboard(model, colorTheme, 100);
-	// Box borders come from the theme's gray (muted), never raw white/dim.
-	assert.ok(captured.some(([c]) => c === "muted"), "box borders use muted (theme gray)");
-	assert.equal(captured.some(([c]) => c === "borderMuted"), false);
-	// Task markers are colour-coded pastel: pending amber, complete green, skipped gray.
 	const byColor = (c: string) => captured.filter(([col]) => col === c).map(([, v]) => v);
+	// The outer frame is a light steel gray-blue (mdLink); interior rules stay
+	// the theme's gray (muted); the old dark border token is gone.
+	assert.ok(byColor("mdLink").some((v) => /^─+$/.test(v)), "outer frame fill is light (mdLink)");
+	assert.equal(byColor("borderMuted").length, 0, "the dark borderMuted token is not used");
+	assert.ok(byColor("muted").some((v) => /^─+$/.test(v)), "interior rule fills use the theme gray (muted)");
+	// Task markers are colour-coded pastel: pending amber, complete green, skipped gray.
 	assert.ok(byColor("mdHeading").includes("·"), "pending marker is pastel amber");
 	assert.ok(byColor("success").includes("✓"), "complete marker is muted green");
 	assert.ok(byColor("muted").includes("~"), "skipped marker is gray");
+	// Task ids share the marker color; titles stay pastel amber; the current
+	// task is fully accent (marker, id, title).
+	assert.ok(byColor("success").some((v) => v.includes("t1") || v.includes("t2")), "completed ids are muted green");
 	assert.ok(byColor("mdHeading").some((v) => v.includes("Review reports page")), "task titles are pastel amber");
-	assert.ok(byColor("accent").some((v) => v.includes("t3")), "current task stays accent (teal)");
+	assert.ok(byColor("accent").some((v) => v.includes("t3")), "current task id stays accent (teal)");
+	assert.ok(byColor("accent").some((v) => v.includes("Add the download button")), "current task title is accent too");
+	// The compact header brand is teal; progress fractions are accent.
+	assert.ok(byColor("accent").some((v) => v.includes("pi-goal-x")), "brand is accent");
+	assert.ok(byColor("accent").some((v) => v.includes("/")), "progress fractions are accent");
 	// No blinding #ffff00-style warning anywhere.
 	assert.equal(byColor("warning").length, 0, "the bright warning color is not used in the dashboard");
 });

--- a/tests/goal-dashboard-golden.test.ts
+++ b/tests/goal-dashboard-golden.test.ts
@@ -229,16 +229,16 @@ test("palette: neutral-gray chrome, colour-coded content (§5)", () => {
 	assert.ok(byColor("mdHeading").some((v) => v.includes("Review reports page")), "task titles are pastel amber");
 	assert.ok(byColor("accent").some((v) => v.includes("t3")), "current task id stays accent (teal)");
 	assert.ok(byColor("accent").some((v) => v.includes("Add the download button")), "current task title is accent too");
-	// The compact header brand is teal; the progress bar keeps its accent fill
-	// with dim empty cells.
+	// The compact header brand is teal; the progress bar is fully muted —
+	// neutral-gray fill with dim empty cells, matching the muted percentage.
 	assert.ok(byColor("accent").some((v) => v.includes("pi-goal-x")), "brand is accent");
-	assert.ok(byColor("accent").some((v) => /^█+$/.test(v)), "progress bar fill is accent");
+	assert.ok(muted.some((v) => /^█+$/.test(v)), "progress bar fill is neutral gray");
 	assert.ok(byColor("dim").some((v) => /^░+$/.test(v)), "progress bar empty cells are dim");
-	// The tasks percentage (fraction and percent) is neutral gray, not accent.
-	// (The current task's own subtask fraction stays accent — it is part of
-	// the current-task emphasis.)
+	// No accent progress numbers remain: the tasks percentage and the current
+	// task's subtask fraction are both neutral gray.
 	assert.ok(muted.some((v) => /^\d+\/\d+ · \d+%$/.test(v)), "tasks percentage is neutral gray");
-	assert.equal(byColor("accent").some((v) => /^\d+\/\d+ · \d+%$/.test(v)), false, "tasks percentage is no longer accent");
+	assert.ok(muted.some((v) => /^\d+\/\d+$/.test(v)), "subtask fraction is neutral gray");
+	assert.equal(byColor("accent").some((v) => /^\d+\/\d+/.test(v)), false, "no accent progress fractions remain");
 	// No blinding #ffff00-style warning anywhere.
 	assert.equal(byColor("warning").length, 0, "the bright warning color is not used in the dashboard");
 });

--- a/tests/goal-dashboard-golden.test.ts
+++ b/tests/goal-dashboard-golden.test.ts
@@ -189,7 +189,7 @@ test("unfocused panel is width-safe at every width", () => {
 	}
 });
 
-test("palette: light frame, gray rules, colour-coded compact rows (§5)", () => {
+test("palette: one-tone frame lines, gray rules, muted percentage, colour-coded rows (§5)", () => {
 	const captured: Array<[string, string]> = [];
 	const colorTheme = {
 		fg: (color: string, value: string) => { captured.push([color, value]); return value; },
@@ -200,11 +200,21 @@ test("palette: light frame, gray rules, colour-coded compact rows (§5)", () => 
 	renderCompactDashboard(model, colorTheme, 100);
 	renderExpandedDashboard(model, colorTheme, 100);
 	const byColor = (c: string) => captured.filter(([col]) => col === c).map(([, v]) => v);
+	const mdLink = byColor("mdLink");
 	// The outer frame is a light steel gray-blue (mdLink); interior rules stay
 	// the theme's gray (muted); the old dark border token is gone.
-	assert.ok(byColor("mdLink").some((v) => /^─+$/.test(v)), "outer frame fill is light (mdLink)");
+	assert.ok(mdLink.some((v) => /^─+$/.test(v)), "outer frame fill is light (mdLink)");
 	assert.equal(byColor("borderMuted").length, 0, "the dark borderMuted token is not used");
 	assert.ok(byColor("muted").some((v) => /^─+$/.test(v)), "interior rule fills use the theme gray (muted)");
+	// Frame lines are one tone: the blue-gray must appear on BOTH the left
+	// and the right of every frame line (regression: it used to read muted on
+	// one side and mdLink on the other).
+	assert.ok(mdLink.some((v) => v === "─"), "header leading dash is frame-colored (LHS)");
+	assert.ok(mdLink.some((v) => v.includes("Ctrl+Shift+T: expand tasks")), "footer hint is frame-colored, not muted");
+	assert.equal(byColor("muted").some((v) => v.includes("Ctrl+Shift+T")), false, "footer hint no longer muted");
+	assert.ok(mdLink.some((v) => v.includes("12m47s")), "header usage meta is frame-colored");
+	assert.ok(mdLink.some((v) => v.includes("Add CSV export to reports")), "header title is frame-colored");
+	assert.ok(byColor("muted").some((v) => v === "─ Tasks "), "section-rule label is part of the muted rule");
 	// Task markers are colour-coded pastel: pending amber, complete green, skipped gray.
 	assert.ok(byColor("mdHeading").includes("·"), "pending marker is pastel amber");
 	assert.ok(byColor("success").includes("✓"), "complete marker is muted green");
@@ -215,9 +225,16 @@ test("palette: light frame, gray rules, colour-coded compact rows (§5)", () => 
 	assert.ok(byColor("mdHeading").some((v) => v.includes("Review reports page")), "task titles are pastel amber");
 	assert.ok(byColor("accent").some((v) => v.includes("t3")), "current task id stays accent (teal)");
 	assert.ok(byColor("accent").some((v) => v.includes("Add the download button")), "current task title is accent too");
-	// The compact header brand is teal; progress fractions are accent.
+	// The compact header brand is teal; the progress bar keeps its accent fill
+	// with dim empty cells.
 	assert.ok(byColor("accent").some((v) => v.includes("pi-goal-x")), "brand is accent");
-	assert.ok(byColor("accent").some((v) => v.includes("/")), "progress fractions are accent");
+	assert.ok(byColor("accent").some((v) => /^█+$/.test(v)), "progress bar fill is accent");
+	assert.ok(byColor("dim").some((v) => /^░+$/.test(v)), "progress bar empty cells are dim");
+	// The tasks percentage (fraction and percent) is muted, not accent. (The
+	// current task's own subtask fraction stays accent — it is part of the
+	// current-task emphasis.)
+	assert.ok(byColor("muted").some((v) => /^\d+\/\d+ · \d+%$/.test(v)), "tasks percentage is muted");
+	assert.equal(byColor("accent").some((v) => /^\d+\/\d+ · \d+%$/.test(v)), false, "tasks percentage is no longer accent");
 	// No blinding #ffff00-style warning anywhere.
 	assert.equal(byColor("warning").length, 0, "the bright warning color is not used in the dashboard");
 });

--- a/tests/goal-dashboard-golden.test.ts
+++ b/tests/goal-dashboard-golden.test.ts
@@ -189,6 +189,30 @@ test("unfocused panel is width-safe at every width", () => {
 	}
 });
 
+test("palette: gray borders, pastel task rows, accent current task (§5)", () => {
+	const captured: Array<[string, string]> = [];
+	const colorTheme = {
+		fg: (color: string, value: string) => { captured.push([color, value]); return value; },
+		bold: (value: string) => value,
+	} as never;
+	const model = modelFor(withTasks(fiveTaskTree(), { currentTaskId: "t3" }));
+	assert.ok(model);
+	renderCompactDashboard(model, colorTheme, 100);
+	renderExpandedDashboard(model, colorTheme, 100);
+	// Box borders come from the theme's gray (muted), never raw white/dim.
+	assert.ok(captured.some(([c]) => c === "muted"), "box borders use muted (theme gray)");
+	assert.equal(captured.some(([c]) => c === "borderMuted"), false);
+	// Task markers are colour-coded pastel: pending amber, complete green, skipped gray.
+	const byColor = (c: string) => captured.filter(([col]) => col === c).map(([, v]) => v);
+	assert.ok(byColor("mdHeading").includes("·"), "pending marker is pastel amber");
+	assert.ok(byColor("success").includes("✓"), "complete marker is muted green");
+	assert.ok(byColor("muted").includes("~"), "skipped marker is gray");
+	assert.ok(byColor("mdHeading").some((v) => v.includes("Review reports page")), "task titles are pastel amber");
+	assert.ok(byColor("accent").some((v) => v.includes("t3")), "current task stays accent (teal)");
+	// No blinding #ffff00-style warning anywhere.
+	assert.equal(byColor("warning").length, 0, "the bright warning color is not used in the dashboard");
+});
+
 test("audit-running widget is width-safe at every width", () => {
 	for (const width of WIDTHS) {
 		assertWidthSafe(renderAuditorWidgetLines(auditorProgress(), theme, width), width);

--- a/tests/goal-dashboard-golden.test.ts
+++ b/tests/goal-dashboard-golden.test.ts
@@ -189,7 +189,7 @@ test("unfocused panel is width-safe at every width", () => {
 	}
 });
 
-test("palette: one-tone frame lines, gray rules, muted percentage, colour-coded rows (§5)", () => {
+test("palette: neutral-gray chrome, colour-coded content (§5)", () => {
 	const captured: Array<[string, string]> = [];
 	const colorTheme = {
 		fg: (color: string, value: string) => { captured.push([color, value]); return value; },
@@ -200,29 +200,29 @@ test("palette: one-tone frame lines, gray rules, muted percentage, colour-coded 
 	renderCompactDashboard(model, colorTheme, 100);
 	renderExpandedDashboard(model, colorTheme, 100);
 	const byColor = (c: string) => captured.filter(([col]) => col === c).map(([, v]) => v);
-	const mdLink = byColor("mdLink");
-	// The chrome is ONE tone: corners, top/bottom dashes, left/right edges
-	// and interior rules all carry the same light steel gray-blue (mdLink).
-	assert.ok(mdLink.some((v) => /^─+$/.test(v)), "outer frame fill is light (mdLink)");
-	assert.ok(mdLink.includes("│"), "vertical edges are frame-colored (mdLink)");
-	for (const glyph of ["╭", "╮", "├", "┤", "╰", "╯"]) {
-		assert.ok(mdLink.includes(glyph), `${glyph} corner is frame-colored`);
-	}
+	const muted = byColor("muted");
+	// The chrome is ONE neutral-gray tone (muted, #808080 — no blue tinge):
+	// corners, top/bottom dashes, left/right edges and interior rules all
+	// share it. The blue-gray mdLink token is banned from the dashboard.
+	assert.equal(byColor("mdLink").length, 0, "no blue-tinged mdLink anywhere — chrome is neutral gray");
 	assert.equal(byColor("borderMuted").length, 0, "the dark borderMuted token is not used");
-	assert.equal(byColor("muted").some((v) => /^─+$/.test(v)), false, "no muted dashes: the rules share the frame color");
-	assert.ok(mdLink.some((v) => v === "─ Tasks "), "section-rule label is part of the frame tone");
-	// Frame lines are one tone: the blue-gray must appear on BOTH the left
-	// and the right of every frame line (regression: it used to read muted on
-	// one side and mdLink on the other).
-	assert.ok(mdLink.some((v) => v === "─"), "header leading dash is frame-colored (LHS)");
-	assert.ok(mdLink.some((v) => v.includes("Ctrl+Shift+T: expand tasks")), "footer hint is frame-colored, not muted");
-	assert.equal(byColor("muted").some((v) => v.includes("Ctrl+Shift+T")), false, "footer hint no longer muted");
-	assert.ok(mdLink.some((v) => v.includes("12m47s")), "header usage meta is frame-colored");
-	assert.ok(mdLink.some((v) => v.includes("Add CSV export to reports")), "header title is frame-colored");
+	assert.ok(muted.some((v) => /^─+$/.test(v)), "top/bottom frame dashes are neutral gray");
+	assert.ok(muted.includes("│"), "vertical edges are neutral gray");
+	for (const glyph of ["╭", "╮", "├", "┤", "╰", "╯"]) {
+		assert.ok(muted.includes(glyph), `${glyph} corner is neutral gray`);
+	}
+	assert.ok(muted.some((v) => v === "─ Tasks "), "section-rule label is part of the frame tone");
+	// Frame lines are one tone: the gray must appear on BOTH the left and the
+	// right of every frame line (regression: it used to read muted on one
+	// side and mdLink on the other).
+	assert.ok(muted.some((v) => v === "─"), "header leading dash is frame-colored (LHS)");
+	assert.ok(muted.some((v) => v.includes("Ctrl+Shift+T: expand tasks")), "footer hint is part of the frame tone");
+	assert.ok(muted.some((v) => v.includes("12m47s")), "header usage meta is part of the frame tone");
+	assert.ok(muted.some((v) => v.includes("Add CSV export to reports")), "header title is part of the frame tone");
 	// Task markers are colour-coded pastel: pending amber, complete green, skipped gray.
 	assert.ok(byColor("mdHeading").includes("·"), "pending marker is pastel amber");
 	assert.ok(byColor("success").includes("✓"), "complete marker is muted green");
-	assert.ok(byColor("muted").includes("~"), "skipped marker is gray");
+	assert.ok(muted.includes("~"), "skipped marker is gray");
 	// Task ids share the marker color; titles stay pastel amber; the current
 	// task is fully accent (marker, id, title).
 	assert.ok(byColor("success").some((v) => v.includes("t1") || v.includes("t2")), "completed ids are muted green");
@@ -234,10 +234,10 @@ test("palette: one-tone frame lines, gray rules, muted percentage, colour-coded 
 	assert.ok(byColor("accent").some((v) => v.includes("pi-goal-x")), "brand is accent");
 	assert.ok(byColor("accent").some((v) => /^█+$/.test(v)), "progress bar fill is accent");
 	assert.ok(byColor("dim").some((v) => /^░+$/.test(v)), "progress bar empty cells are dim");
-	// The tasks percentage (fraction and percent) is muted, not accent. (The
-	// current task's own subtask fraction stays accent — it is part of the
-	// current-task emphasis.)
-	assert.ok(byColor("muted").some((v) => /^\d+\/\d+ · \d+%$/.test(v)), "tasks percentage is muted");
+	// The tasks percentage (fraction and percent) is neutral gray, not accent.
+	// (The current task's own subtask fraction stays accent — it is part of
+	// the current-task emphasis.)
+	assert.ok(muted.some((v) => /^\d+\/\d+ · \d+%$/.test(v)), "tasks percentage is neutral gray");
 	assert.equal(byColor("accent").some((v) => /^\d+\/\d+ · \d+%$/.test(v)), false, "tasks percentage is no longer accent");
 	// No blinding #ffff00-style warning anywhere.
 	assert.equal(byColor("warning").length, 0, "the bright warning color is not used in the dashboard");

--- a/tests/goal-dashboard-golden.test.ts
+++ b/tests/goal-dashboard-golden.test.ts
@@ -72,6 +72,20 @@ function fiveTaskTree(): GoalTask[] {
 	];
 }
 
+/** 30 top-level tasks; t5 and t20 completed (t20 latest) — the anchored
+ * viewport lands mid-list so both compact and expanded windows scroll in
+ * both directions. */
+function manyTaskTree(): GoalTask[] {
+	const tasks: GoalTask[] = Array.from({ length: 30 }, (_, i) => ({
+		id: `t${i + 1}`,
+		title: `Task number ${i + 1}`,
+		status: "pending" as const,
+	}));
+	tasks[4] = { ...tasks[4]!, status: "complete", completedAt: "2026-01-01T10:00:00.000Z" };
+	tasks[19] = { ...tasks[19]!, status: "complete", completedAt: "2026-01-01T11:00:00.000Z" };
+	return tasks;
+}
+
 function modelFor(goal: GoalRecord, opts: { focused?: boolean; otherOpenGoals?: number; ledgerEvents?: GoalLedgerEvent[] } = {}): ReturnType<typeof deriveGoalDashboardModel> {
 	return deriveGoalDashboardModel(goal, {
 		focused: opts.focused ?? true,
@@ -152,6 +166,20 @@ for (const width of WIDTHS) {
 			assertWidthSafe(renderCompactDashboard(model, theme, width), width);
 			assertWidthSafe(renderExpandedDashboard(model, theme, width), width);
 		}
+
+		// Scrolled viewports: a long list with completion timestamps at
+		// several window positions (anchored default, top, middle, off-scale)
+		// must stay width-safe — the ↑/↓ indicator rows count toward width.
+		const scrolled = withTasks(manyTaskTree(), { currentTaskId: "t21" });
+		const scrolledModel = modelFor(scrolled);
+		if (scrolledModel) {
+			assertWidthSafe(renderCompactDashboard(scrolledModel, theme, width), width);
+			assertWidthSafe(renderExpandedDashboard(scrolledModel, theme, width, { rows: 10 }), width);
+			for (const offset of [0, 3, 7, 99]) {
+				assertWidthSafe(renderCompactDashboard(scrolledModel, theme, width, { scrollOffset: offset }), width);
+				assertWidthSafe(renderExpandedDashboard(scrolledModel, theme, width, { rows: 10, scrollOffset: offset }), width);
+			}
+		}
 	});
 }
 
@@ -192,6 +220,46 @@ test("compact: top-level task list is shown by default with '+N more' overflow",
 	assert.ok(emptyModel);
 	const empty = renderCompactDashboard(emptyModel, theme, 100).join("\n");
 	assert.equal(empty.includes("├─ Tasks"), false);
+});
+
+test("compact: the default viewport anchors to the most recently completed tasks (§9.6)", () => {
+	const model = modelFor(withTasks(manyTaskTree(), { currentTaskId: "t21" }));
+	assert.ok(model);
+	// Wide (100): 5 rows; anchor t20 → window t16..t20, indicator on both sides.
+	const wide = renderCompactDashboard(model, theme, 100).join("\n");
+	assert.match(wide, /↑ 15 more tasks/);
+	assert.match(wide, /Task number 20/);
+	assert.doesNotMatch(wide, /[✓▸·~] t1\s/, "the earliest task row is hidden");
+	assert.match(wide, /… \+10 more tasks/);
+	// Minimal (40): 2 rows; the anchor stays the last visible row.
+	const minimal = renderCompactDashboard(model, theme, 40).join("\n");
+	assert.match(minimal, /↑ 18 more tasks/);
+	assert.match(minimal, /Task number 20/);
+});
+
+test("compact: an explicit scrollOffset windows the list and clamps at both ends", () => {
+	const model = modelFor(withTasks(manyTaskTree(), { currentTaskId: "t21" }));
+	assert.ok(model);
+	const top = renderCompactDashboard(model, theme, 100, { scrollOffset: 0 }).join("\n");
+	assert.doesNotMatch(top, /↑ \d+ more tasks/);
+	assert.match(top, /Task number 1/);
+	assert.match(top, /… \+25 more tasks/);
+	const tail = renderCompactDashboard(model, theme, 100, { scrollOffset: 99 }).join("\n");
+	assert.match(tail, /↑ 25 more tasks/);
+	assert.doesNotMatch(tail, /… \+\d+ more tasks/);
+});
+
+test("expanded: rows + scrollOffset window the tree with indicators; full tree by default", () => {
+	const model = modelFor(withTasks(manyTaskTree()));
+	assert.ok(model);
+	const mid = renderExpandedDashboard(model, theme, 100, { rows: 10, scrollOffset: 5 }).join("\n");
+	assert.match(mid, /↑ 5 more tasks/);
+	assert.match(mid, /Task number 6/);
+	assert.match(mid, /… \+15 more tasks/);
+	// No rows option → the whole tree is rendered (backward compatible).
+	const full = renderExpandedDashboard(model, theme, 100).join("\n");
+	assert.doesNotMatch(full, /↑ \d+ more tasks/);
+	assert.match(full, /Task number 30/);
 });
 
 test("compact: running with tasks at 100 shows status, progress, current, contract, file", () => {

--- a/tests/goal-dashboard-golden.test.ts
+++ b/tests/goal-dashboard-golden.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Dashboard golden tests (plan §19.4): render compact and expanded dashboards
+ * at 40/50/60/80/100/140 columns across every §5.5 layout mode and the §19.4
+ * state list. For every rendered line: visibleWidth(line) <= width.
+ *
+ * Rendering data always flows through the shared pure model
+ * (deriveGoalDashboardModel), so these tests also pin the model pipeline.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { GoalLedgerEvent } from "../extensions/goal-ledger.ts";
+import type { GoalRecord, GoalTask } from "../extensions/goal-record.ts";
+import { deriveGoalDashboardModel } from "../extensions/widgets/goal-dashboard-model.ts";
+import {
+	renderCompactDashboard,
+	renderExpandedDashboard,
+	renderUnfocusedDashboard,
+} from "../extensions/widgets/goal-dashboard-renderer.ts";
+import { renderAuditorWidgetLines, type AuditorWidgetProgress } from "../extensions/widgets/goal-widget.ts";
+
+const WIDTHS = [40, 50, 60, 80, 100, 140];
+
+const theme = {
+	fg: (_color: string, value: string) => value,
+	bold: (value: string) => value,
+} as never;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function task(id: string, title: string, overrides: Partial<GoalTask> = {}): GoalTask {
+	return { id, title, status: "pending", ...overrides };
+}
+
+function record(overrides: Partial<GoalRecord> = {}): GoalRecord {
+	return {
+		id: "g1",
+		objective: "Add CSV export to reports",
+		status: "active",
+		autoContinue: true,
+		usage: { tokensUsed: 18200, activeSeconds: 767 },
+		sisyphus: false,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		activePath: ".pi/goals/active_goal_g1.md",
+		...overrides,
+	};
+}
+
+function withTasks(taskList: GoalTask[], overrides: Partial<GoalRecord> = {}): GoalRecord {
+	return record({ ...overrides, taskList: { tasks: taskList, blockCompletion: false, proposedAt: "2026-01-01T00:00:00.000Z" } });
+}
+
+function fiveTaskTree(): GoalTask[] {
+	return [
+		task("t1", "Review reports page and data source", { status: "complete", evidence: "Reviewed source" }),
+		task("t2", "Implement filtered CSV export", { status: "complete" }),
+		task("t3", "Add the download button", {
+			verificationContract: "The button downloads a CSV using the active filters.",
+			subtasks: [
+				task("t3.1", "Add loading state", { status: "complete", evidence: "Loading state added" }),
+				task("t3.2", "Generate timestamped filename", { status: "complete" }),
+				task("t3.3", "Add error handling"),
+			],
+		}),
+		task("t4", "Add documentation"),
+		task("t5", "Add and run tests", { status: "skipped", skipReason: "Covered by t2" }),
+	];
+}
+
+function modelFor(goal: GoalRecord, opts: { focused?: boolean; otherOpenGoals?: number; ledgerEvents?: GoalLedgerEvent[] } = {}): ReturnType<typeof deriveGoalDashboardModel> {
+	return deriveGoalDashboardModel(goal, {
+		focused: opts.focused ?? true,
+		otherOpenGoals: opts.otherOpenGoals ?? 2,
+		ledgerEvents: opts.ledgerEvents ?? [],
+	});
+}
+
+function ledgerEventsFor(goalId: string): GoalLedgerEvent[] {
+	return [
+		{ type: "goal_created", goalId, objective: "Add CSV export to reports", sisyphus: false, autoContinue: true, at: "2026-01-01T09:00:00.000Z" },
+		{ type: "task_complete", goalId, taskId: "t2", evidence: "Done", at: "2026-01-01T09:05:00.000Z" },
+		{ type: "task_started", goalId, taskId: "t3.3", at: "2026-01-01T09:06:00.000Z" },
+	] as unknown as GoalLedgerEvent[];
+}
+
+function auditorProgress(): AuditorWidgetProgress {
+	return {
+		phase: "tool_executing",
+		elapsedMs: 138000,
+		currentTool: "read",
+		currentToolArgs: '{"path":"src/parser.ts"}',
+		recentOutput: ["checking file exists...", "confirming test coverage..."],
+		percentage: 72,
+		label: "Workspace inspection",
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Width-safety helper
+// ---------------------------------------------------------------------------
+
+function assertWidthSafe(lines: string[], width: number): void {
+	for (let i = 0; i < lines.length; i++) {
+		assert.ok(
+			visibleWidth(lines[i]) <= width,
+			`line ${i} at width ${width} has visible width ${visibleWidth(lines[i])}: ${JSON.stringify(lines[i].slice(0, 60))}`,
+		);
+	}
+}
+
+for (const width of WIDTHS) {
+	test(`width safety at ${width} cols: compact and expanded over all dashboard states`, () => {
+		const states: GoalRecord[] = [
+			// Running without tasks.
+			record(),
+			// Running with tasks.
+			withTasks(fiveTaskTree(), { currentTaskId: "t3", verificationContract: "Run npm test with zero failures." }),
+			// Paused.
+			record({ status: "paused", stopReason: "user", pauseReason: "User is away", pauseSuggestedAction: "Run /goal-resume when back." }),
+			// Blocked.
+			record({ status: "blocked", pauseReason: "Missing API key", pauseSuggestedAction: "Set the key and run /goal-resume." }),
+			// Budget limited.
+			record({ status: "budget_limited", tokenBudget: 20000 }),
+			// Complete (pre-archive).
+			withTasks(fiveTaskTree().map((t) => ({ ...t, status: "complete" as const, subtasks: t.subtasks?.map((s) => ({ ...s, status: "complete" as const, skipReason: undefined })) })), {
+				status: "complete",
+				activePath: undefined,
+				archivedPath: ".pi/goals/archived/goal_g1.md",
+			}),
+			// Long objective.
+			record({ objective: "x".repeat(600) }),
+			// Long path.
+			record({ activePath: `.pi/goals/${"a".repeat(200)}.md` }),
+			// Long contract.
+			record({ verificationContract: "Run ".repeat(60) }),
+			// Unicode content.
+			withTasks([
+				task("u1", "中文任务：处理報告数据", { status: "complete" }),
+				task("u2", "日本語のタスクと📊チャート"),
+				task("u3", "Combiné avec des caractères accentués"),
+			], { currentTaskId: "u2" }),
+		];
+
+		for (const goal of states) {
+			const model = modelFor(goal, { ledgerEvents: ledgerEventsFor(goal.id) });
+			if (!model) continue;
+			assertWidthSafe(renderCompactDashboard(model, theme, width), width);
+			assertWidthSafe(renderExpandedDashboard(model, theme, width), width);
+		}
+	});
+}
+
+test("unfocused panel is width-safe at every width", () => {
+	for (const width of WIDTHS) {
+		assertWidthSafe(renderUnfocusedDashboard(3, theme, width), width);
+	}
+});
+
+test("audit-running widget is width-safe at every width", () => {
+	for (const width of WIDTHS) {
+		assertWidthSafe(renderAuditorWidgetLines(auditorProgress(), theme, width), width);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Compact layout goldens (spot checks at fixed widths)
+// ---------------------------------------------------------------------------
+
+test("compact: top-level task list is shown by default with '+N more' overflow", () => {
+	const model = modelFor(withTasks(fiveTaskTree(), { currentTaskId: "t3" }));
+	assert.ok(model);
+	// Medium (80): four rows + overflow for the fifth.
+	const medium = renderCompactDashboard(model, theme, 80).join("\n");
+	assert.match(medium, /├─ Tasks /);
+	assert.match(medium, /✓ t1  Review reports page and data source/);
+	assert.match(medium, /… \+1 more task/);
+	// Wide (100): all five top-level rows fit, no overflow.
+	const wide = renderCompactDashboard(model, theme, 100).join("\n");
+	assert.match(wide, /~ t5  Add and run tests/);
+	assert.doesNotMatch(wide, /\+[0-9]+ more task/);
+	// Minimal (40): only the first two rows fit, the rest overflow.
+	const minimal = renderCompactDashboard(model, theme, 40).join("\n");
+	assert.match(minimal, /\+3 more tasks/);
+	assert.match(minimal, /✓ t1  /);
+	// No tasks → no task section at all.
+	const emptyModel = modelFor(record());
+	assert.ok(emptyModel);
+	const empty = renderCompactDashboard(emptyModel, theme, 100).join("\n");
+	assert.equal(empty.includes("├─ Tasks"), false);
+});
+
+test("compact: running with tasks at 100 shows status, progress, current, contract, file", () => {
+	const model = modelFor(withTasks(fiveTaskTree(), { currentTaskId: "t3", verificationContract: "Run npm test with zero failures." }));
+	assert.ok(model);
+	const lines = renderCompactDashboard(model, theme, 100);
+	const text = lines.join("\n");
+	assert.match(lines[0], /^╭─ pi-goal-x ─ Add CSV export to reports/);
+	assert.match(lines[0], /12m47s · 18.2K tok/);
+	assert.match(lines[1], /● In progress · Focused: yes · Other goals: 2/);
+	assert.match(text, /├─ Tasks /);
+	assert.match(text, /✓ t1  Review reports page and data source/);
+	assert.match(text, /▸ t3  Add the download button/);
+	assert.match(text, /· t4  Add documentation/);
+	assert.match(text, /~ t5  Add and run tests/);
+	assert.doesNotMatch(text, /\+[0-9]+ more task/, "all five top-level tasks fit at 100 cols");
+	assert.match(text, /Tasks  \[.*\] 3\/5 · 60%/);
+	assert.match(text, /Current  t3 · Add the download button/);
+	assert.match(text, /Subtasks \[.*\] 2\/3 · 67%/);
+	assert.match(text, /Verify   Run npm test with zero failures/);
+	assert.match(text, /File     \.pi\/goals\/active_goal_g1\.md/);
+	assert.match(lines.at(-1) ?? "", /Ctrl\+Shift\+T: expand tasks/);
+});
+
+test("compact: minimal mode at 40 keeps the essential summary", () => {
+	const model = modelFor(withTasks(fiveTaskTree(), { currentTaskId: "t3", verificationContract: "Run npm test with zero failures." }));
+	assert.ok(model);
+	const lines = renderCompactDashboard(model, theme, 40);
+	const text = lines.join("\n");
+	assert.match(text, /● In progress/);
+	assert.match(text, /Tasks  \[.*\] 3\/5 · 60%/);
+	assert.match(text, /▸ Add the download button/);
+	assert.doesNotMatch(text, /Other goals/);
+	assert.doesNotMatch(text, /File/);
+});
+
+test("compact: blocked state surfaces blocker and suggested action", () => {
+	const model = modelFor(record({ status: "blocked", pauseReason: "Build fails", pauseSuggestedAction: "Run npm test" }));
+	assert.ok(model);
+	const lines = renderCompactDashboard(model, theme, 100);
+	const text = lines.join("\n");
+	assert.match(text, /⊘ Blocked/);
+	assert.match(text, /Blocker  Build fails/);
+	assert.match(text, /Action   Run npm test/);
+});
+
+test("compact: paused state shows who paused and the reason", () => {
+	const model = modelFor(record({ status: "paused", stopReason: "agent", pauseReason: "Waiting for input" }));
+	assert.ok(model);
+	const text = renderCompactDashboard(model, theme, 100).join("\n");
+	assert.match(text, /◐ Paused \(agent\)/);
+	assert.match(text, /Reason   Waiting for input/);
+});
+
+test("compact: budget-limited state shows the budget summary", () => {
+	const model = modelFor(record({ status: "budget_limited", tokenBudget: 20000 }));
+	assert.ok(model);
+	const text = renderCompactDashboard(model, theme, 100).join("\n");
+	assert.match(text, /⛽ Budget 18\.2K \/ 20K · 91%/);
+	assert.match(text, /Budget limited/);
+});
+
+test("compact: complete state shows the §4.7 message", () => {
+	const model = modelFor(withTasks(fiveTaskTree().map((t) => ({ ...t, status: "complete" as const, subtasks: t.subtasks?.map((s) => ({ ...s, status: "complete" as const })) })), {
+		status: "complete",
+		activePath: undefined,
+		archivedPath: ".pi/goals/archived/goal_g1.md",
+	}));
+	assert.ok(model);
+	const text = renderCompactDashboard(model, theme, 100).join("\n");
+	assert.match(text, /All required work is complete/);
+	assert.match(text, /5\/5 · 100%/);
+});
+
+// ---------------------------------------------------------------------------
+// Expanded layout goldens
+// ---------------------------------------------------------------------------
+
+test("expanded: full dashboard at 100 shows sections and complete task tree", () => {
+	const model = modelFor(withTasks(fiveTaskTree(), { currentTaskId: "t3", verificationContract: "Run npm test with zero failures." }), {
+		ledgerEvents: ledgerEventsFor("g1"),
+	});
+	assert.ok(model);
+	const lines = renderExpandedDashboard(model, theme, 100);
+	const text = lines.join("\n");
+	assert.match(text, /├─ Progress /);
+	assert.match(text, /3\/5 tasks · 60%/);
+	assert.match(text, /├─ Tasks /);
+	assert.match(text, /✓ t1  Review reports page and data source/);
+	assert.match(text, /▸ t3  Add the download button/);
+	assert.match(text, /✓ t3\.1  Add loading state/);
+	assert.match(text, /· t4  Add documentation/);
+	assert.match(text, /├─ Current task /);
+	assert.match(text, /Subtasks \[.*\] 2\/3 · 67%/);
+	assert.match(text, /Contract: The button downloads a CSV using the active filters/);
+	assert.match(text, /├─ Verification /);
+	assert.match(text, /Run npm test with zero failures/);
+	assert.match(text, /├─ Recent activity /);
+	assert.match(text, /Started “Add error handling”/);
+	assert.match(lines.at(-1) ?? "", /Esc\/Ctrl\+Shift\+T: collapse/);
+});
+
+test("expanded: inferred current task is labelled", () => {
+	const model = modelFor(withTasks(fiveTaskTree()));
+	assert.ok(model);
+	const text = renderExpandedDashboard(model, theme, 100).join("\n");
+	assert.match(text, /Inferred from the first pending task/);
+});
+
+test("expanded: current nested subtask shows its depth in the tree", () => {
+	const model = modelFor(withTasks(fiveTaskTree(), { currentTaskId: "t3.3" }));
+	assert.ok(model);
+	const text = renderExpandedDashboard(model, theme, 100).join("\n");
+	assert.match(text, /▸ t3\.3  Add error handling/);
+	assert.match(text, /t3\.3 · Add error handling/);
+});
+
+test("expanded: no task sections when tasks are disabled (§9.5)", () => {
+	const model = modelFor(withTasks(fiveTaskTree(), { verificationContract: "Run the suite." }), {});
+	assert.ok(model);
+	// Re-derive with tasksDisabled (settings).
+	const disabled = deriveGoalDashboardModel(withTasks(fiveTaskTree(), { verificationContract: "Run the suite." }), {
+		focused: true,
+		otherOpenGoals: 1,
+		tasksDisabled: true,
+	});
+	assert.ok(disabled);
+	const text = renderExpandedDashboard(disabled, theme, 100).join("\n");
+	assert.doesNotMatch(text, /Tasks/);
+	assert.doesNotMatch(text, /Current task/);
+	assert.match(text, /Verification/);
+});

--- a/tests/goal-dashboard-golden.test.ts
+++ b/tests/goal-dashboard-golden.test.ts
@@ -201,11 +201,16 @@ test("palette: one-tone frame lines, gray rules, muted percentage, colour-coded 
 	renderExpandedDashboard(model, colorTheme, 100);
 	const byColor = (c: string) => captured.filter(([col]) => col === c).map(([, v]) => v);
 	const mdLink = byColor("mdLink");
-	// The outer frame is a light steel gray-blue (mdLink); interior rules stay
-	// the theme's gray (muted); the old dark border token is gone.
+	// The chrome is ONE tone: corners, top/bottom dashes, left/right edges
+	// and interior rules all carry the same light steel gray-blue (mdLink).
 	assert.ok(mdLink.some((v) => /^─+$/.test(v)), "outer frame fill is light (mdLink)");
+	assert.ok(mdLink.includes("│"), "vertical edges are frame-colored (mdLink)");
+	for (const glyph of ["╭", "╮", "├", "┤", "╰", "╯"]) {
+		assert.ok(mdLink.includes(glyph), `${glyph} corner is frame-colored`);
+	}
 	assert.equal(byColor("borderMuted").length, 0, "the dark borderMuted token is not used");
-	assert.ok(byColor("muted").some((v) => /^─+$/.test(v)), "interior rule fills use the theme gray (muted)");
+	assert.equal(byColor("muted").some((v) => /^─+$/.test(v)), false, "no muted dashes: the rules share the frame color");
+	assert.ok(mdLink.some((v) => v === "─ Tasks "), "section-rule label is part of the frame tone");
 	// Frame lines are one tone: the blue-gray must appear on BOTH the left
 	// and the right of every frame line (regression: it used to read muted on
 	// one side and mdLink on the other).
@@ -214,7 +219,6 @@ test("palette: one-tone frame lines, gray rules, muted percentage, colour-coded 
 	assert.equal(byColor("muted").some((v) => v.includes("Ctrl+Shift+T")), false, "footer hint no longer muted");
 	assert.ok(mdLink.some((v) => v.includes("12m47s")), "header usage meta is frame-colored");
 	assert.ok(mdLink.some((v) => v.includes("Add CSV export to reports")), "header title is frame-colored");
-	assert.ok(byColor("muted").some((v) => v === "─ Tasks "), "section-rule label is part of the muted rule");
 	// Task markers are colour-coded pastel: pending amber, complete green, skipped gray.
 	assert.ok(byColor("mdHeading").includes("·"), "pending marker is pastel amber");
 	assert.ok(byColor("success").includes("✓"), "complete marker is muted green");

--- a/tests/goal-dashboard-model.test.ts
+++ b/tests/goal-dashboard-model.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Dashboard model tests (plan §19.1): pure derivation of the unified
+ * dashboard view model from persisted goal state and the durable ledger.
+ *
+ * The model module must stay free of TUI imports; these tests exercise the
+ * derivation rules only (status codes, top-level progress, tree flattening,
+ * current-task resolution, subtask progress, budget, activity, formatting).
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { GoalLedgerEvent } from "../extensions/goal-ledger.ts";
+import type { GoalRecord, GoalTask } from "../extensions/goal-record.ts";
+import {
+	deriveCurrentTask,
+	deriveCurrentTaskSubtaskProgress,
+	deriveGoalDashboardModel,
+	deriveGoalStatus,
+	deriveTopLevelTaskProgress,
+	flattenTaskTree,
+	formatBudget,
+	formatCompactTokens,
+	formatDashboardDuration,
+	type DashboardTaskNode,
+} from "../extensions/widgets/goal-dashboard-model.ts";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function task(id: string, title: string, overrides: Partial<GoalTask> = {}): GoalTask {
+	return { id, title, status: "pending", ...overrides };
+}
+
+function goal(overrides: Partial<GoalRecord> = {}): GoalRecord {
+	return {
+		id: "g1",
+		objective: "Add CSV export to reports",
+		status: "active",
+		autoContinue: true,
+		usage: { tokensUsed: 18200, activeSeconds: 767 },
+		sisyphus: false,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+function model(
+	overrides: Partial<GoalRecord> = {},
+	opts: Partial<{ focused: boolean; otherOpenGoals: number; ledgerEvents: GoalLedgerEvent[]; activityLimit: number }> = {},
+) {
+	const m = deriveGoalDashboardModel(goal(overrides), { focused: true, otherOpenGoals: 0, ...opts });
+	if (!m) throw new Error("deriveGoalDashboardModel returned null for a non-null goal");
+	return m;
+}
+
+/** Standard five-top-level-task tree from the plan's examples. */
+function fiveTaskList(): GoalTask[] {
+	return [
+		task("t1", "Review reports page and data source", { status: "complete", evidence: "Reviewed source" }),
+		task("t2", "Implement filtered CSV export", { status: "complete" }),
+		task("t3", "Add the download button", {
+			verificationContract: "The button downloads a CSV using the active filters.",
+			subtasks: [
+				task("t3.1", "Add loading state", { status: "complete", evidence: "Loading state added" }),
+				task("t3.2", "Generate timestamped filename", { status: "complete" }),
+				task("t3.3", "Add error handling"),
+			],
+		}),
+		task("t4", "Add documentation"),
+		task("t5", "Add and run tests"),
+	];
+}
+
+function withTasks(taskList: GoalTask[]): Partial<GoalRecord> {
+	return { taskList: { tasks: taskList, blockCompletion: false, proposedAt: "2026-01-01T00:00:00.000Z" } };
+}
+
+function ev(type: string, at: string, extra: Record<string, unknown> = {}): GoalLedgerEvent {
+	return { type, goalId: "g1", at, ...extra } as unknown as GoalLedgerEvent;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+test("formatDashboardDuration renders compact h/m/s labels", () => {
+	assert.equal(formatDashboardDuration(0), "0s");
+	assert.equal(formatDashboardDuration(767), "12m47s");
+	assert.equal(formatDashboardDuration(3661), "1h01m01s");
+});
+
+test("formatCompactTokens renders compact token labels", () => {
+	assert.equal(formatCompactTokens(0), "0");
+	assert.equal(formatCompactTokens(999), "999");
+	assert.equal(formatCompactTokens(1200), "1.2K");
+	assert.equal(formatCompactTokens(18200), "18.2K");
+	assert.equal(formatCompactTokens(2_500_000), "2.5M");
+});
+
+test("formatBudget summarizes used/total/percentage", () => {
+	assert.equal(formatBudget(18200, 50000), "18.2K / 50K · 36%");
+	assert.equal(formatBudget(0, 0), "0 / 0 · 0%");
+});
+
+// ---------------------------------------------------------------------------
+// Status derivation
+// ---------------------------------------------------------------------------
+
+test("status maps lifecycle states to explicit display codes", () => {
+	assert.deepEqual(deriveGoalStatus(goal()), { code: "running", label: "In progress" });
+	assert.deepEqual(deriveGoalStatus(goal({ autoContinue: false })), { code: "idle", label: "Idle" });
+	assert.deepEqual(deriveGoalStatus(goal({ status: "paused", stopReason: "agent" })), { code: "paused", label: "Paused (agent)" });
+	assert.deepEqual(deriveGoalStatus(goal({ status: "paused", stopReason: "user" })), { code: "paused", label: "Paused (user)" });
+	assert.deepEqual(
+		deriveGoalStatus(goal({ status: "blocked", pauseReason: "Build fails", pauseSuggestedAction: "Run npm test" })),
+		{ code: "blocked", label: "Blocked", reason: "Build fails", suggestedAction: "Run npm test" },
+	);
+	assert.deepEqual(deriveGoalStatus(goal({ status: "budget_limited" })), { code: "budget_limited", label: "Budget limited" });
+	assert.deepEqual(deriveGoalStatus(goal({ status: "complete" })), { code: "complete", label: "Complete" });
+});
+
+// ---------------------------------------------------------------------------
+// Top-level progress (§9.1)
+// ---------------------------------------------------------------------------
+
+test("active goal without tasks has no progress sections", () => {
+	const m = model();
+	assert.equal(m.title, "Add CSV export to reports");
+	assert.equal(m.status.code, "running");
+	assert.equal(m.taskProgress, undefined);
+	assert.deepEqual(m.taskTree, []);
+	assert.equal(m.currentTask, undefined);
+});
+
+test("partial tasks derive 3/5 · 60% with skipped counted as done", () => {
+	const tasks = fiveTaskList();
+	tasks.push(task("t6", "Legacy fallback", { status: "skipped" }));
+	const m = model(withTasks(tasks));
+	assert.deepEqual(m.taskProgress, { completed: 3, total: 6, percentage: 50 });
+	// skipped is tracked separately in the tree but counts toward progress
+	const skipped = m.taskTree.find((n) => n.id === "t6");
+	assert.equal(skipped?.status, "skipped");
+});
+
+test("all top-level tasks complete derive 100% and no current task", () => {
+	const tasks = fiveTaskList().map((t) => ({
+		...t,
+		status: "complete" as const,
+		subtasks: t.subtasks?.map((s) => ({ ...s, status: "complete" as const })),
+	}));
+	const m = model(withTasks(tasks));
+	assert.deepEqual(m.taskProgress, { completed: 5, total: 5, percentage: 100 });
+	assert.equal(m.currentTask, undefined);
+});
+
+test("top-level progress counts only top-level tasks", () => {
+	const tasks = [task("a", "A", { status: "complete" }), task("b", "B", { subtasks: [task("b.1", "B1", { status: "complete" })] })];
+	assert.deepEqual(deriveTopLevelTaskProgress(goal(withTasks(tasks))), { completed: 1, total: 2, percentage: 50 });
+});
+
+// ---------------------------------------------------------------------------
+// Task tree flattening (§9.2)
+// ---------------------------------------------------------------------------
+
+test("flattenTaskTree walks the tree recursively with depth and current marker", () => {
+	const nodes = flattenTaskTree(fiveTaskList(), "t3.3");
+	const ids = nodes.map((n) => n.id);
+	assert.deepEqual(ids, ["t1", "t2", "t3", "t3.1", "t3.2", "t3.3", "t4", "t5"]);
+	assert.equal(nodes.find((n) => n.id === "t3.3")?.depth, 1);
+	assert.equal(nodes.find((n) => n.id === "t3")?.depth, 0);
+	assert.equal(nodes.find((n) => n.id === "t3.3")?.isCurrent, true);
+	assert.equal(nodes.filter((n) => n.isCurrent).length, 1);
+});
+
+test("flattenTaskTree with no tasks returns an empty tree", () => {
+	assert.deepEqual(flattenTaskTree(undefined), []);
+	assert.deepEqual(flattenTaskTree([]), []);
+});
+
+test("tree nodes carry verification contracts and evidence", () => {
+	const nodes = flattenTaskTree(fiveTaskList());
+	const t1 = nodes.find((n) => n.id === "t1");
+	const t3 = nodes.find((n) => n.id === "t3");
+	assert.equal(t1?.evidence, "Reviewed source");
+	assert.equal(t3?.verificationContract, "The button downloads a CSV using the active filters.");
+});
+
+// ---------------------------------------------------------------------------
+// Current task resolution (§7.2, §7.4, §9.3)
+// ---------------------------------------------------------------------------
+
+test("persisted current top-level task is resolved without inference", () => {
+	const m = model({ ...withTasks(fiveTaskList()), currentTaskId: "t3" });
+	assert.equal(m.currentTask?.id, "t3");
+	assert.equal(m.currentTask?.title, "Add the download button");
+	assert.equal(m.currentTask?.depth, 0);
+	assert.equal(m.currentTask?.inferred, undefined);
+	const t3 = m.taskTree.find((n) => n.id === "t3");
+	assert.equal(t3?.isCurrent, true);
+});
+
+test("current nested subtask is resolved with its depth", () => {
+	const m = model({ ...withTasks(fiveTaskList()), currentTaskId: "t3.3" });
+	assert.equal(m.currentTask?.id, "t3.3");
+	assert.equal(m.currentTask?.depth, 1);
+	assert.equal(m.taskTree.find((n) => n.id === "t3.3")?.isCurrent, true);
+});
+
+test("current parent task shows direct-child subtask progress", () => {
+	const m = model({ ...withTasks(fiveTaskList()), currentTaskId: "t3" });
+	assert.deepEqual(
+		{
+			completed: m.currentTask?.completedSubtasks,
+			total: m.currentTask?.totalSubtasks,
+			pct: m.currentTask?.subtaskPercentage,
+		},
+		{ completed: 2, total: 3, pct: 67 },
+	);
+});
+
+test("current leaf task omits subtask progress (all-zero totals)", () => {
+	const m = model({ ...withTasks(fiveTaskList()), currentTaskId: "t4" });
+	assert.equal(m.currentTask?.totalSubtasks, 0);
+	assert.equal(m.currentTask?.subtaskPercentage, 0);
+});
+
+test("invalid currentTaskId falls back to the first pending task and is marked inferred", () => {
+	const m = model({ ...withTasks(fiveTaskList()), currentTaskId: "t999" });
+	assert.equal(m.currentTask?.inferred, true);
+	assert.equal(m.currentTask?.id, "t3"); // first pending in tree order
+	assert.equal(m.currentTask?.completedSubtasks, 2); // subtask progress still derives
+});
+
+test("removed current task falls back to first pending", () => {
+	const tasks = [task("a", "A", { status: "complete" }), task("b", "B")];
+	const m = model({ ...withTasks(tasks), currentTaskId: "vanished" });
+	assert.equal(m.currentTask?.id, "b");
+	assert.equal(m.currentTask?.inferred, true);
+});
+
+test("currentTaskId pointing at a completed task is not accepted", () => {
+	const tasks = [task("a", "A", { status: "complete" }), task("b", "B")];
+	const m = model({ ...withTasks(tasks), currentTaskId: "a" });
+	assert.equal(m.currentTask?.id, "b");
+});
+
+test("deriveCurrentTask returns undefined when nothing is pending", () => {
+	const tasks = [task("a", "A", { status: "complete" })];
+	const nodes: DashboardTaskNode[] = flattenTaskTree(tasks);
+	assert.equal(deriveCurrentTask(goal(withTasks(tasks)), nodes), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Subtask progress rule (§9.3)
+// ---------------------------------------------------------------------------
+
+test("deriveCurrentTaskSubtaskProgress uses direct children of the parent", () => {
+	const tasks = fiveTaskList();
+	const progress = deriveCurrentTaskSubtaskProgress({ id: "t3" }, tasks);
+	assert.deepEqual(progress, { completedSubtasks: 2, totalSubtasks: 3, subtaskPercentage: 67 });
+});
+
+test("deriveCurrentTaskSubtaskProgress omits the ratio for a leaf", () => {
+	const tasks = fiveTaskList();
+	assert.deepEqual(deriveCurrentTaskSubtaskProgress({ id: "t4" }, tasks), { completedSubtasks: 0, totalSubtasks: 0, subtaskPercentage: 0 });
+});
+
+// ---------------------------------------------------------------------------
+// Verification visibility (§11)
+// ---------------------------------------------------------------------------
+
+test("goal-level and task-level verification contracts are surfaced", () => {
+	const m = model({
+		...withTasks(fiveTaskList()),
+		verificationContract: "Run npm test with zero failures.",
+		currentTaskId: "t3",
+	});
+	assert.equal(m.goalVerificationContract, "Run npm test with zero failures.");
+	assert.equal(m.currentTask?.verificationContract, "The button downloads a CSV using the active filters.");
+});
+
+// ---------------------------------------------------------------------------
+// Open goals / focus / path
+// ---------------------------------------------------------------------------
+
+test("other open goals and focus state are reflected", () => {
+	const m = model(withTasks(fiveTaskList()), { focused: false, otherOpenGoals: 2 });
+	assert.equal(m.focused, false);
+	assert.equal(m.otherOpenGoals, 2);
+});
+
+test("filePath prefers the active path and falls back to the archive path", () => {
+	const m = model({ activePath: ".pi/goals/active_goal_g1.md" });
+	assert.equal(m.filePath, ".pi/goals/active_goal_g1.md");
+	const archived = model({ status: "complete", activePath: undefined, archivedPath: ".pi/goals/archived/goal_g1.md" });
+	assert.equal(archived.filePath, ".pi/goals/archived/goal_g1.md");
+});
+
+test("no goal record derives a null model", () => {
+	assert.equal(deriveGoalDashboardModel(null, { focused: false, otherOpenGoals: 0 }), null);
+});
+
+// ---------------------------------------------------------------------------
+// Token budget
+// ---------------------------------------------------------------------------
+
+test("token budget derives used/total/percentage/remaining", () => {
+	const m = model({ tokenBudget: 50000 });
+	assert.deepEqual(m.budget, { used: 18200, total: 50000, percentage: 36, remaining: 31800 });
+});
+
+test("budget percentage clamps to 100 and remaining to zero", () => {
+	const m = model({ tokenBudget: 10000 });
+	assert.deepEqual(m.budget, { used: 18200, total: 10000, percentage: 100, remaining: 0 });
+});
+
+test("no budget means no budget section", () => {
+	assert.equal(model().budget, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Usage labels
+// ---------------------------------------------------------------------------
+
+test("usage derives elapsed and compact token labels", () => {
+	const m = model();
+	assert.equal(m.usage.activeSeconds, 767);
+	assert.equal(m.usage.elapsedLabel, "12m47s");
+	assert.equal(m.usage.tokens, 18200);
+	assert.equal(m.usage.tokenLabel, "18.2K tok");
+});
+
+// ---------------------------------------------------------------------------
+// Activity (§12 via the model)
+// ---------------------------------------------------------------------------
+
+test("recent activity is derived from the durable ledger", () => {
+	const events = [
+		ev("goal_created", "2026-01-01T09:00:00.000Z", { objective: "x", sisyphus: false, autoContinue: true }),
+		ev("task_complete", "2026-01-01T09:05:00.000Z", { taskId: "t2", evidence: "Done" }),
+		ev("task_started", "2026-01-01T09:06:00.000Z", { taskId: "t3" }),
+	];
+	const m = model(withTasks(fiveTaskList()), { ledgerEvents: events });
+	assert.deepEqual(
+		m.recentActivity.map((a) => a.text),
+		["Created and focused the goal.", "Completed “Implement filtered CSV export”. — Done", "Started “Add the download button”."],
+	);
+});
+
+test("activity respects the configured limit and excludes other goals", () => {
+	const events = [
+		ev("goal_created", "2026-01-01T09:00:00.000Z", { objective: "x", sisyphus: false, autoContinue: true }),
+		ev("task_complete", "2026-01-01T09:05:00.000Z", { taskId: "t1" }),
+		ev("task_complete", "2026-01-01T09:06:00.000Z", { taskId: "t2" }),
+		{ ...ev("goal_created", "2026-01-01T09:01:00.000Z", { objective: "other", sisyphus: false, autoContinue: true }), goalId: "g2" },
+	];
+	const m = model(withTasks(fiveTaskList()), { ledgerEvents: events, activityLimit: 2 });
+	assert.deepEqual(
+		m.recentActivity.map((a) => a.text),
+		["Completed “Review reports page and data source”.", "Completed “Implement filtered CSV export”."],
+	);
+});

--- a/tests/goal-dashboard-model.test.ts
+++ b/tests/goal-dashboard-model.test.ts
@@ -13,15 +13,22 @@ import test from "node:test";
 import type { GoalLedgerEvent } from "../extensions/goal-ledger.ts";
 import type { GoalRecord, GoalTask } from "../extensions/goal-record.ts";
 import {
+	anchoredScrollOffset,
+	clampScrollOffset,
+	compactTaskViewportRows,
 	deriveCurrentTask,
 	deriveCurrentTaskSubtaskProgress,
 	deriveGoalDashboardModel,
 	deriveGoalStatus,
+	deriveTaskListViewport,
 	deriveTopLevelTaskProgress,
 	flattenTaskTree,
 	formatBudget,
 	formatCompactTokens,
 	formatDashboardDuration,
+	latestCompletedNodeIndex,
+	maxScrollOffset,
+	taskViewportPageSize,
 	type DashboardTaskNode,
 } from "../extensions/widgets/goal-dashboard-model.ts";
 
@@ -186,6 +193,119 @@ test("tree nodes carry verification contracts and evidence", () => {
 	const t3 = nodes.find((n) => n.id === "t3");
 	assert.equal(t1?.evidence, "Reviewed source");
 	assert.equal(t3?.verificationContract, "The button downloads a CSV using the active filters.");
+});
+
+// ---------------------------------------------------------------------------
+// Task-list viewport / scroll (§9.6)
+// ---------------------------------------------------------------------------
+
+function nodesWithCompletions(completed: Array<[string, string]>): DashboardTaskNode[] {
+	const ids = ["t1", "t2", "t3", "t4", "t5", "t6", "t7"];
+	return ids.map((id, i) => {
+		const entry = completed.find(([tid]) => tid === id);
+		return {
+			id,
+			title: `Task ${id}`,
+			status: entry ? ("complete" as const) : ("pending" as const),
+			depth: 0,
+			isCurrent: false,
+			...(entry ? { completedAt: entry[1] } : {}),
+		};
+	});
+}
+
+test("latestCompletedNodeIndex picks the max completedAt and ties resolve to the last in plan order", () => {
+	const nodes = nodesWithCompletions([
+		["t1", "2026-01-01T10:00:00.000Z"],
+		["t2", "2026-01-01T11:00:00.000Z"],
+		["t5", "2026-01-01T09:00:00.000Z"],
+	]);
+	assert.equal(latestCompletedNodeIndex(nodes), 1); // t2
+	const tied = nodesWithCompletions([
+		["t2", "2026-01-01T11:00:00.000Z"],
+		["t5", "2026-01-01T11:00:00.000Z"],
+	]);
+	assert.equal(latestCompletedNodeIndex(tied), 4); // t5 wins the tie (last position)
+});
+
+test("latestCompletedNodeIndex returns -1 without completed/timestamped tasks", () => {
+	assert.equal(latestCompletedNodeIndex([]), -1);
+	assert.equal(latestCompletedNodeIndex(nodesWithCompletions([])), -1);
+	// status complete but no completedAt (legacy) does not qualify
+	const legacy = [{ id: "t1", title: "A", status: "complete" as const, depth: 0, isCurrent: false }];
+	assert.equal(latestCompletedNodeIndex(legacy), -1);
+	// skipped tasks never qualify
+	const skipped = [
+		{ id: "t1", title: "A", status: "skipped" as const, depth: 0, isCurrent: false, completedAt: "2026-01-01T10:00:00.000Z" },
+	];
+	assert.equal(latestCompletedNodeIndex(skipped), -1);
+});
+
+test("anchoredScrollOffset bottom-anchors the latest completion as the last visible row", () => {
+	// t5 completed last (index 4); a 3-row window ends at t5 → offset 2
+	const nodes = nodesWithCompletions([
+		["t1", "2026-01-01T10:00:00.000Z"],
+		["t2", "2026-01-01T11:00:00.000Z"],
+		["t5", "2026-01-01T12:00:00.000Z"],
+	]);
+	assert.equal(anchoredScrollOffset(nodes, 3), 2); // rows t3..t5, t5 at the bottom
+	assert.equal(anchoredScrollOffset(nodes, 5), 0); // t5 already the bottom row of the initial window
+	// anchor near the end clamps to the tail
+	const tail = nodesWithCompletions([["t6", "2026-01-01T12:00:00.000Z"]]);
+	assert.equal(anchoredScrollOffset(tail, 3), 3); // rows t4..t6, t6 at the bottom
+	// early completion with everything else pending stays at the top
+	const early = nodesWithCompletions([["t2", "2026-01-01T10:00:00.000Z"]]);
+	assert.equal(anchoredScrollOffset(early, 5), 0);
+	// no completions → top
+	assert.equal(anchoredScrollOffset(nodesWithCompletions([]), 3), 0);
+	// list fits entirely → top
+	assert.equal(anchoredScrollOffset(nodesWithCompletions([["t3", "2026-01-01T10:00:00.000Z"]]), 7), 0);
+	// long list: the most recent completion (t12) pulls the window to the tail,
+	// hiding the earliest tasks — the core ask
+	const longList: DashboardTaskNode[] = Array.from({ length: 12 }, (_, i) => ({
+		id: `t${i + 1}`,
+		title: `Task ${i + 1}`,
+		status: "pending" as const,
+		depth: 0,
+		isCurrent: false,
+	}));
+	longList[1] = { ...longList[1]!, status: "complete", completedAt: "2026-01-01T10:00:00.000Z" };
+	longList[11] = { ...longList[11]!, status: "complete", completedAt: "2026-01-01T11:00:00.000Z" };
+	assert.equal(anchoredScrollOffset(longList, 5), 7); // rows t8..t12
+});
+
+test("clampScrollOffset and maxScrollOffset bound the window", () => {
+	assert.equal(maxScrollOffset(7, 5), 2);
+	assert.equal(maxScrollOffset(3, 5), 0);
+	assert.equal(clampScrollOffset(-3, 7, 5), 0);
+	assert.equal(clampScrollOffset(99, 7, 5), 2);
+	assert.equal(clampScrollOffset(1.9, 7, 5), 1);
+	assert.equal(clampScrollOffset(2, 3, 5), 0);
+});
+
+test("compactTaskViewportRows matches the §5.5 width buckets", () => {
+	assert.equal(compactTaskViewportRows(140), 5);
+	assert.equal(compactTaskViewportRows(100), 5);
+	assert.equal(compactTaskViewportRows(99), 4);
+	assert.equal(compactTaskViewportRows(70), 4);
+	assert.equal(compactTaskViewportRows(69), 3);
+	assert.equal(compactTaskViewportRows(50), 3);
+	assert.equal(compactTaskViewportRows(49), 2);
+	assert.equal(compactTaskViewportRows(40), 2);
+});
+
+test("taskViewportPageSize is one viewport of rows", () => {
+	assert.equal(taskViewportPageSize(5), 5);
+	assert.equal(taskViewportPageSize(1), 1);
+	assert.equal(taskViewportPageSize(0), 1);
+});
+
+test("deriveTaskListViewport computes the window with hidden counts", () => {
+	const v = deriveTaskListViewport(9, 5, 2);
+	assert.deepEqual(v, { totalRows: 9, rows: 5, offset: 2, maxOffset: 4, hiddenAbove: 2, hiddenBelow: 2 });
+	assert.deepEqual(deriveTaskListViewport(9, 5, 99), { totalRows: 9, rows: 5, offset: 4, maxOffset: 4, hiddenAbove: 4, hiddenBelow: 0 });
+	assert.deepEqual(deriveTaskListViewport(4, 5, 3), { totalRows: 4, rows: 5, offset: 0, maxOffset: 0, hiddenAbove: 0, hiddenBelow: 0 });
+	assert.deepEqual(deriveTaskListViewport(0, 5, 0), { totalRows: 0, rows: 5, offset: 0, maxOffset: 0, hiddenAbove: 0, hiddenBelow: 0 });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/goal-drafting.test.ts
+++ b/tests/goal-drafting.test.ts
@@ -14,9 +14,11 @@ import assert from "node:assert/strict";
 
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import goalExtension from "../extensions/goal.ts";
-import { parseGoalFile } from "../extensions/storage/goal-files.ts";
+import { parseGoalFile, writeActiveGoalFile } from "../extensions/storage/goal-files.ts";
 import { readGoalLedger } from "../extensions/goal-ledger.ts";
 import { goalSettingsPath } from "../extensions/goal-settings.ts";
+import { proposalText, type ActiveGoalDraft } from "../extensions/goal-drafting.ts";
+import type { GoalRecord } from "../extensions/goal-record.ts";
 
 interface Harness {
 	ctx: ExtensionContext;
@@ -611,7 +613,7 @@ test("/goal-status reports state without initiating drafting", async () => {
 		// Unfocused with open goals: reports the pool without mutating.
 		await h.commands.get("goal-unfocus")!.handler("", h.ctx);
 		await h.commands.get("goal-status")!.handler("", h.ctx);
-		assert.ok(h.notifications.some((n) => n.includes("No goal is focused") && n.includes("open goal")), "pool summary reported");
+		assert.ok(h.notifications.some((n) => n.includes("open goal") && n.includes("/goal-focus")), "unfocused panel reported");
 	} finally {
 		try { rmSync(cwd, { recursive: true, force: true }); } catch {}
 	}
@@ -699,6 +701,275 @@ test("a tweak confirmation persists the auditor choice in the same transaction",
 		assert.ok(after.objective.includes("Revised objective"), "objective updated");
 		assert.equal(after.skipAuditor, true, "skipAuditor mutated in the tweak transaction");
 		assert.ok(ledgerEvents(cwd).some((e) => e.type === "goal_tweaked"), "tweak recorded");
+	} finally {
+		try { rmSync(cwd, { recursive: true, force: true }); } catch {}
+	}
+});
+
+// ── §14 durable proposal summary and confirmation polish ──────────────────
+
+test("confirmed proposal writes the durable summary and the richer confirmation report", async () => {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-draft-summary-"));
+	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
+	try {
+		const h = createHarness(cwd, { hasUI: true });
+		await h.sessionStart();
+		await h.commands.get("goal")!.handler("Add CSV export", h.ctx);
+		const objective = "Add CSV export to the reports page.\nSuccess criteria: exports use active filters.\nVerification contract: Run npm test (0 failures)";
+		const tasks = [
+			{ id: "review", title: "Review the reports page and data source" },
+			{ id: "export", title: "Implement filtered CSV export" },
+			{ id: "download", title: "Add the download control" },
+		];
+		const pending = runProposal(h, proposalParams(objective, { tasks }));
+		h.dialogResult({ questions: [], answers: [{ id: "confirm", question: "Confirm Goal Draft", answer: CONFIRM_ANSWER, wasCustom: false }], cancelled: false });
+		const result = await pending;
+		const text = result.content[0].text;
+		// Durable proposal summary in the transcript (§14).
+		assert.match(text, /Proposed objective:/);
+		assert.match(text, /Add CSV export to the reports page\./);
+		assert.match(text, /Proposed plan:/);
+		assert.match(text, /1\. Review the reports page and data source/);
+		assert.match(text, /2\. Implement filtered CSV export/);
+		assert.match(text, /Verification:/);
+		assert.match(text, /Run npm test \(0 failures\)/);
+		assert.match(text, /Automatic continuation: enabled/);
+		assert.match(text, /Independent auditor: enabled/);
+		// Richer confirmation output (§14).
+		assert.match(text, /✓ Goal created and focused\./);
+		assert.match(text, /Continuing automatically with the confirmed plan\./);
+		assert.match(text, /Goal id: /);
+		assert.match(text, /File: \.pi\/goals\/active_goal_/);
+		assert.match(text, /Tasks: 3/);
+		assert.match(text, /Verification: Run npm test \(0 failures\)/);
+		assert.match(text, /Auditor: enabled/);
+	} finally {
+		try { rmSync(cwd, { recursive: true, force: true }); } catch {}
+	}
+});
+
+test("questionnaire answers are captured in the confirmed-goal report (E5 §14)", async () => {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-draft-qa-echo-"));
+	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
+	try {
+		const h = createHarness(cwd, { hasUI: true });
+		await h.sessionStart();
+		await h.commands.get("goal")!.handler("Scope the migration", h.ctx);
+		const questionnaire = h.tools.get("goal_questionnaire");
+		const pendingQ = questionnaire.execute("q-echo", {
+			questions: [{ id: "scope", question: "Which systems?", options: ["A", "B"] }],
+		}, new AbortController().signal, undefined, h.ctx);
+		assert.ok(h.hasDialog());
+		h.dialogResult({
+			questions: [{ id: "scope", question: "Which systems?", options: ["A", "B"], allowCustom: true }],
+			answers: [{ id: "scope", question: "Which systems?", answer: "A", wasCustom: false }],
+			cancelled: false,
+		});
+		await pendingQ;
+		const pending = runProposal(h, proposalParams("Migrate systems A.\nSuccess criteria: all services moved."));
+		h.dialogResult({ questions: [], answers: [{ id: "confirm", question: "Confirm Goal Draft", answer: CONFIRM_ANSWER, wasCustom: false }], cancelled: false });
+		const result = await pending;
+		// The Q&A echo survives draft clearing and appears in the report.
+		assert.match(result.content[0].text, /Which systems\?/);
+		assert.match(result.content[0].text, /A/);
+	} finally {
+		try { rmSync(cwd, { recursive: true, force: true }); } catch {}
+	}
+});
+
+test("cancel and refine outcomes still carry the durable proposal summary", async () => {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-draft-summary-cancel-"));
+	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
+	try {
+		const h = createHarness(cwd, { hasUI: true });
+		await h.sessionStart();
+		await h.commands.get("goal")!.handler("Ship a feature", h.ctx);
+		// Cancel carries the summary.
+		const pendingCancel = runProposal(h, proposalParams("Ship a feature.\nSuccess criteria: tests pass."));
+		h.dialogResult({ questions: [], answers: [{ id: "confirm", question: "Confirm Goal Draft", answer: CANCEL_ANSWER, wasCustom: false }], cancelled: false });
+		const cancelled = await pendingCancel;
+		assert.match(cancelled.content[0].text, /Proposed objective:/);
+		assert.match(cancelled.content[0].text, /Draft cancelled/);
+		assert.equal(activeGoalFiles(cwd).length, 0, "cancel must not create a goal");
+		// Refine carries the summary and keeps the draft.
+		await h.commands.get("goal")!.handler("Ship a feature", h.ctx);
+		const pendingRefine = runProposal(h, proposalParams("Ship a feature.\nSuccess criteria: tests pass."));
+		h.dialogResult({ questions: [], answers: [{ id: "confirm", question: "Confirm Goal Draft", answer: CONTINUE_ANSWER, wasCustom: false }], cancelled: false });
+		const refined = await pendingRefine;
+		assert.match(refined.content[0].text, /Proposed objective:/);
+		assert.match(refined.content[0].text, /Automatic continuation: enabled/);
+		assert.match(refined.content[0].text, /refinement requested/);
+		assert.equal(activeGoalFiles(cwd).length, 0, "refining must not create a goal");
+	} finally {
+		try { rmSync(cwd, { recursive: true, force: true }); } catch {}
+	}
+});
+
+// ── F2 regression: proposals always show the task list exactly once ──────
+
+function testDraft(mode: ActiveGoalDraft["mode"], originalTopic: string): ActiveGoalDraft {
+	return { mode, originalTopic, startedAt: "2026-08-05T00:00:00.000Z", auditorEnabled: true };
+}
+
+function taskList(tasks: Array<{ id: string; title: string; status?: string }>) {
+	return {
+		tasks: tasks.map((t) => ({ id: t.id, title: t.title, status: (t.status ?? "pending") as "pending" })),
+		blockCompletion: false,
+		proposedAt: "2026-08-05T00:00:00.000Z",
+	};
+}
+
+function currentGoal(objective: string, tasks: Array<{ id: string; title: string; status?: string }>): GoalRecord {
+	return {
+		id: "g1",
+		objective,
+		status: "active",
+		autoContinue: true,
+		sisyphus: false,
+		taskList: taskList(tasks),
+	} as unknown as GoalRecord;
+}
+
+test("a numbered-step objective with no explicit tasks previews the derived task list in the confirmation", () => {
+	// Regression: the F2 preview derived from the boxed confirmation text
+	// (every line prefixed with "│   ") so the ordered-marker regex never
+	// matched and numbered objectives showed NO task list. Deriving from the
+	// raw objective must surface the derived tree in the confirmation.
+	const objective = "Ship the release.\n1) Implement core\n2) Add tests\n3) Write docs";
+	const text = proposalText(testDraft("goal", "Ship the release"), objective, true, undefined, undefined);
+	assert.match(text, /Tasks derived from the objective \(confirm or ask the agent to adjust\):/);
+	assert.match(text, /\[ \] step-1: Implement core/);
+	assert.match(text, /\[ \] step-2: Add tests/);
+	assert.match(text, /\[ \] step-3: Write docs/);
+	assert.doesNotMatch(text, /Tasks proposed for confirmation/);
+	assert.doesNotMatch(text, /Tasks derived from the objective[\s\S]*Tasks derived from the objective/, "derived preview appears exactly once");
+});
+
+test("a new-draft proposal with explicit tasks shows them once and never adds a derived block", () => {
+	const text = proposalText(
+		testDraft("goal", "Build a tool"),
+		"Build a tool.\n1) wire it\n2) test it",
+		true,
+		taskList([{ id: "t1", title: "Explicit task" }]),
+		undefined,
+	);
+	assert.equal((text.match(/Tasks proposed for confirmation:/g) ?? []).length, 1, "explicit list shown exactly once");
+	assert.equal((text.match(/Tasks derived from the objective/g) ?? []).length, 0, "no derived block when tasks are explicit");
+	assert.match(text, /\[ \] t1: Explicit task/);
+});
+
+test("a tweak confirmation renders the explicit task list exactly once", () => {
+	// Regression: buildTweakConfirmationText already renders tasks inside its
+	// ┌─ TASKS ─┐ box; appending a second "Tasks proposed" block duplicated it.
+	const current = currentGoal("Old objective.", [{ id: "old", title: "Old task", status: "complete" }]);
+	const text = proposalText(
+		testDraft("tweak", "Revise the plan"),
+		"New objective.",
+		true,
+		taskList([{ id: "new-1", title: "New task" }]),
+		current,
+	);
+	assert.equal((text.match(/┌─ TASKS ─/g) ?? []).length, 1, "the task box renders exactly once");
+	assert.equal((text.match(/Tasks proposed for confirmation:/g) ?? []).length, 0, "no duplicated appended list");
+	assert.match(text, /\[ \] new-1: New task/);
+	assert.doesNotMatch(text, /Current task list \(retained unchanged\):/, "explicit tasks replace the retained preview");
+});
+
+test("a tweak without explicit tasks previews the retained current list exactly once", () => {
+	const current = currentGoal("Old objective.", [{ id: "keep", title: "Retained task", status: "complete" }]);
+	const text = proposalText(testDraft("tweak", "Clarify wording"), "Clarified objective.", true, undefined, current);
+	assert.equal((text.match(/Current task list \(retained unchanged\):/g) ?? []).length, 1, "retained list shown exactly once");
+	assert.match(text, /\[ \] keep: Retained task/);
+	assert.equal((text.match(/┌─ TASKS ─/g) ?? []).length, 0, "no empty explicit task box");
+	assert.doesNotMatch(text, /Tasks proposed for confirmation:/);
+	assert.doesNotMatch(text, /Tasks derived from the objective/);
+});
+
+// ── §7.5 regression: a tweak never changes the status of persisting steps ─
+
+test("a tweak merges the proposed task list by id, preserving statuses of surviving steps", async () => {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-tweak-merge-"));
+	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
+	try {
+		const h = createHarness(cwd, { hasUI: true });
+		await h.sessionStart();
+		await h.commands.get("goal-direct")!.handler("Initial objective", h.ctx);
+		// Seed a task list on disk with a completed step, a removable step, and
+		// the current task. /goal-tweak reconciles from disk before drafting.
+		const goal = firstGoal(cwd);
+		writeActiveGoalFile({ cwd }, {
+			...goal,
+			currentTaskId: "ct",
+			taskList: {
+				tasks: [
+					{ id: "keep", title: "Surviving task", status: "complete", evidence: "Done it.", completedAt: "2026-08-05T10:00:00.000Z", verificationContract: "tests pass" },
+					{ id: "drop", title: "Removed task", status: "pending" },
+					{ id: "ct", title: "Current task", status: "pending" },
+				],
+				blockCompletion: false,
+				proposedAt: "2026-08-05T09:00:00.000Z",
+			},
+		});
+		await h.commands.get("goal-tweak")!.handler("Revise the scope", h.ctx);
+		const pending = runProposal(h, proposalParams("Revised objective", {
+			sisyphus: false,
+			tasks: [
+				{ id: "keep", title: "Surviving task (retitled)", verification_contract: "contract v2" },
+				{ id: "fresh", title: "Brand new task" },
+			],
+		}));
+		h.dialogResult({ questions: [], answers: [{ id: "confirm", question: "Confirm Goal Draft", answer: CONFIRM_ANSWER, wasCustom: false }], cancelled: false });
+		await pending;
+		const after = firstGoal(cwd);
+		const byId = new Map(after.taskList?.tasks.map((t) => [t.id, t]) ?? []);
+		const keep = byId.get("keep");
+		assert.equal(keep?.status, "complete", "persisting step keeps its status across the tweak");
+		assert.equal(keep?.evidence, "Done it.", "evidence preserved");
+		assert.equal(keep?.completedAt, "2026-08-05T10:00:00.000Z", "completedAt preserved");
+		assert.equal(keep?.verificationContract, "contract v2", "structural fields (contract) follow the proposal");
+		assert.equal(keep?.title, "Surviving task (retitled)", "structural fields follow the proposal");
+		assert.equal(byId.has("drop"), false, "removed step is dropped");
+		assert.equal(byId.has("ct"), false, "removed current task is dropped");
+		assert.equal(byId.get("fresh")?.status, "pending", "new step starts pending");
+		assert.equal(after.currentTaskId, undefined, "currentTaskId cleared when its task no longer survives pending");
+		const setEvent = ledgerEvents(cwd).find((e) => e.type === "task_list_set");
+		assert.equal(setEvent?.taskCount, 2, "ledger records the merged task count");
+	} finally {
+		try { rmSync(cwd, { recursive: true, force: true }); } catch {}
+	}
+});
+
+test("a tweak with no task list retains the current list and keeps its statuses", async () => {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-tweak-retain-"));
+	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
+	try {
+		const h = createHarness(cwd, { hasUI: true });
+		await h.sessionStart();
+		await h.commands.get("goal-direct")!.handler("Initial objective", h.ctx);
+		const goal = firstGoal(cwd);
+		writeActiveGoalFile({ cwd }, {
+			...goal,
+			currentTaskId: "do",
+			taskList: {
+				tasks: [
+					{ id: "do", title: "In progress", status: "pending" },
+					{ id: "done", title: "Already done", status: "complete", evidence: "Shipped.", completedAt: "2026-08-05T08:00:00.000Z" },
+				],
+				blockCompletion: false,
+				proposedAt: "2026-08-05T09:00:00.000Z",
+			},
+		});
+		await h.commands.get("goal-tweak")!.handler("Clarify the wording", h.ctx);
+		// No tasks in the proposal: the current list is retained unchanged.
+		const pending = runProposal(h, proposalParams("Clarified objective", { sisyphus: false }));
+		h.dialogResult({ questions: [], answers: [{ id: "confirm", question: "Confirm Goal Draft", answer: CONFIRM_ANSWER, wasCustom: false }], cancelled: false });
+		await pending;
+		const after = firstGoal(cwd);
+		const byId = new Map(after.taskList?.tasks.map((t) => [t.id, t]) ?? []);
+		assert.equal(byId.get("do")?.status, "pending", "pending task untouched");
+		assert.equal(byId.get("done")?.status, "complete", "completed task untouched");
+		assert.equal(after.currentTaskId, "do", "currentTaskId retained when its task is still pending");
+		assert.equal(ledgerEvents(cwd).some((e) => e.type === "task_list_set"), false, "no task_list_set event when the list is retained");
 	} finally {
 		try { rmSync(cwd, { recursive: true, force: true }); } catch {}
 	}

--- a/tests/goal-enhancements.test.ts
+++ b/tests/goal-enhancements.test.ts
@@ -91,14 +91,12 @@ describe("E4 budget line in the widget", () => {
 		goal.usage = { tokensUsed: 45000, activeSeconds: 0 };
 		const lines = renderGoalWidgetLines(goal, theme, 100, { openGoalCount: 1 });
 		const joined = lines.join("\n");
-		assert.match(joined, /Budget:/);
-		assert.match(joined, /45% used/);
-		assert.match(joined, /remaining/);
+		assert.match(joined, /Budget 45K \/ 100K · 45%/);
 	});
 
 	it("omits the budget line when no budget is set", () => {
 		const goal = makeGoalRecord({ objective: "No budget" });
 		const lines = renderGoalWidgetLines(goal, theme, 100, { openGoalCount: 1 });
-		assert.equal(lines.join("\n").includes("Budget:"), false);
+		assert.equal(lines.join("\n").includes("Budget"), false);
 	});
 });

--- a/tests/goal-features.test.ts
+++ b/tests/goal-features.test.ts
@@ -171,9 +171,10 @@ describe("F4 sisyphus ordered-step widget", () => {
 		};
 		const lines = renderGoalWidgetLines(goal, theme, 100, { openGoalCount: 1 });
 		const joined = lines.join("\n");
-		assert.match(joined, /Step 2\/3/);
-		assert.match(joined, /Step 1: a/);
-		assert.match(joined, /Step 2: b/);
+		// The unified dashboard derives progress from the task tree (§9.1): the
+		// ordered-step detector stays in prompts; the widget shows task progress.
+		assert.match(joined, /Tasks  \[.*\] 1\/3 · 33%/);
+		assert.match(joined, /Current  t2 · b/);
 	});
 });
 

--- a/tests/goal-golden.test.ts
+++ b/tests/goal-golden.test.ts
@@ -81,6 +81,7 @@ function expectedFixtureRecord(now: string): GoalRecord {
 		skipAuditor: undefined,
 		revision: 0,
 		tokenBudget: undefined,
+		currentTaskId: undefined,
 		taskList: {
 			blockCompletion: true,
 			proposedAt: "2026-08-03T09:05:00.000Z",

--- a/tests/goal-modal-escape.test.ts
+++ b/tests/goal-modal-escape.test.ts
@@ -38,6 +38,7 @@ const CTRL_SHIFT_T = "\x1b[116;6u"; // kitty protocol: 't' with ctrl+shift modif
 
 interface Harness {
 	handlers: Record<string, (event: unknown, ctx: ExtensionContext) => unknown>;
+	tools: Record<string, { execute: (...args: unknown[]) => Promise<unknown> }>;
 	sentMessages: Array<{ customType?: string; details?: unknown }>;
 	notifyCalls: string[];
 	ctx: ExtensionContext;
@@ -54,8 +55,9 @@ function createHarness(cwd: string): Harness {
 	let resolveOverlay: (() => void) | null = null;
 	let overlayShown = false;
 
+	const tools: Record<string, { execute: (...args: unknown[]) => Promise<unknown> }> = {};
 	const mockPi = {
-		registerTool: () => {},
+		registerTool: (def: { name: string; execute: (...args: unknown[]) => Promise<unknown> }) => { tools[def.name] = def; },
 		registerCommand: () => {},
 		on: (event: string, handler: (...args: never[]) => unknown) => {
 			handlers[event] = handler as Harness["handlers"][string];
@@ -98,7 +100,7 @@ function createHarness(cwd: string): Harness {
 			setWorkingVisible: () => {},
 			custom: (factory: (...args: unknown[]) => unknown) => new Promise((resolve) => {
 				overlayShown = true;
-				resolveOverlay = () => resolve(undefined);
+				resolveOverlay = () => resolve({ decision: "confirm" } as never);
 				factory(createMockTUI().tui, createMockTheme(), null, resolveOverlay);
 			}),
 			select: async () => null,
@@ -111,6 +113,7 @@ function createHarness(cwd: string): Harness {
 
 	return {
 		handlers,
+		tools,
 		sentMessages,
 		notifyCalls,
 		ctx,
@@ -161,11 +164,26 @@ test("Escape while a goal modal is open never pauses the goal; Escape after it c
 		await startSession(h);
 		assert.ok(h.ctx.hasUI);
 
-		// Ctrl+Shift+T opens the task-list overlay through the real keybinding:
-		// the widget enters the goal modal (depth counter) before showing it.
+		// Ctrl+Shift+T now toggles the unified dashboard expansion (the separate
+		// task-list overlay registration is removed; §10/§19.5). It must be
+		// consumed and must NOT open an overlay or enter a goal modal.
 		const openResult = h.terminalInput(CTRL_SHIFT_T);
 		assert.deepEqual(openResult, { consume: true }, "ctrl+shift+t must be consumed by the widget");
-		assert.ok(h.overlayShown(), "task-list overlay must be shown");
+		assert.equal(h.overlayShown(), false, "ctrl+shift+t must not open the task-list overlay anymore");
+		// Toggle back to compact so the final Escape exercises the pause path
+		// rather than collapsing the expanded dashboard.
+		h.terminalInput(CTRL_SHIFT_T);
+
+		// Open a real goal modal through the real wiring: set_goal_tasks shows
+		// the task-confirmation dialog (ui.custom), entering the goal modal
+		// (depth counter) before showing it.
+		const setTasks = h.tools["set_goal_tasks"];
+		assert.ok(setTasks, "set_goal_tasks tool registered");
+		const toolPromise = setTasks.execute("set-1", {
+			tasks: [{ id: "t1", title: "Task one" }],
+		}, undefined, undefined, h.ctx);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		assert.ok(h.overlayShown(), "task confirmation modal must be shown");
 
 		// Escape while the modal is open: the handler must yield to the dialog
 		// (return undefined) and never pause the goal.
@@ -173,8 +191,9 @@ test("Escape while a goal modal is open never pauses the goal; Escape after it c
 		assert.equal(escapeInModal, undefined, "handler must not consume Escape while a goal modal is open");
 		assert.ok(!h.notifyCalls.includes("Goal paused."), "goal must not be paused while a goal modal is open");
 
-		// Close the overlay via its done callback -> the modal exits (finally).
+		// Close the modal via its done callback -> the modal exits (finally).
 		h.overlayDone();
+		await toolPromise;
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
 		// Escape with no goal modal open: the normal pause path must work.

--- a/tests/goal-prompts.test.ts
+++ b/tests/goal-prompts.test.ts
@@ -314,3 +314,38 @@ test("active prompts no longer reference removed tools", () => {
 		assert.ok(prompt.includes("set_goal_tasks") || prompt.includes("update_goal_task"), "prompt must mention the task tools");
 	}
 });
+
+test("taskListBlock surfaces the persisted current task with its contract", () => {
+	const g = goal({ id: "focus-goal" });
+	g.taskList = {
+		tasks: [
+			{ id: "t1", title: "Task one", status: "pending" },
+			{ id: "t2", title: "Task two", status: "pending", verificationContract: "Run the check." },
+		],
+		blockCompletion: false,
+		proposedAt: "2026-05-27T00:00:00.000Z",
+	};
+	g.currentTaskId = "t2";
+	const block = taskListBlock(g);
+	assert.match(block, /Current: t2 · Task two \(contract: Run the check\.\)/);
+	// No focus: no Current line.
+	g.currentTaskId = undefined;
+	assert.doesNotMatch(taskListBlock(g), /Current:/);
+	// Focus on a contract-less task: no contract suffix.
+	g.currentTaskId = "t1";
+	assert.match(taskListBlock(g), /Current: t1 · Task one\n/);
+});
+
+test("prompt cache key changes when currentTaskId changes", () => {
+	const g = goal({ id: "cache-goal" });
+	g.taskList = {
+		tasks: [{ id: "t1", title: "Task one", status: "pending" }],
+		blockCompletion: false,
+		proposedAt: "2026-05-27T00:00:00.000Z",
+	};
+	const before = continuationPrompt(g);
+	g.currentTaskId = "t1";
+	const after = continuationPrompt(g);
+	assert.match(after, /Current: t1 · Task one/);
+	assert.doesNotMatch(before, /Current:/);
+});

--- a/tests/goal-status.test.ts
+++ b/tests/goal-status.test.ts
@@ -1,0 +1,167 @@
+/**
+ * /goal-status tests (plan §13): standard mode composes the compact dashboard
+ * + current-task details + recent activity + last audit from the shared model;
+ * verbose mode carries the full diagnostic detail; neither mode emits lines
+ * wider than the configured rendering width.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { GoalLedgerEvent } from "../extensions/goal-ledger.ts";
+import type { GoalRecord, GoalTask } from "../extensions/goal-record.ts";
+import { buildGoalStatusText, GOAL_STATUS_WIDTH } from "../extensions/goal-status.ts";
+
+function task(id: string, title: string, overrides: Partial<GoalTask> = {}): GoalTask {
+	return { id, title, status: "pending", ...overrides };
+}
+
+function goal(overrides: Partial<GoalRecord> = {}): GoalRecord {
+	return {
+		id: "g1",
+		objective: "Add CSV export to reports",
+		status: "active",
+		autoContinue: true,
+		usage: { tokensUsed: 18200, activeSeconds: 767 },
+		sisyphus: false,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		activePath: ".pi/goals/active_goal_g1.md",
+		...overrides,
+	};
+}
+
+function withTasks(taskList: GoalTask[], overrides: Partial<GoalRecord> = {}): GoalRecord {
+	return goal({ ...overrides, taskList: { tasks: taskList, blockCompletion: false, proposedAt: "2026-01-01T00:00:00.000Z" } });
+}
+
+function fiveTasks(): GoalTask[] {
+	return [
+		task("t1", "Review reports page and data source", { status: "complete", evidence: "Reviewed source" }),
+		task("t2", "Implement filtered CSV export", { status: "complete" }),
+		task("t3", "Add the download button", {
+			verificationContract: "The button downloads a CSV using the active filters.",
+			subtasks: [
+				task("t3.1", "Add loading state", { status: "complete" }),
+				task("t3.2", "Generate timestamped filename", { status: "complete" }),
+				task("t3.3", "Add error handling"),
+			],
+		}),
+		task("t4", "Add documentation"),
+		task("t5", "Add and run tests", { status: "skipped", skipReason: "Covered by t2" }),
+	];
+}
+
+function events(): GoalLedgerEvent[] {
+	return [
+		{ type: "goal_created", goalId: "g1", objective: "x", sisyphus: false, autoContinue: true, at: "2026-01-01T09:00:00.000Z" },
+		{ type: "task_complete", goalId: "g1", taskId: "t2", evidence: "Done", at: "2026-01-01T09:05:00.000Z" },
+		{ type: "task_started", goalId: "g1", taskId: "t3.3", at: "2026-01-01T09:06:00.000Z" },
+		{ type: "audit_result", goalId: "g1", verdict: "disapproved", report: "Tests were not run after the final change.", at: "2026-01-02T10:00:00.000Z" },
+	] as unknown as GoalLedgerEvent[];
+}
+
+function base(): Parameters<typeof buildGoalStatusText>[0] {
+	return {
+		goal: withTasks(fiveTasks(), { currentTaskId: "t3", verificationContract: "Run npm test with zero failures." }),
+		focused: true,
+		otherOpenGoals: 2,
+		ledgerEvents: events(),
+	};
+}
+
+test("standard mode renders the compact dashboard from the shared model (§13.1)", () => {
+	const text = buildGoalStatusText(base());
+	assert.match(text, /╭─ pi-goal-x ─ Add CSV export to reports/);
+	assert.match(text, /● In progress · Focused: yes · Other goals: 2/);
+	// The top-level task list is part of the compact dashboard now (step-11).
+	assert.match(text, /├─ Tasks /);
+	assert.match(text, /✓ t1  Review reports page and data source/);
+	// The five-task list overflows the medium-status width (78 cols).
+	assert.match(text, /… \+1 more task/);
+	assert.match(text, /Tasks  \[.*\] 3\/5 · 60%/);
+	assert.match(text, /Current  t3 · Add the download button/);
+	assert.match(text, /Subtasks \[.*\] 2\/3 · 67%/);
+	assert.match(text, /Verify   Run npm test with zero failures/);
+	assert.match(text, /File     \.pi\/goals\/active_goal_g1\.md/);
+});
+
+test("standard mode adds current-task details, activity, and the last audit", () => {
+	const text = buildGoalStatusText(base());
+	// Current-task details block (§13.1 item 2).
+	assert.match(text, /├─ Current task /);
+	assert.match(text, /Contract: The button downloads a CSV using the active filters/);
+	// Recent activity (§13.1 item 3) — ledger-derived, task titles preferred.
+	assert.match(text, /├─ Recent activity /);
+	assert.match(text, /Started “Add error handling”\./);
+	assert.match(text, /Completed “Implement filtered CSV export”\. — Done/);
+	// Last audit result (§13.1 item 4).
+	assert.match(text, /Last audit: CHANGES REQUIRED \(2026-01-02\)/);
+});
+
+test("standard mode includes no effective settings noise by default", () => {
+	const text = buildGoalStatusText(base());
+	assert.doesNotMatch(text, /Effective settings/);
+	assert.doesNotMatch(text, /provider:/);
+});
+
+test("verbose mode carries full diagnostic detail (§13.2)", () => {
+	const text = buildGoalStatusText({
+		...base(),
+		verbose: true,
+		settingsReport: ["provider: anthropic (from .pi/pi-goal-x-settings.json)", "disableTasks: false"],
+	});
+	assert.match(text, /Goal id: g1/);
+	assert.match(text, /Revision: \d+/);
+	assert.match(text, /Status: In progress \(focused\)/);
+	assert.match(text, /Objective:/);
+	assert.match(text, /Add CSV export to reports/);
+	// Full task tree with full evidence and contracts.
+	assert.match(text, /✓ t1  Review reports page and data source — evidence: Reviewed source/);
+	assert.match(text, /▸ t3  Add the download button — contract: The button downloads a CSV/);
+	assert.match(text, /~ t5  Add and run tests/);
+	// Current task detail.
+	assert.match(text, /Current task: t3 · Add the download button/);
+	assert.match(text, /subtasks: 2\/3 \(67%\)/);
+	// Recent ledger history.
+	assert.match(text, /Recent ledger:/);
+	assert.match(text, /task_started/);
+	// Last audit report.
+	assert.match(text, /Last audit \(2026-01-02\): disapproved/);
+	assert.match(text, /Tests were not run after the final change/);
+	// Effective settings with provenance.
+	assert.match(text, /Effective settings:/);
+	assert.match(text, /provider: anthropic \(from .pi\/pi-goal-x-settings.json\)/);
+});
+
+test("no rendered line of the boxed standard output exceeds the rendering width", () => {
+	const text = buildGoalStatusText(base());
+	for (const line of text.split("\n")) {
+		assert.ok(
+			visibleWidth(line) <= GOAL_STATUS_WIDTH,
+			`line exceeds ${GOAL_STATUS_WIDTH}: ${JSON.stringify(line.slice(0, 60))}`,
+		);
+	}
+});
+
+test("unfocused and no-goal states render correctly", () => {
+	const unfocused = buildGoalStatusText({ goal: null, focused: false, otherOpenGoals: 3 });
+	assert.match(unfocused, /3 open goals are available/);
+	assert.match(unfocused, /\/goal-focus/);
+	const none = buildGoalStatusText({ goal: null, focused: false, otherOpenGoals: 0 });
+	assert.match(none, /No goal is set/);
+});
+
+test("complete goal standard output shows the §4.7 message", () => {
+	const text = buildGoalStatusText({
+		goal: withTasks(fiveTasks().map((t) => ({ ...t, status: "complete" as const })), {
+			status: "complete",
+			activePath: undefined,
+			archivedPath: ".pi/goals/archived/goal_g1.md",
+		}),
+		focused: true,
+		otherOpenGoals: 0,
+	});
+	assert.match(text, /All required work is complete/);
+});

--- a/tests/goal-status.test.ts
+++ b/tests/goal-status.test.ts
@@ -106,6 +106,33 @@ test("standard mode includes no effective settings noise by default", () => {
 	assert.doesNotMatch(text, /provider:/);
 });
 
+test("standard mode shows the anchored task window — parity with the widget default (§9.6)", () => {
+	// 30 top-level tasks; t5 and t20 completed (t20 latest). The status
+	// width (78 cols, medium) budgets 4 task rows, so the anchored window is
+	// t17..t20 — the most recently completed task visible, earliest hidden,
+	// exactly like the compact widget's default rendering.
+	const tasks: GoalTask[] = Array.from({ length: 30 }, (_, i) => ({
+		id: `t${i + 1}`,
+		title: `Task number ${i + 1}`,
+		status: "pending" as const,
+	}));
+	tasks[4] = { ...tasks[4]!, status: "complete", completedAt: "2026-01-01T10:00:00.000Z" };
+	tasks[19] = { ...tasks[19]!, status: "complete", completedAt: "2026-01-01T11:00:00.000Z" };
+	const text = buildGoalStatusText({
+		goal: withTasks(tasks, { currentTaskId: "t21" }),
+		focused: true,
+		otherOpenGoals: 0,
+	});
+	assert.match(text, /↑ 16 more tasks/, "the anchored window hides the earliest tasks");
+	assert.match(text, /Task number 20/, "the latest completion is the last visible row");
+	assert.match(text, /… \+10 more tasks/, "pending tasks after the anchor stay reachable below");
+	assert.doesNotMatch(text, /[✓▸·~] t1\s/, "the earliest task row is not rendered");
+	// Width-safe including the indicator rows.
+	for (const line of text.split("\n")) {
+		assert.ok(visibleWidth(line) <= GOAL_STATUS_WIDTH, `line exceeds ${GOAL_STATUS_WIDTH}: ${JSON.stringify(line.slice(0, 60))}`);
+	}
+});
+
 test("verbose mode carries full diagnostic detail (§13.2)", () => {
 	const text = buildGoalStatusText({
 		...base(),

--- a/tests/goal-task-lifecycle.test.ts
+++ b/tests/goal-task-lifecycle.test.ts
@@ -1,0 +1,476 @@
+/**
+ * Current-task lifecycle tests (plan §19.2, §19.8): update_goal_task
+ * start/complete/skip focus semantics, currentTaskId persistence and
+ * normalization (legacy + stale ids), and task-list replacement rules (§7.5).
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import goalExtension from "../extensions/goal.ts";
+import { convertFlatTasks, mergeTasksWithExisting, type FlatTaskInput } from "../extensions/goal-task-tools.ts";
+import { createGoal, goalFocusDetails, normalizeGoalRecord, type GoalRecord, type GoalTask } from "../extensions/goal-record.ts";
+import { parseGoalFile, serializeGoalFile, writeActiveGoalFile } from "../extensions/storage/goal-files.ts";
+import { goalLedgerPath } from "../extensions/goal-ledger.ts";
+
+// ── Tool execution harness (mirrors goal-task-tools.test.ts) ────────────────
+
+function createHarness(cwd: string, sessionEntries: unknown[]) {
+	const handlers = new Map<string, Function>();
+	const tools = new Map<string, ToolDefinition>();
+	let activeTools = ["read", "bash", "edit", "write"];
+	const pi = {
+		registerTool: (def: ToolDefinition) => { tools.set(def.name, def); },
+		registerCommand: () => {},
+		on: (event: string, handler: Function) => { handlers.set(event, handler); },
+		appendEntry: () => {},
+		registerMessageRenderer: () => {},
+		sendMessage: () => {},
+		getActiveTools: () => [...activeTools],
+		setActiveTools: (names: string[]) => { activeTools = [...names]; },
+		hasUI: false,
+	};
+	const ctx = {
+		cwd,
+		hasUI: false,
+		sessionManager: {
+			getBranch: () => sessionEntries,
+			getCwd: () => cwd,
+			getSessionId: () => "task-lifecycle-session",
+			getRoot: () => cwd,
+		},
+		ui: {
+			notify: () => {},
+			setStatus: () => {},
+			setWidget: () => {},
+			onTerminalInput: () => () => {},
+			select: async () => undefined,
+			confirm: async () => false,
+			custom: async () => undefined,
+		},
+		getSystemPrompt: () => "base",
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		abort: () => {},
+	} as unknown as ExtensionContext;
+	goalExtension(pi as any, {});
+	return { handlers, tools, ctx };
+}
+
+function fixtureWithTasks(tasks: Array<Record<string, unknown>>, opts: { pauseReason?: string; status?: "active" | "paused" } = {}) {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-lifecycle-"));
+	mkdirSync(path.join(cwd, ".pi", "goals", "archived"), { recursive: true });
+	const goal = createGoal({ objective: "Lifecycle goal", autoContinue: true, sisyphus: false }, Date.UTC(2026, 7, 5, 9, 0, 0));
+	goal.taskList = { tasks: tasks as any, blockCompletion: false, proposedAt: new Date().toISOString() };
+	if (opts.status === "paused") {
+		goal.status = "paused";
+		goal.stopReason = "user";
+		goal.pauseReason = opts.pauseReason ?? "user pause";
+	}
+	const written = writeActiveGoalFile({ cwd }, goal);
+	const sessionEntries = [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(goal.id, "created") }];
+	const cleanup = () => { try { rmSync(cwd, { recursive: true, force: true }); } catch {} };
+	return { cwd, goal: written, sessionEntries, cleanup };
+}
+
+function activeGoal(cwd: string): GoalRecord | null {
+	const files = readdirSync(path.join(cwd, ".pi", "goals")).filter((n) => n.startsWith("active_goal_"));
+	return parseGoalFile(path.join(cwd, ".pi", "goals", files[0]!));
+}
+
+function activeFile(cwd: string): string {
+	const files = readdirSync(path.join(cwd, ".pi", "goals")).filter((n) => n.startsWith("active_goal_"));
+	return path.join(cwd, ".pi", "goals", files[0]!);
+}
+
+function ledgerEvents(cwd: string): Array<Record<string, unknown>> {
+	try {
+		return readFileSync(goalLedgerPath({ cwd }), "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l) as Record<string, unknown>);
+	} catch {
+		return [];
+	}
+}
+
+async function startSession(cwd: string, sessionEntries: unknown[]) {
+	const h = createHarness(cwd, sessionEntries);
+	await h.handlers.get("session_start")?.({ reason: "start" }, h.ctx);
+	await h.handlers.get("before_agent_start")?.({ systemPrompt: "base", prompt: "go", systemPromptOptions: {} }, h.ctx);
+	return h;
+}
+
+async function callTool(h: ReturnType<typeof createHarness>, name: string, callId: string, params: Record<string, unknown>) {
+	const tool = h.tools.get(name)!;
+	return (tool.execute as any)(callId, params, undefined, undefined, h.ctx);
+}
+
+function pendingTasks(): Array<Record<string, unknown>> {
+	return [
+		{ id: "t1", title: "Task one" },
+		{ id: "t2", title: "Task two" },
+		{ id: "t3", title: "Parent", subtasks: [{ id: "t3.1", title: "Child" }] },
+	];
+}
+
+// ── §19.2 update_goal_task lifecycle ────────────────────────────────────────
+
+test("start sets the persisted currentTaskId and appends task_started", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		const result = await callTool(h, "update_goal_task", "start-1", { task_id: "t2", status: "start" });
+		const text = result.content?.[0]?.text ?? "";
+		assert.ok(text.includes("Started t2"), `start message, got: ${text}`);
+		assert.equal(result.terminate, undefined, "start does not terminate the turn");
+		// Memory + disk both carry the focus.
+		const goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, "t2");
+		const events = ledgerEvents(f.cwd);
+		assert.ok(events.some((e) => e.type === "task_started" && e.taskId === "t2"), "task_started ledger event");
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("start surfaces the task verification contract", async () => {
+	const f = fixtureWithTasks([
+		{ id: "t1", title: "Task one", verificationContract: "Run the check." },
+	]);
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		const result = await callTool(h, "update_goal_task", "start-2", { task_id: "t1", status: "start" });
+		const text = result.content?.[0]?.text ?? "";
+		assert.ok(text.includes("Contract: Run the check."), `contract surfaced, got: ${text}`);
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("starting another task replaces the current task", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		await callTool(h, "update_goal_task", "start-3", { task_id: "t1", status: "start" });
+		await callTool(h, "update_goal_task", "start-4", { task_id: "t3", status: "start" });
+		const goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, "t3", "later start replaces earlier focus");
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("starting a subtask sets focus to the nested node", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		await callTool(h, "update_goal_task", "start-5", { task_id: "t3.1", status: "start" });
+		const goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, "t3.1");
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("completing the current task clears currentTaskId", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		await callTool(h, "update_goal_task", "start-6", { task_id: "t2", status: "start" });
+		await callTool(h, "update_goal_task", "complete-1", { task_id: "t2", status: "complete", evidence: "done" });
+		const goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, undefined, "completing the current task clears focus");
+		assert.equal(goal?.taskList?.tasks.find((t) => t.id === "t2")?.status, "complete");
+		assert.ok(ledgerEvents(f.cwd).some((e) => e.type === "task_complete"), "task_complete event");
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("skipping the current task clears currentTaskId", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		await callTool(h, "update_goal_task", "start-7", { task_id: "t1", status: "start" });
+		await callTool(h, "update_goal_task", "skip-1", { task_id: "t1", status: "skipped", reason: "user direction" });
+		const goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, undefined, "skipping the current task clears focus");
+		assert.equal(goal?.taskList?.tasks.find((t) => t.id === "t1")?.status, "skipped");
+		assert.ok(ledgerEvents(f.cwd).some((e) => e.type === "task_skipped"), "task_skipped event");
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("completing a non-current task leaves focus untouched", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		await callTool(h, "update_goal_task", "start-8", { task_id: "t2", status: "start" });
+		await callTool(h, "update_goal_task", "complete-2", { task_id: "t1", status: "complete", evidence: "done" });
+		const goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, "t2", "unrelated completion keeps focus");
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("start validation rejects missing, terminal, and ineligible tasks", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		// Missing task.
+		const missing = await callTool(h, "update_goal_task", "start-9", { task_id: "ghost", status: "start" });
+		assert.ok((missing.content?.[0]?.text ?? "").includes("not found"));
+		// Complete the task first, then starting it must fail.
+		await callTool(h, "update_goal_task", "complete-3", { task_id: "t1", status: "complete", evidence: "done" });
+		const terminal = await callTool(h, "update_goal_task", "start-10", { task_id: "t1", status: "start" });
+		assert.ok((terminal.content?.[0]?.text ?? "").includes("only pending tasks can be started"));
+		const goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, undefined, "failed start does not set focus");
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("start validation rejects paused and taskless goals", async () => {
+	const f = fixtureWithTasks(pendingTasks(), { status: "paused" });
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		const result = await callTool(h, "update_goal_task", "start-11", { task_id: "t1", status: "start" });
+		assert.ok((result.content?.[0]?.text ?? "").includes("only to an active goal"));
+		const goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, undefined);
+	} finally {
+		f.cleanup();
+	}
+	const noTasks = fixtureWithTasks([]);
+	try {
+		const h = await startSession(noTasks.cwd, noTasks.sessionEntries);
+		const result = await callTool(h, "update_goal_task", "start-12", { task_id: "t1", status: "start" });
+		assert.ok((result.content?.[0]?.text ?? "").includes("no task list"));
+	} finally {
+		noTasks.cleanup();
+	}
+});
+
+test("start honors disableTasks settings", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		mkdirSync(path.join(f.cwd, ".pi"), { recursive: true });
+		writeFileSync(path.join(f.cwd, ".pi", "pi-goal-x-settings.json"), JSON.stringify({ disableTasks: true }));
+		const h = await startSession(f.cwd, f.sessionEntries);
+		const result = await callTool(h, "update_goal_task", "start-13", { task_id: "t1", status: "start" });
+		assert.ok((result.content?.[0]?.text ?? "").includes("disabled by settings"));
+		const goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, undefined);
+	} finally {
+		f.cleanup();
+	}
+});
+
+// ── §7.5 task-list replacement rules ────────────────────────────────────────
+
+test("set_goal_tasks preserves currentTaskId when the id remains pending", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		await callTool(h, "update_goal_task", "start-14", { task_id: "t2", status: "start" });
+		// Restructure: keep t2 (with a new title), drop t3, add t4.
+		const result = await callTool(h, "set_goal_tasks", "set-1", {
+			tasks: [
+				{ id: "t1", title: "Task one" },
+				{ id: "t2", title: "Task two renamed" },
+				{ id: "t4", title: "Task four" },
+			],
+		});
+		assert.equal(result.terminate, true);
+		const goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, "t2", "focus preserved when id stays pending");
+		assert.equal(goal?.taskList?.tasks.find((t) => t.id === "t2")?.title, "Task two renamed");
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("set_goal_tasks clears currentTaskId when the id is removed or terminal", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		await callTool(h, "update_goal_task", "start-15", { task_id: "t3", status: "start" });
+		// Remove t3 entirely.
+		await callTool(h, "set_goal_tasks", "set-2", {
+			tasks: [{ id: "t1", title: "Task one" }, { id: "t2", title: "Task two" }],
+		});
+		let goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, undefined, "removed id clears focus");
+		// Restructure with t2 completed: focus on t2, then restructure keeping t2 complete.
+		await callTool(h, "set_goal_tasks", "set-3", {
+			tasks: [{ id: "t1", title: "Task one" }, { id: "t2", title: "Task two" }, { id: "t5", title: "Task five" }],
+		});
+		await callTool(h, "update_goal_task", "start-16", { task_id: "t5", status: "start" });
+		await callTool(h, "update_goal_task", "complete-4", { task_id: "t5", status: "complete", evidence: "done" });
+		// Re-set the same list (t5 now complete in the existing tree): merge keeps
+		// the completion, so the previously-current id is no longer pending.
+		await callTool(h, "set_goal_tasks", "set-4", {
+			tasks: [{ id: "t1", title: "Task one" }, { id: "t2", title: "Task two" }, { id: "t5", title: "Task five" }],
+		});
+		goal = activeGoal(f.cwd);
+		assert.equal(goal?.currentTaskId, undefined, "terminal id clears focus after structural merge");
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("mergeTasksWithExisting preserves status, evidence, and timestamps", () => {
+	const existing: GoalTask[] = [{
+		id: "a", title: "Old", status: "complete", evidence: "verified", completedAt: "2026-01-01T00:00:00.000Z",
+	}];
+	const incoming = convertFlatTasks([{ id: "a", title: "Renamed" }, { id: "b", title: "New" }]);
+	assert.ok(incoming.ok);
+	if (!incoming.ok) return;
+	const merged = mergeTasksWithExisting(existing, incoming.tasks);
+	assert.equal(merged[0]?.status, "complete");
+	assert.equal(merged[0]?.evidence, "verified");
+	assert.equal(merged[0]?.completedAt, "2026-01-01T00:00:00.000Z");
+	assert.equal(merged[0]?.title, "Renamed");
+	assert.equal(merged[1]?.status, "pending");
+});
+
+// ── §19.8 persistence and migration ─────────────────────────────────────────
+
+test("legacy goal files load without currentTaskId and preserve task state", () => {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-legacy-"));
+	try {
+		mkdirSync(path.join(cwd, ".pi", "goals"), { recursive: true });
+		const goal = createGoal({ objective: "Legacy goal", autoContinue: true, sisyphus: false }, Date.UTC(2026, 7, 5, 9, 0, 0));
+		goal.taskList = {
+			tasks: [{ id: "a", title: "A", status: "complete", evidence: "kept" }, { id: "b", title: "B" }] as any,
+			blockCompletion: false,
+			proposedAt: new Date().toISOString(),
+		};
+		goal.verificationContract = "Run the suite.";
+		goal.usage = { tokensUsed: 4200, activeSeconds: 300 };
+		// No currentTaskId anywhere: a historical file.
+		const written = writeActiveGoalFile({ cwd }, goal);
+		const parsed = parseGoalFile(path.join(cwd, written.activePath!));
+		assert.ok(parsed);
+		assert.equal(parsed.currentTaskId, undefined, "legacy file has no focus");
+		assert.equal(parsed.taskList?.tasks[0]?.status, "complete");
+		assert.equal(parsed.taskList?.tasks[0]?.evidence, "kept");
+		assert.equal(parsed.verificationContract, "Run the suite.");
+		assert.deepEqual(parsed.usage, { tokensUsed: 4200, activeSeconds: 300 });
+		assert.equal(parsed.status, "active");
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("currentTaskId persists through write→parse round trips", () => {
+	const cwd = mkdtempSync(path.join(tmpdir(), "goal-persist-"));
+	try {
+		mkdirSync(path.join(cwd, ".pi", "goals"), { recursive: true });
+		const goal = createGoal({ objective: "Persist goal", autoContinue: true, sisyphus: false }, Date.UTC(2026, 7, 5, 9, 0, 0));
+		goal.taskList = { tasks: [{ id: "a", title: "A" }, { id: "b", title: "B" }] as any, blockCompletion: false, proposedAt: new Date().toISOString() };
+		goal.currentTaskId = "b";
+		const written = writeActiveGoalFile({ cwd }, goal);
+		const parsed = parseGoalFile(path.join(cwd, written.activePath!));
+		assert.equal(parsed?.currentTaskId, "b", "focus survives a write→read round trip");
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("stale currentTaskId is cleared during normalization", () => {
+	const base = createGoal({ objective: "Stale goal", autoContinue: true, sisyphus: false }, Date.UTC(2026, 7, 5, 9, 0, 0));
+	base.taskList = { tasks: [{ id: "a", title: "A" }, { id: "b", title: "B" }] as any, blockCompletion: false, proposedAt: new Date().toISOString() };
+
+	// Removed id.
+	const removed = normalizeGoalRecord({ ...base, currentTaskId: "ghost" } as unknown);
+	assert.equal(removed?.currentTaskId, undefined, "removed id is cleared");
+
+	// Completed id.
+	const completeTask = normalizeGoalRecord({
+		...base,
+		taskList: { ...base.taskList, tasks: [{ id: "a", title: "A", status: "complete" }, { id: "b", title: "B" }] },
+		currentTaskId: "a",
+	} as unknown);
+	assert.equal(completeTask?.currentTaskId, undefined, "complete id is cleared");
+
+	// Skipped id.
+	const skippedTask = normalizeGoalRecord({
+		...base,
+		taskList: { ...base.taskList, tasks: [{ id: "a", title: "A", status: "skipped" }, { id: "b", title: "B" }] },
+		currentTaskId: "a",
+	} as unknown);
+	assert.equal(skippedTask?.currentTaskId, undefined, "skipped id is cleared");
+
+	// Nested pending id.
+	const nested = normalizeGoalRecord({
+		...base,
+		taskList: {
+			...base.taskList,
+			tasks: [{ id: "p", title: "P", subtasks: [{ id: "p.1", title: "P1" }] }],
+		},
+		currentTaskId: "p.1",
+	} as unknown);
+	assert.equal(nested?.currentTaskId, "p.1", "nested pending id is accepted");
+
+	// Pending id.
+	const valid = normalizeGoalRecord({ ...base, currentTaskId: "a" } as unknown);
+	assert.equal(valid?.currentTaskId, "a", "pending id is accepted");
+
+	// No task list.
+	const noTasks = normalizeGoalRecord({ ...base, taskList: undefined, currentTaskId: "a" } as unknown);
+	assert.equal(noTasks?.currentTaskId, undefined, "no task list means no focus");
+});
+
+test("normalization never rewrites legacy files", () => {
+	const f = fixtureWithTasks([{ id: "a", title: "A" }, { id: "b", title: "B" }]);
+	try {
+		// Plant a stale focus in the file (simulates an externally-edited record).
+		const file = activeFile(f.cwd);
+		const raw = readFileSync(file, "utf8");
+		const parsed = parseGoalFile(file);
+		assert.ok(parsed);
+		parsed.currentTaskId = "ghost";
+		const goal = normalizeGoalRecord(JSON.parse(JSON.stringify(parsed)));
+		assert.equal(goal?.currentTaskId, undefined);
+		// Reading must not modify the file.
+		parseGoalFile(file);
+		parseGoalFile(file);
+		assert.equal(readFileSync(file, "utf8"), raw, "parse/normalize never rewrites the file");
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("focus survives restart (reload from disk) and session refocus", async () => {
+	const f = fixtureWithTasks(pendingTasks());
+	try {
+		const h = await startSession(f.cwd, f.sessionEntries);
+		await callTool(h, "update_goal_task", "start-17", { task_id: "t3", status: "start" });
+		// Simulate a restart: a fresh harness with the same session entries.
+		const h2 = await startSession(f.cwd, f.sessionEntries);
+		const g = activeGoal(f.cwd);
+		assert.equal(g?.currentTaskId, "t3", "focus restored after restart");
+		const h3 = h2; // refocus path uses the same focus entry
+		assert.ok(h3.handlers.has("session_start"));
+	} finally {
+		f.cleanup();
+	}
+});
+
+test("serializeGoalFile round-trips currentTaskId in the JSON header", () => {
+	const goal = createGoal({ objective: "Round trip", autoContinue: true, sisyphus: false }, Date.UTC(2026, 7, 5, 9, 0, 0));
+	goal.taskList = { tasks: [{ id: "a", title: "A" }] as any, blockCompletion: false, proposedAt: new Date().toISOString() };
+	goal.currentTaskId = "a";
+	const serialized = serializeGoalFile(goal);
+	assert.ok(serialized.includes('"currentTaskId": "a"'), "JSON header carries currentTaskId");
+	const end = serialized.indexOf("\n\n# Goal Prompt");
+	const raw = JSON.parse(serialized.slice(0, end));
+	const reparsed = normalizeGoalRecord({ ...raw, objective: "Round trip" } as unknown);
+	assert.equal(reparsed?.currentTaskId, "a");
+});

--- a/tests/goal-widget.test.ts
+++ b/tests/goal-widget.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import { renderGoalWidgetLines, renderAuditorWidgetLines, GoalWidgetComponent, type GoalWidgetRecord, type AuditorWidgetProgress } from "../extensions/widgets/goal-widget.ts";
+import { renderGoalWidgetLines, renderAuditorWidgetLines, renderAuditResultCardView, GoalWidgetComponent, type GoalWidgetRecord, type AuditorWidgetProgress } from "../extensions/widgets/goal-widget.ts";
 import { createMockTUI, createMockTheme } from "./tui-test-utils.ts";
 
 const theme = {
@@ -38,170 +38,142 @@ function auditorProgress(overrides: Partial<AuditorWidgetProgress> = {}): Audito
 	};
 }
 
-test("renderGoalWidgetLines renders a distinct Sisyphus goal beacon", () => {
+test("renderGoalWidgetLines renders the unified compact dashboard", () => {
 	const lines = renderGoalWidgetLines(goal(), theme, 100);
-	assert.match(lines[0], /^◆ Sisyphus running/);
-	assert.match(lines[0], /auto · 1m05s · 2\.5K/);
-	assert.doesNotMatch(lines[0], /▰|▱/);
-	assert.match(lines[1], /^├─ ⟡ Componentize the goal widget/);
-	assert.doesNotMatch(lines.join("\n"), /pulse/);
-	assert.match(lines.at(-1) ?? "", /^└─ \.pi\/goals\/active_goal\.md/);
+	assert.match(lines[0], /^╭─ pi-goal-x ─ Componentize the goal widget/);
+	assert.match(lines[0], /1m05s · 2\.5K tok/);
+	assert.match(lines[1], /● In progress · Focused: yes/);
+	assert.match(lines.at(-1) ?? "", /^╰─ .*Ctrl\+Shift\+T: expand/);
 });
 
-test("renderGoalWidgetLines merges complete usage into the heading", () => {
+test("renderGoalWidgetLines shows the complete state", () => {
 	const lines = renderGoalWidgetLines(goal({
 		status: "complete",
 		autoContinue: false,
 		sisyphus: false,
 		archivedPath: ".pi/goals/archived/goal.md",
 	}), theme, 100);
-	assert.match(lines[0], /^✓ Goal complete/);
 	assert.match(lines[0], /1m05s · 2\.5K/);
-	assert.doesNotMatch(lines.join("\n"), /pulse/);
+	assert.match(lines.join("\n"), /All required work is complete/);
 });
 
 
-test("renderGoalWidgetLines highlights agent blockers and suggested action", () => {
+test("renderGoalWidgetLines highlights blocked state with reason and action", () => {
+	const lines = renderGoalWidgetLines(goal({
+		status: "blocked",
+		autoContinue: false,
+		pauseReason: "Missing API token",
+		pauseSuggestedAction: "Set TOKEN and run /goal-resume",
+	}), theme, 100);
+	assert.match(lines.join("\n"), /⊘ Blocked/);
+	assert.match(lines.join("\n"), /Blocker  Missing API token/);
+	assert.match(lines.join("\n"), /Action   Set TOKEN and run \/goal-resume/);
+});
+
+test("renderGoalWidgetLines shows paused reason and who paused", () => {
 	const lines = renderGoalWidgetLines(goal({
 		status: "paused",
 		autoContinue: false,
 		stopReason: "agent",
-		pauseReason: "Missing API token",
-		pauseSuggestedAction: "Set TOKEN and run /goal-resume",
+		pauseReason: "waiting on the user",
 	}), theme, 100);
-	assert.match(lines[0], /⊘ Sisyphus blocked/);
-	assert.match(lines.join("\n"), /^├─ blocker Missing API token/m);
-	assert.match(lines.join("\n"), /^├─ next Set TOKEN and run \/goal-resume/m);
+	assert.match(lines.join("\n"), /◐ Paused \(agent\)/);
+	assert.match(lines.join("\n"), /Reason   waiting on the user/);
 });
 
 test("renderGoalWidgetLines shows other open goals and unfocused multi-goal guidance", () => {
 	const focused = renderGoalWidgetLines(goal(), theme, 100, { openGoalCount: 3 });
-	assert.match(focused[0], /\+2 open/);
+	assert.match(focused[1], /Other goals: 2/);
 
 	const unfocused = renderGoalWidgetLines(null, theme, 100, { openGoalCount: 2 });
-	assert.match(unfocused[0], /^◇ Goal unfocused/);
-	assert.match(unfocused[0], /2 open/);
+	assert.match(unfocused[0], /^╭─ pi-goal-x ─ Goal focus required/);
+	assert.match(unfocused.join("\n"), /2 open goals are available/);
 	assert.match(unfocused.join("\n"), /\/goal-focus/);
 });
 
-test("renderAuditorWidgetLines shows auditor progress with current tool", () => {
+test("renderAuditorWidgetLines shows the structured audit dashboard (§15.3)", () => {
+	const progress = auditorProgress({ auditorLabel: "anthropic/claude" });
+	const lines = renderAuditorWidgetLines(progress, theme, 100);
+	assert.match(lines[0], /Independent completion audit ─ anthropic\/claude/);
+	// Five check stages in order.
+	const text = lines.join("\n");
+	assert.ok(text.indexOf("Objective and success criteria") < text.indexOf("Verification contracts"));
+	assert.ok(text.indexOf("Verification contracts") < text.indexOf("Tasks and recorded evidence"));
+	assert.ok(text.indexOf("Tasks and recorded evidence") < text.indexOf("Workspace inspection"));
+	assert.ok(text.indexOf("Workspace inspection") < text.indexOf("Final decision"));
+	// Active audit footer.
+	assert.match(lines.at(-1) ?? "", /Esc: stop audit/);
+	// Tool + output details are hidden by default (shown only in expanded/debug).
+	assert.doesNotMatch(text, /tool read/);
+	assert.doesNotMatch(text, /checking file exists/);
+});
+
+test("renderAuditorWidgetLines shows tool and output details in expanded/debug mode", () => {
 	const progress = auditorProgress();
+	const lines = renderAuditorWidgetLines(progress, theme, 100, { showToolDetails: true });
+	const text = lines.join("\n");
+	assert.match(text, /tool read/);
+	assert.match(text, /test\.txt/);
+	assert.match(text, /checking file exists/);
+});
+
+test("renderAuditorWidgetLines drives check states from percentage bands (§15.2)", () => {
+	const progress = auditorProgress({ phase: "running", percentage: 72, recentOutput: [] });
 	const lines = renderAuditorWidgetLines(progress, theme, 100);
-	// Should show audit heading with duration (5s)
-	assert.match(lines[0], /Audit/);
-	assert.match(lines[0], /auditing/);
-	// Should show current tool
-	assert.match(lines.join("\n"), /tool.*read.*test\.txt/);
-	// Should show recent output lines
-	assert.match(lines.join("\n"), /checking file exists/);
-	assert.match(lines.join("\n"), /confirming test coverage/);
+	const text = lines.join("\n");
+	assert.match(text, /✓ Objective and success criteria/);
+	assert.match(text, /✓ Verification contracts/);
+	assert.match(text, /✓ Tasks and recorded evidence/);
+	assert.match(text, /◌ Workspace inspection/);
+	assert.match(text, /· Final decision/);
+	assert.match(text, /72%/);
 });
 
-test("renderAuditorWidgetLines shows done phase with success icon", () => {
-	const progress = auditorProgress({ phase: "done", currentTool: undefined, currentToolArgs: undefined });
-	const lines = renderAuditorWidgetLines(progress, theme, 100);
-	assert.match(lines[0], /✓.*audit complete/);
-	assert.doesNotMatch(lines.join("\n"), /tool/);
-});
-
-test("renderAuditorWidgetLines handles empty recent output", () => {
-	const progress = auditorProgress({ recentOutput: [], phase: "running" });
-	const lines = renderAuditorWidgetLines(progress, theme, 100);
-	assert.match(lines[0], /Audit.*auditing/);
-	// Should have heading + tool line, but no separator dash line (which contains 4+ ─ characters)
-	assert.equal(lines.filter((l) => l.includes("────")).length, 0);
-});
-
-test("auditor progress overrides normal goal display when provided", () => {
-	// When auditorProgress is passed to renderGoalWidgetLines, should show auditor instead of goal
-	const progress = auditorProgress();
-	const lines = renderGoalWidgetLines(goal(), theme, 100, { auditorProgress: progress });
-	assert.match(lines[0], /Audit/);
-	assert.doesNotMatch(lines[0], /Sisyphus|Goal/);
-});
-
-test("renderAuditorWidgetLines shows Esc to skip hint when audit is active", () => {
-	const progress = auditorProgress({ phase: "running" });
-	const lines = renderAuditorWidgetLines(progress, theme, 100);
-	// The skip hint should appear when audit is actively running
-	const allText = lines.join("\n");
-	assert.match(allText, /Esc to skip/);
-	assert.match(allText, /abort the audit/);
-	// Skip hint should be on the last line (closing branch)
-	assert.match(lines[lines.length - 1], /Esc to skip/);
-});
-
-test("renderAuditorWidgetLines omits skip hint when audit is done", () => {
-	const progress = auditorProgress({ phase: "done" });
-	const lines = renderAuditorWidgetLines(progress, theme, 100);
-	const allText = lines.join("\n");
-	assert.doesNotMatch(allText, /Esc to skip/);
-	assert.doesNotMatch(allText, /abort the audit/);
-});
-
-test("renderAuditorWidgetLines shows progress bar when percentage is set", () => {
-	const progress = auditorProgress({
-		phase: "running",
-		percentage: 40,
-		label: "Inspecting files...",
-	});
-	const lines = renderAuditorWidgetLines(progress, theme, 100);
-	const allText = lines.join("\n");
-	// Should show step label
-	assert.match(allText, /Inspecting files/);
-	// Should show percentage
-	assert.match(allText, /40%/);
-	// Should show a progress bar (brackets with filled/empty chars)
-	assert.match(allText, /\[.*█.*░.*\]/);
-});
-
-test("renderAuditorWidgetLines shows thinking phase with distinct icon", () => {
-	const progress = auditorProgress({
-		phase: "thinking",
-		label: "Analyzing goal...",
-		recentOutput: [],
-	});
-	const lines = renderAuditorWidgetLines(progress, theme, 100);
-	const allText = lines.join("\n");
-	// Should show thinking label
-	assert.match(allText, /thinking\.\.\./);
-	// Should not show Esc to skip hint during thinking
-	assert.doesNotMatch(allText, /Esc to skip/);
-});
-
-test("renderAuditorWidgetLines shows step label when present", () => {
-	const progress = auditorProgress({
-		phase: "running",
-		label: "Verifying success criteria...",
-		percentage: 50,
-	});
-	const lines = renderAuditorWidgetLines(progress, theme, 100);
-	const allText = lines.join("\n");
-	assert.match(allText, /Verifying success criteria/);
-	// Should show both label and percentage
-	assert.match(allText, /50%/);
-});
-
-test("renderAuditorWidgetLines handles progress bar at 0% and 100%", () => {
-	const zero = renderAuditorWidgetLines(auditorProgress({ phase: "running", percentage: 0 }), theme, 100).join("\n");
+test("renderAuditorWidgetLines shows the progress bar at 0% and 100%", () => {
+	const zero = renderAuditorWidgetLines(auditorProgress({ phase: "running", percentage: 0, recentOutput: [] }), theme, 100).join("\n");
 	assert.match(zero, /0%/);
-
-	const hundred = renderAuditorWidgetLines(auditorProgress({ phase: "done", percentage: 100 }), theme, 100).join("\n");
+	const hundred = renderAuditorWidgetLines(auditorProgress({ phase: "running", percentage: 100, recentOutput: [] }), theme, 100).join("\n");
 	assert.match(hundred, /100%/);
 });
 
-test("renderAuditorWidgetLines no progress bar when percentage is undefined", () => {
+test("renderAuditorWidgetLines shows no percentage when undefined", () => {
 	const progress = auditorProgress({ phase: "running", label: "Working..." });
 	const lines = renderAuditorWidgetLines(progress, theme, 100);
-	const allText = lines.join("\n");
-	// Should show label but no percentage
-	assert.match(allText, /Working/);
-	assert.doesNotMatch(allText, /\d+%/);
+	assert.match(lines.join("\n"), /Working/);
+	assert.doesNotMatch(lines.join("\n"), /\d+%/);
+});
+
+test("renderAuditorWidgetLines shows the done phase without the stop hint", () => {
+	const progress = auditorProgress({ phase: "done", currentTool: undefined, currentToolArgs: undefined, recentOutput: [] });
+	const lines = renderAuditorWidgetLines(progress, theme, 100);
+	assert.doesNotMatch(lines.join("\n"), /Esc: stop audit/);
+});
+
+test("audit progress overrides normal goal display when provided", () => {
+	const progress = auditorProgress();
+	const lines = renderGoalWidgetLines(goal(), theme, 100, { auditorProgress: progress });
+	assert.match(lines[0], /Independent completion audit/);
+	assert.doesNotMatch(lines[0], /pi-goal-x ─/);
+});
+
+test("finished audit shows the result card view (§15.4)", () => {
+	const approved = renderAuditResultCardView({ verdict: "approved", report: "ok" }, theme, 100);
+	assert.match(approved[0], /Audit result ─ APPROVED/);
+	const approvedText = approved.join("\n");
+	assert.match(approvedText, /✓ Objective satisfied\./);
+	assert.match(approvedText, /✓ Verification requirements satisfied\./);
+	assert.match(approvedText, /✓ Required tasks and evidence accepted\./);
+
+	const rejected = renderAuditResultCardView({ verdict: "disapproved", report: "- Tests were not run after the final change.\n- Task \"docs\" has no evidence." }, theme, 100);
+	const rejectedText = rejected.join("\n");
+	assert.match(rejectedText, /Audit result ─ CHANGES REQUIRED/);
+	assert.match(rejectedText, /✗ Tests were not run after the final change\./);
+	assert.match(rejectedText, /✗ Task \"docs\" has no evidence\./);
 });
 
 const testProposedAt = "2026-01-01T00:00:00.000Z";
 
-test("renderGoalWidgetLines shows task count in heading when taskList present", () => {
+test("renderGoalWidgetLines shows top-level task progress (§9.1, skipped counts as done)", () => {
 	const lines = renderGoalWidgetLines(goal({
 		taskList: {
 			tasks: [
@@ -213,12 +185,10 @@ test("renderGoalWidgetLines shows task count in heading when taskList present", 
 			proposedAt: testProposedAt,
 		},
 	}), theme, 100);
-	const heading = lines[0];
-	assert.ok(heading);
-	assert.match(heading, /2\/3 tasks/);
+	assert.match(lines.join("\n"), /Tasks  \[.*\] 2\/3 · 67%/);
 });
 
-test("renderGoalWidgetLines shows next pending task in body", () => {
+test("renderGoalWidgetLines shows the current task (first pending, inferred)", () => {
 	const lines = renderGoalWidgetLines(goal({
 		taskList: {
 			tasks: [
@@ -230,15 +200,12 @@ test("renderGoalWidgetLines shows next pending task in body", () => {
 			proposedAt: testProposedAt,
 		},
 	}), theme, 100);
-	const body = lines.slice(1).join(" ");
-	assert.match(body, /◻/);
-	// F1: counts + pending task ids, no "(next)" marker anymore.
-	assert.match(body, /1\/3 done/);
-	assert.match(body, /t2/);
-	assert.match(body, /t3/);
+	const body = lines.join("\n");
+	assert.match(body, /Tasks  \[.*\] 1\/3 · 33%/);
+	assert.match(body, /Current  t2 · Task 2/);
 });
 
-test("renderGoalWidgetLines shows 'All tasks complete' when all done", () => {
+test("renderGoalWidgetLines shows 'All tasks complete' when all done (§9.4)", () => {
 	const lines = renderGoalWidgetLines(goal({
 		taskList: {
 			tasks: [
@@ -249,37 +216,38 @@ test("renderGoalWidgetLines shows 'All tasks complete' when all done", () => {
 			proposedAt: testProposedAt,
 		},
 	}), theme, 100);
-	const body = lines.slice(1).join(" ");
-	assert.match(body, /All tasks complete/);
+	assert.match(lines.join("\n"), /Tasks  \[.*\] 2\/2 · 100%/);
+	assert.match(lines.join("\n"), /Current  All tasks complete/);
 });
 
-test("renderGoalWidgetLines omits task line when no taskList", () => {
+test("renderGoalWidgetLines omits task rows when no taskList", () => {
 	const lines = renderGoalWidgetLines(goal(), theme, 100);
-	const body = lines.slice(1).join(" ");
-	assert.equal(body.includes("tasks"), false);
+	const body = lines.join("\n");
+	assert.equal(body.includes("Tasks"), false);
+	assert.equal(body.includes("Current"), false);
 });
 
 // ── Subtask widget display ──────────────────────────────────────────────
 
-test("renderGoalWidgetLines counts subtasks recursively in heading", () => {
+test("renderGoalWidgetLines shows subtask progress for the current parent task (§9.3)", () => {
 	const lines = renderGoalWidgetLines(goal({
+		currentTaskId: "t1",
 		taskList: {
 			tasks: [{
-				id: "t1", title: "Parent", status: "complete",
+				id: "t1", title: "Parent", status: "pending",
 				subtasks: [
-					{ id: "t1a", title: "Child", status: "pending" },
-					{ id: "t1b", title: "Child2", status: "pending" },
+					{ id: "t1a", title: "Child", status: "complete" },
+					{ id: "t1b", title: "Child2", status: "complete" },
 				],
 			}],
 			blockCompletion: false,
 			proposedAt: testProposedAt,
 		},
 	}), theme, 100);
-	// Heading: 1/3 tasks (1 parent complete + 2 pending children)
-	assert.match(lines[0], /1\/3 tasks/);
+	assert.match(lines.join("\n"), /Subtasks \[.*\] 2\/2 · 100%/);
 });
 
-test("renderGoalWidgetLines finds first pending at any depth", () => {
+test("renderGoalWidgetLines infers a pending subtask as current at any depth", () => {
 	const lines = renderGoalWidgetLines(goal({
 		taskList: {
 			tasks: [{
@@ -292,10 +260,8 @@ test("renderGoalWidgetLines finds first pending at any depth", () => {
 			proposedAt: testProposedAt,
 		},
 	}), theme, 100);
-	const body = lines.slice(1).join(" ");
-	// F1: the pending child renders (depth-aware) under the count line.
-	assert.match(body, /1\/2 done/);
-	assert.match(body, /t1a/);
+	const body = lines.join("\n");
+	assert.match(body, /Current  t1a · Child/);
 });
 
 test("renderGoalWidgetLines shows all complete when subtasks are done", () => {
@@ -311,11 +277,11 @@ test("renderGoalWidgetLines shows all complete when subtasks are done", () => {
 			proposedAt: testProposedAt,
 		},
 	}), theme, 100);
-	const body = lines.slice(1).join(" ");
-	assert.match(body, /All tasks complete/);
+	const body = lines.join("\n");
+	assert.match(body, /Current  All tasks complete/);
 });
 
-test("renderGoalWidgetLines suppresses task info when disableTasks is true with subtasks", () => {
+test("renderGoalWidgetLines suppresses task info when disableTasks is true with subtasks (§9.5)", () => {
 	const lines = renderGoalWidgetLines(goal({
 		taskList: {
 			tasks: [{
@@ -326,9 +292,10 @@ test("renderGoalWidgetLines suppresses task info when disableTasks is true with 
 			proposedAt: testProposedAt,
 		},
 	}), theme, 100, { disableTasks: true });
-	const body = lines.slice(1).join(" ");
-	assert.equal(body.includes("tasks"), false);
+	const body = lines.join("\n");
+	assert.equal(body.includes("Tasks"), false);
 	assert.equal(body.includes("t1a"), false);
+	assert.equal(body.includes("Current"), false);
 });
 
 // ── TUI rendering path: GoalWidgetComponent ───────────────────────────
@@ -345,8 +312,8 @@ test("GoalWidgetComponent renders through mock TUI path", () => {
 
 	const lines = component.render(100);
 	assert.ok(lines.length > 0, "Component renders lines");
-	assert.match(lines[0], /◆ Sisyphus running/);
-	assert.match(lines[1], /├─ ⟡ Componentize the goal widget/);
+	assert.match(lines[0], /^╭─ pi-goal-x ─ Componentize the goal widget/);
+	assert.match(lines[1], /● In progress · Focused: yes/);
 });
 
 test("GoalWidgetComponent shows open goal count when > 1", () => {
@@ -361,7 +328,7 @@ test("GoalWidgetComponent shows open goal count when > 1", () => {
 
 	const lines = component.render(100);
 	const text = lines.join("\n");
-assert.match(text, /\+2 open/);
+	assert.match(text, /Other goals: 2/);
 });
 
 test("GoalWidgetComponent update triggers requestRender", () => {
@@ -394,7 +361,7 @@ test("GoalWidgetComponent invalidate triggers requestRender", () => {
 	assert.ok(state.requestRenderCalls > before, "invalidate() triggers requestRender");
 });
 
-test("GoalWidgetComponent renders auditor progress when present", () => {
+test("GoalWidgetComponent renders the audit dashboard when audit progress is present", () => {
 	const { tui } = createMockTUI();
 	const component = new GoalWidgetComponent({
 		tui,
@@ -414,8 +381,10 @@ test("GoalWidgetComponent renders auditor progress when present", () => {
 
 	const lines = component.render(100);
 	const text = lines.join("\n");
-	assert.match(text, /read/);
-	assert.match(text, /test\.txt/);
+	assert.match(text, /Independent completion audit/);
+	assert.match(text, /Objective and success criteria/);
+	// Tool details are hidden unless the dashboard is expanded (debug/audit mode).
+	assert.doesNotMatch(text, /tool read/);
 });
 
 test("GoalWidgetComponent renders with disableTasks setting", () => {
@@ -436,7 +405,8 @@ getGoal: () => goal({
 
 	const lines = component.render(100);
 	const text = lines.join("\n");
-	assert.equal(text.includes("tasks"), false, "Tasks hidden when disableTasks is true");
+	assert.equal(text.includes("Tasks"), false, "Tasks hidden when disableTasks is true");
+	assert.equal(text.includes("Current"), false, "Current hidden when disableTasks is true");
 });
 
 test("GoalWidgetComponent shows completed goal status", () => {
@@ -450,7 +420,7 @@ test("GoalWidgetComponent shows completed goal status", () => {
 	});
 
 	const lines = component.render(100);
-	assert.match(lines[0], /Goal complete/);
+	assert.match(lines.join("\n"), /All required work is complete/);
 });
 
 for (const width of [50, 70, 100, 109, 120]) {
@@ -525,4 +495,149 @@ test("GoalWidgetComponent unfocused with 38 open goals at width 109", () => {
 			`Line ${i} has visible width ${visibleWidth(lines[i])} > ${width}: ${JSON.stringify(lines[i].slice(0, 80))}`,
 		);
 	}
+});
+
+// ── §19.5 dashboard interaction tests ────────────────────────────────────────
+
+import { syncTerminalInputPause } from "../extensions/goal-widget.ts";
+
+const CTRL_SHIFT_T = "\u001b[27;6;84~";
+
+function keybindingHarness(initialExpanded = false) {
+	let expanded = initialExpanded;
+	const consumed: string[] = [];
+	let inputCb: ((data: string) => unknown) | undefined;
+	const ctx = {
+		hasUI: true,
+		ui: {
+			onTerminalInput: (cb: unknown) => { inputCb = cb as (data: string) => unknown; return () => {}; },
+			notify: () => {},
+		},
+	} as never;
+	const core = {
+		goalModalDepth: 0,
+		auditProgress: null,
+		state: { goal: null },
+		pauseActiveGoal: () => { consumed.push("pause"); },
+		abortAudit: () => { consumed.push("abort-audit"); },
+		isDashboardExpanded: () => expanded,
+		toggleDashboardExpanded: () => { expanded = !expanded; consumed.push("toggle"); },
+		terminalInputUnsubscribe: null,
+	} as never;
+	syncTerminalInputPause(core as never, ctx as never);
+	return {
+		core,
+		fire: (data: string) => inputCb?.(data),
+		expanded: () => expanded,
+		consumed,
+	};
+}
+
+test("compact mode is the default and the task shortcut expands and collapses", () => {
+	const h = keybindingHarness();
+	const compact = renderGoalWidgetLines(goal({ taskList: { tasks: [{ id: "t1", title: "T1", status: "pending" }], blockCompletion: false, proposedAt: testProposedAt } }), theme, 100);
+	assert.match(compact.join("\n"), /Ctrl\+Shift\+T: expand tasks/);
+
+	h.fire(CTRL_SHIFT_T);
+	assert.equal(h.expanded(), true, "ctrl+shift+t expands the dashboard");
+	h.fire(CTRL_SHIFT_T);
+	assert.equal(h.expanded(), false, "the same shortcut collapses it");
+	assert.deepEqual(h.consumed, ["toggle", "toggle"]);
+});
+
+test("escape collapses the expanded dashboard instead of pausing", () => {
+	const h = keybindingHarness(true);
+	h.fire("\u001b");
+	assert.equal(h.expanded(), false, "escape collapses the expanded dashboard");
+	assert.deepEqual(h.consumed, ["toggle"]);
+	assert.equal(h.consumed.includes("pause"), false, "escape while expanded must not pause the goal");
+});
+
+test("escape still pauses a running goal when the dashboard is compact", () => {
+	const h = keybindingHarness(false);
+	(h.core as unknown as { state: { goal: unknown } }).state.goal = { status: "active", autoContinue: true };
+	h.fire("\u001b");
+	assert.deepEqual(h.consumed, ["pause"]);
+});
+
+test("expanded mode renders the full dashboard without mutating editor state", () => {
+	const { tui } = createMockTUI();
+	const g = goal({ taskList: { tasks: [{ id: "t1", title: "T1", status: "pending" }], blockCompletion: false, proposedAt: testProposedAt } });
+	const expanded = { current: false };
+	const component = new GoalWidgetComponent({
+		tui,
+		theme: createMockTheme(),
+		getGoal: () => g,
+		getOpenGoalCount: () => 1,
+		getExpanded: () => expanded.current,
+		getSettings: () => ({}),
+	});
+	const compactLines = component.render(100);
+	expanded.current = true;
+	const expandedLines = component.render(100);
+	const text = expandedLines.join("\n");
+	assert.match(text, /├─ Tasks /);
+	assert.match(text, /Esc\/Ctrl\+Shift\+T: collapse/);
+	// Rendering is pure: re-rendering returns identical lines.
+	assert.deepEqual(component.render(100), expandedLines);
+	expanded.current = false;
+	assert.deepEqual(component.render(100), compactLines, "collapsing returns the compact view");
+});
+
+test("goal state updates are visible in both modes", () => {
+	const { tui } = createMockTUI();
+	let current = goal({ objective: "=== Goal ===\nObjective: First objective" });
+	const expanded = { current: false };
+	const component = new GoalWidgetComponent({
+		tui,
+		theme: createMockTheme(),
+		getGoal: () => current,
+		getOpenGoalCount: () => 1,
+		getExpanded: () => expanded.current,
+		getSettings: () => ({}),
+	});
+	assert.match(component.render(100).join("\n"), /First objective/);
+	current = goal({ objective: "=== Goal ===\nObjective: Second objective" });
+	assert.match(component.render(100).join("\n"), /Second objective/);
+	expanded.current = true;
+	assert.match(component.render(100).join("\n"), /Second objective/, "expanded mode sees updated state");
+});
+
+test("audit mode temporarily replaces the normal view and returns after", () => {
+	const { tui } = createMockTUI();
+	let audit: AuditorWidgetProgress | null = auditorProgress();
+	const component = new GoalWidgetComponent({
+		tui,
+		theme: createMockTheme(),
+		getGoal: () => goal(),
+		getOpenGoalCount: () => 1,
+		getAuditorProgress: () => audit,
+		getSettings: () => ({}),
+	});
+	const during = component.render(100).join("\n");
+	assert.match(during, /Independent completion audit/);
+	assert.doesNotMatch(during, /pi-goal-x ─/);
+	audit = null;
+	const after = component.render(100).join("\n");
+	assert.match(after, /pi-goal-x ─/);
+	assert.doesNotMatch(after, /audit complete|auditing/);
+});
+
+test("ledger events flow into the dashboard recent-activity feed", () => {
+	const { tui } = createMockTUI();
+	const events = [
+		{ type: "goal_created", goalId: "g1", objective: "x", sisyphus: false, autoContinue: true, at: "2026-01-01T09:00:00.000Z" },
+		{ type: "task_started", goalId: "g1", taskId: "t1", at: "2026-01-01T09:01:00.000Z" },
+	] as never;
+	const component = new GoalWidgetComponent({
+		tui,
+		theme: createMockTheme(),
+		getGoal: () => goal({ id: "g1", taskList: { tasks: [{ id: "t1", title: "T1", status: "pending" }], blockCompletion: false, proposedAt: testProposedAt } }),
+		getOpenGoalCount: () => 1,
+		getExpanded: () => true,
+		getLedgerEvents: () => events as never,
+		getSettings: () => ({}),
+	});
+	const text = component.render(100).join("\n");
+	assert.match(text, /Started “T1”\./, "ledger task_started maps to readable activity with the task title");
 });

--- a/tests/goal-widget.test.ts
+++ b/tests/goal-widget.test.ts
@@ -651,7 +651,13 @@ const PGUP = "\x1b[5~";
 const PGDN = "\x1b[6~";
 const HOME = "\x1b[H";
 const END = "\x1b[F";
-const F6 = "\x1b[17~";
+// Ctrl+Shift chords (free in pi — the editor owns the plain arrows).
+const CS_UP = "\x1b[1;6A";
+const CS_DOWN = "\x1b[1;6B";
+const CS_HOME = "\x1b[1;6H";
+const CS_END = "\x1b[1;6F";
+const CS_PGUP = "\x1b[5;6~";
+const CS_PGDN = "\x1b[6;6~";
 
 /** 30 top-level tasks with t5 and t20 completed (t20 latest, mid-list): both
  * the compact (5 rows @100) and expanded (20 rows @100) views overflow, the
@@ -724,43 +730,62 @@ test("compact default viewport is anchored to the most recently completed tasks"
 	assert.match(text, /… \+10 more tasks/, "pending tasks after the anchor stay reachable below");
 });
 
-test("arrows are not consumed when the compact dashboard is not focused", () => {
+test("plain arrows are never consumed in compact mode; the editor keeps them", () => {
 	const h = scrollHarness(false);
 	h.component.render(100);
 	h.fire(UP);
 	h.fire(DOWN);
 	h.fire(PGUP);
 	h.fire(PGDN);
-	assert.deepEqual(h.consumed, [], "editor keeps the arrow keys when the widget is not focused");
+	assert.deepEqual(h.consumed, [], "plain arrow/page keys belong to the editor in compact mode");
 });
 
-test("F6 engages compact scroll focus; arrows scroll and Esc disengages without pausing", () => {
+test("Ctrl+Shift+↑/↓ scroll the compact list one row; Esc is untouched", () => {
 	const h = scrollHarness(false);
 	h.component.render(100);
-	assert.match(h.component.render(100).join("\n"), /↑ 15 more tasks/);
-	h.fire(F6);
-	assert.ok(h.consumed.some((c) => c.startsWith("c:")), "F6 is consumed");
-	assert.equal(h.component.isCompactScrollFocusActive(), true);
-	h.fire(UP);
+	assert.match(h.component.render(100).join("\n"), /↑ 15 more tasks/, "anchored window hides the earliest tasks");
+	h.fire(CS_UP);
+	assert.ok(h.consumed.includes("c:" + CS_UP), "Ctrl+Shift+↑ is consumed");
 	assert.match(h.component.render(100).join("\n"), /↑ 14 more tasks/, "up scrolls the compact window");
-	h.fire(DOWN);
+	h.fire(CS_DOWN);
 	assert.match(h.component.render(100).join("\n"), /↑ 15 more tasks/, "down scrolls the compact window back");
-	// Esc disengages scroll focus — it must not pause the goal
-	h.fire("\u001b");
-	assert.equal(h.component.isCompactScrollFocusActive(), false);
-	assert.equal(h.consumed.includes("pause"), false, "Esc while scroll-focused must not pause");
+	// plain arrows and Esc still reach the editor afterwards — nothing to disengage
 	h.fire(UP);
-	assert.equal(h.consumed.filter((c) => c === "c:" + UP).length, 1, "only the focused ↑ was consumed; after Esc the arrows reach the editor");
+	h.fire("\u001b");
+	assert.equal(h.consumed.filter((c) => c === "c:" + UP).length, 0, "plain ↑ is never consumed");
+	assert.equal(h.consumed.includes("c:\u001b"), false, "Esc is not consumed when not expanded");
 });
 
-test("compact scroll focus shows a scroll hint in the footer", () => {
+test("Ctrl+Shift+Home/End/PgUp/PgDn jump and page in the compact list", () => {
 	const h = scrollHarness(false);
-	assert.match(h.component.render(100).join("\n"), /Ctrl\+Shift\+T: expand tasks/);
-	h.fire(F6);
-	assert.match(h.component.render(100).join("\n"), /↑↓\/PgUp\/PgDn: scroll · Esc done/);
+	h.component.render(100);
+	h.fire(CS_HOME);
+	assert.doesNotMatch(h.component.render(100).join("\n"), /↑ \d+ more tasks/, "home jumps to the top");
+	assert.match(h.component.render(100).join("\n"), /[✓▸·~] t1\s/, "the earliest task row is visible");
+	h.fire(CS_END);
+	assert.match(h.component.render(100).join("\n"), /↑ 25 more tasks/, "end jumps to the tail (max offset 25)");
+	assert.doesNotMatch(h.component.render(100).join("\n"), /… \+\d+ more tasks/);
+	h.fire(CS_PGDN); // at max: clamped, still consumed
+	assert.match(h.component.render(100).join("\n"), /↑ 25 more tasks/);
+	h.fire(CS_PGUP); // page up 5 rows → offset 20
+	assert.match(h.component.render(100).join("\n"), /↑ 20 more tasks/);
 });
 
-test("F6 does not engage scroll focus when the compact list fits", () => {
+test("compact overflow shows the scroll hint in the footer; a short list does not", () => {
+	const overflowing = scrollHarness(false);
+	assert.match(overflowing.component.render(100).join("\n"), /Ctrl\+Shift\+T: expand · Ctrl\+Shift\+↑↓: scroll/);
+	const narrow = scrollHarness(false);
+	assert.match(narrow.component.render(40).join("\n"), /↑↓: scroll/, "minimal layout shortens the hint");
+	const g = goal({ taskList: { tasks: [
+		{ id: "t1", title: "One", status: "pending" },
+		{ id: "t2", title: "Two", status: "pending" },
+		{ id: "t3", title: "Three", status: "pending" },
+	], blockCompletion: false, proposedAt: testProposedAt } });
+	const short = scrollHarness(false, g);
+	assert.match(short.component.render(100).join("\n"), /Ctrl\+Shift\+T: expand tasks/, "no overflow → no scroll hint");
+});
+
+test("Ctrl+Shift chords are not consumed when the compact list fits", () => {
 	const g = goal({ taskList: { tasks: [
 		{ id: "t1", title: "One", status: "pending" },
 		{ id: "t2", title: "Two", status: "pending" },
@@ -768,10 +793,9 @@ test("F6 does not engage scroll focus when the compact list fits", () => {
 	], blockCompletion: false, proposedAt: testProposedAt } });
 	const h = scrollHarness(false, g);
 	h.component.render(100);
-	h.fire(F6);
-	assert.equal(h.component.isCompactScrollFocusActive(), false, "no overflow → focus never engages");
-	h.fire(DOWN);
-	assert.equal(h.consumed.filter((c) => c.startsWith("c:")).length, 1, "only F6 was consumed; arrows reach the editor");
+	h.fire(CS_UP);
+	h.fire(CS_DOWN);
+	assert.deepEqual(h.consumed, [], "nothing to scroll → chords pass through");
 });
 
 test("expanded mode scrolls the task tree with arrows, Home, End, and page keys", () => {
@@ -793,18 +817,19 @@ test("expanded mode scrolls the task tree with arrows, Home, End, and page keys"
 	assert.ok(h.consumed.filter((c) => c.startsWith("c:")).length >= 6, "every navigation key is consumed while expanded");
 });
 
-test("expanding clears compact scroll focus; collapsing returns arrows to the editor", () => {
+test("Ctrl+Shift+T toggles expansion; plain arrows scroll only while expanded", () => {
 	const h = scrollHarness(false);
 	h.component.render(100);
-	h.fire(F6);
-	assert.equal(h.component.isCompactScrollFocusActive(), true);
-	h.fire(CTRL_SHIFT_T); // expand — clears scroll focus
+	h.fire(CS_UP); // compact scroll — chord
+	assert.ok(h.consumed.includes("c:" + CS_UP));
+	h.fire(CTRL_SHIFT_T); // expand
 	assert.equal(h.expanded(), true);
-	assert.equal(h.component.isCompactScrollFocusActive(), false);
+	h.fire(UP); // expanded is modal → plain arrow scrolls
+	assert.ok(h.consumed.includes("c:" + UP));
 	h.fire("\u001b"); // collapse
 	assert.equal(h.expanded(), false);
 	h.fire(UP);
-	assert.equal(h.consumed.filter((c) => c.startsWith("c:")).length, 3, "only F6 + Ctrl+Shift+T + Esc consumed; arrows reach the editor");
+	assert.equal(h.consumed.filter((c) => c.startsWith("c:")).length, 4, "chord + Ctrl+Shift+T + expanded ↑ + Esc consumed; plain ↑ reaches the editor after collapse");
 });
 
 test("a new completion re-anchors the viewport to the latest completed task", () => {
@@ -819,11 +844,12 @@ test("a new completion re-anchors the viewport to the latest completed task", ()
 	});
 	// anchored to t20 → compact window t16..t20
 	assert.match(component.render(100).join("\n"), /↑ 15 more tasks/);
-	// engage compact scroll focus, then scroll to the top
-	assert.equal(component.toggleCompactScrollFocus(), true, "compact list overflows → focus engages");
-	component.handleNavigationKey("home");
+	// scroll to the top with the compact chord
+	assert.equal(component.handleCompactScrollKey("home"), true, "compact list overflows → chord consumed");
 	assert.doesNotMatch(component.render(100).join("\n"), /↑ \d+ more tasks/);
 	assert.match(component.render(100).join("\n"), /[✓▸·~] t1\s/, "the earliest task row is visible after scrolling up");
+	// a short list: the chord is inert
+	assert.equal(component.handleCompactScrollKey("down"), true, "still overflows → consumed");
 	// a new completion (t9, later than t20) arrives → re-anchor to t9
 	const tasks = (current.taskList!.tasks as GoalTask[]).map((t) => ({ ...t }));
 	tasks[8] = { ...tasks[8]!, status: "complete", completedAt: "2026-01-01T12:00:00.000Z" };

--- a/tests/goal-widget.test.ts
+++ b/tests/goal-widget.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { renderGoalWidgetLines, renderAuditorWidgetLines, renderAuditResultCardView, GoalWidgetComponent, type GoalWidgetRecord, type AuditorWidgetProgress } from "../extensions/widgets/goal-widget.ts";
+import type { GoalTask } from "../extensions/goal-record.ts";
 import { createMockTUI, createMockTheme } from "./tui-test-utils.ts";
 
 const theme = {
@@ -640,4 +641,194 @@ test("ledger events flow into the dashboard recent-activity feed", () => {
 	});
 	const text = component.render(100).join("\n");
 	assert.match(text, /Started “T1”\./, "ledger task_started maps to readable activity with the task title");
+});
+
+// ── §9.6 task-list scrolling ─────────────────────────────────────────────────
+
+const UP = "\x1b[A";
+const DOWN = "\x1b[B";
+const PGUP = "\x1b[5~";
+const PGDN = "\x1b[6~";
+const HOME = "\x1b[H";
+const END = "\x1b[F";
+const F6 = "\x1b[17~";
+
+/** 30 top-level tasks with t5 and t20 completed (t20 latest, mid-list): both
+ * the compact (5 rows @100) and expanded (20 rows @100) views overflow, the
+ * anchored window is a middle slice that can scroll in BOTH directions, and
+ * the earliest task row is hidden by default. */
+function manyTasksGoal(): GoalWidgetRecord {
+	const tasks: GoalTask[] = Array.from({ length: 30 }, (_, i) => ({
+		id: `t${i + 1}`,
+		title: `Task number ${i + 1}`,
+		status: "pending" as const,
+	}));
+	tasks[4] = { ...tasks[4]!, status: "complete", completedAt: "2026-01-01T10:00:00.000Z" };
+	tasks[19] = { ...tasks[19]!, status: "complete", completedAt: "2026-01-01T11:00:00.000Z" };
+	return goal({ taskList: { tasks, blockCompletion: false, proposedAt: testProposedAt } });
+}
+
+function scrollHarness(initialExpanded = false, g: GoalWidgetRecord = manyTasksGoal()) {
+	let expanded = initialExpanded;
+	const consumed: string[] = [];
+	let inputCb: ((data: string) => unknown) | undefined;
+	const { tui } = createMockTUI();
+	const component = new GoalWidgetComponent({
+		tui,
+		theme: createMockTheme(),
+		getGoal: () => g,
+		getOpenGoalCount: () => 1,
+		getExpanded: () => expanded,
+		getSettings: () => ({}),
+	});
+	const ctx = {
+		hasUI: true,
+		ui: {
+			onTerminalInput: (cb: unknown) => { inputCb = cb as (data: string) => unknown; return () => {}; },
+			notify: () => {},
+		},
+	} as never;
+	const core = {
+		goalModalDepth: 0,
+		auditProgress: null,
+		state: { goal: null },
+		pauseActiveGoal: () => { consumed.push("pause"); },
+		abortAudit: () => { consumed.push("abort-audit"); },
+		isDashboardExpanded: () => expanded,
+		toggleDashboardExpanded: () => { expanded = !expanded; consumed.push("toggle"); },
+		goalWidgetComponentRef: { current: component },
+		terminalInputUnsubscribe: null,
+	} as never;
+	syncTerminalInputPause(core as never, ctx as never);
+	return {
+		fire: (data: string) => {
+			const result = inputCb?.(data);
+			if (result && typeof result === "object" && (result as { consume?: boolean }).consume) {
+				consumed.push(`c:${data}`);
+			}
+			return result;
+		},
+		expanded: () => expanded,
+		consumed,
+		component,
+	};
+}
+
+test("compact default viewport is anchored to the most recently completed tasks", () => {
+	const lines = renderGoalWidgetLines(manyTasksGoal(), theme, 100);
+	const text = lines.join("\n");
+	assert.match(text, /↑ 15 more tasks/, "earliest tasks are hidden above the anchored window");
+	assert.match(text, /Task number 20/, "the latest completion is the last visible row");
+	assert.match(text, /Task number 16/, "the window is a middle slice around the anchor");
+	assert.doesNotMatch(text, /[✓▸·~] t1\s/, "the earliest task row is not shown");
+	assert.match(text, /… \+10 more tasks/, "pending tasks after the anchor stay reachable below");
+});
+
+test("arrows are not consumed when the compact dashboard is not focused", () => {
+	const h = scrollHarness(false);
+	h.component.render(100);
+	h.fire(UP);
+	h.fire(DOWN);
+	h.fire(PGUP);
+	h.fire(PGDN);
+	assert.deepEqual(h.consumed, [], "editor keeps the arrow keys when the widget is not focused");
+});
+
+test("F6 engages compact scroll focus; arrows scroll and Esc disengages without pausing", () => {
+	const h = scrollHarness(false);
+	h.component.render(100);
+	assert.match(h.component.render(100).join("\n"), /↑ 15 more tasks/);
+	h.fire(F6);
+	assert.ok(h.consumed.some((c) => c.startsWith("c:")), "F6 is consumed");
+	assert.equal(h.component.isCompactScrollFocusActive(), true);
+	h.fire(UP);
+	assert.match(h.component.render(100).join("\n"), /↑ 14 more tasks/, "up scrolls the compact window");
+	h.fire(DOWN);
+	assert.match(h.component.render(100).join("\n"), /↑ 15 more tasks/, "down scrolls the compact window back");
+	// Esc disengages scroll focus — it must not pause the goal
+	h.fire("\u001b");
+	assert.equal(h.component.isCompactScrollFocusActive(), false);
+	assert.equal(h.consumed.includes("pause"), false, "Esc while scroll-focused must not pause");
+	h.fire(UP);
+	assert.equal(h.consumed.filter((c) => c === "c:" + UP).length, 1, "only the focused ↑ was consumed; after Esc the arrows reach the editor");
+});
+
+test("compact scroll focus shows a scroll hint in the footer", () => {
+	const h = scrollHarness(false);
+	assert.match(h.component.render(100).join("\n"), /Ctrl\+Shift\+T: expand tasks/);
+	h.fire(F6);
+	assert.match(h.component.render(100).join("\n"), /↑↓\/PgUp\/PgDn: scroll · Esc done/);
+});
+
+test("F6 does not engage scroll focus when the compact list fits", () => {
+	const g = goal({ taskList: { tasks: [
+		{ id: "t1", title: "One", status: "pending" },
+		{ id: "t2", title: "Two", status: "pending" },
+		{ id: "t3", title: "Three", status: "pending" },
+	], blockCompletion: false, proposedAt: testProposedAt } });
+	const h = scrollHarness(false, g);
+	h.component.render(100);
+	h.fire(F6);
+	assert.equal(h.component.isCompactScrollFocusActive(), false, "no overflow → focus never engages");
+	h.fire(DOWN);
+	assert.equal(h.consumed.filter((c) => c.startsWith("c:")).length, 1, "only F6 was consumed; arrows reach the editor");
+});
+
+test("expanded mode scrolls the task tree with arrows, Home, End, and page keys", () => {
+	const h = scrollHarness(true);
+	h.component.render(100); // expanded rows 20 over 30 nodes; anchor t20 → offset 0
+	assert.doesNotMatch(h.component.render(100).join("\n"), /↑ \d+ more tasks/, "anchored window starts at the top");
+	assert.match(h.component.render(100).join("\n"), /Task number 20/, "the latest completion is the last visible row");
+	h.fire(DOWN);
+	assert.match(h.component.render(100).join("\n"), /↑ 1 more task/, "down moves the expanded window");
+	h.fire(HOME);
+	assert.doesNotMatch(h.component.render(100).join("\n"), /↑ \d+ more tasks/, "home jumps to the top");
+	h.fire(UP); // at top: clamped, still consumed
+	h.fire(END);
+	assert.match(h.component.render(100).join("\n"), /↑ 10 more tasks/, "end jumps to the tail (max offset 10)");
+	h.fire(PGDN); // at max: clamped, still consumed
+	assert.match(h.component.render(100).join("\n"), /↑ 10 more tasks/);
+	h.fire(PGUP); // page up 20 rows → top
+	assert.doesNotMatch(h.component.render(100).join("\n"), /↑ \d+ more tasks/);
+	assert.ok(h.consumed.filter((c) => c.startsWith("c:")).length >= 6, "every navigation key is consumed while expanded");
+});
+
+test("expanding clears compact scroll focus; collapsing returns arrows to the editor", () => {
+	const h = scrollHarness(false);
+	h.component.render(100);
+	h.fire(F6);
+	assert.equal(h.component.isCompactScrollFocusActive(), true);
+	h.fire(CTRL_SHIFT_T); // expand — clears scroll focus
+	assert.equal(h.expanded(), true);
+	assert.equal(h.component.isCompactScrollFocusActive(), false);
+	h.fire("\u001b"); // collapse
+	assert.equal(h.expanded(), false);
+	h.fire(UP);
+	assert.equal(h.consumed.filter((c) => c.startsWith("c:")).length, 3, "only F6 + Ctrl+Shift+T + Esc consumed; arrows reach the editor");
+});
+
+test("a new completion re-anchors the viewport to the latest completed task", () => {
+	let current = manyTasksGoal();
+	const { tui } = createMockTUI();
+	const component = new GoalWidgetComponent({
+		tui,
+		theme: createMockTheme(),
+		getGoal: () => current,
+		getOpenGoalCount: () => 1,
+		getSettings: () => ({}),
+	});
+	// anchored to t20 → compact window t16..t20
+	assert.match(component.render(100).join("\n"), /↑ 15 more tasks/);
+	// engage compact scroll focus, then scroll to the top
+	assert.equal(component.toggleCompactScrollFocus(), true, "compact list overflows → focus engages");
+	component.handleNavigationKey("home");
+	assert.doesNotMatch(component.render(100).join("\n"), /↑ \d+ more tasks/);
+	assert.match(component.render(100).join("\n"), /[✓▸·~] t1\s/, "the earliest task row is visible after scrolling up");
+	// a new completion (t9, later than t20) arrives → re-anchor to t9
+	const tasks = (current.taskList!.tasks as GoalTask[]).map((t) => ({ ...t }));
+	tasks[8] = { ...tasks[8]!, status: "complete", completedAt: "2026-01-01T12:00:00.000Z" };
+	current = { ...current, taskList: { tasks, blockCompletion: false, proposedAt: testProposedAt } };
+	const text = component.render(100).join("\n");
+	assert.match(text, /↑ 4 more tasks/, "re-anchored window shows the new completion (offset 4)");
+	assert.match(text, /Task number 9/, "the newest completion is visible at the bottom of the window");
 });

--- a/tests/integration/extension.test.ts
+++ b/tests/integration/extension.test.ts
@@ -63,6 +63,8 @@ function createHarness(options: HarnessOptions): Harness {
 	const ctx = {
 		cwd: options.cwd,
 		hasUI: options.hasUI ?? false,
+		modelRegistry: { getAvailable: () => [] },
+		model: undefined,
 		sessionManager: {
 			getBranch: () => options.sessionEntries,
 			getCwd: () => options.cwd,
@@ -320,7 +322,7 @@ describe("five-tool handler integration", () => {
 	it("goal-settings menu toggles the disabled switch through the registered handler", async () => {
 		const f = fixture();
 		try {
-			const selects: string[] = ["  disabled: (default)", "Done"];
+			const selects: string[] = ["  auditor disabled: false", "Done"];
 			const h = createHarness({
 				cwd: f.cwd,
 				sessionEntries: f.sessionEntries,
@@ -370,7 +372,7 @@ describe("five-tool handler integration", () => {
 			return existsSync(p) ? JSON.parse(readFileSync(p, "utf8")) : {};
 		};
 
-		it("displays every one of the eight persisted rows and reflects file values", async () => {
+		it("displays every one of the nine persisted rows and reflects file values", async () => {
 			const f = fixture();
 			try {
 				writeFileSync(settingsPath(f.cwd), JSON.stringify({
@@ -387,8 +389,8 @@ describe("five-tool handler integration", () => {
 				await start(h);
 				await h.commands.get("goal-settings").handler("", h.ctx);
 				const lines = firstOptions.filter((o) => o.startsWith("  ") && !o.startsWith("  ───"));
-				assert.equal(lines.length, 8, `all eight rows rendered, got: ${lines.join(" | ")}`);
-				assert.ok(lines.some((l) => l === "  disabled: true"));
+				assert.equal(lines.length, 9, `all nine rows rendered, got: ${lines.join(" | ")}`);
+				assert.ok(lines.some((l) => l === "  auditor disabled: true"));
 				assert.ok(lines.some((l) => l === "  provider: anthropic"));
 				assert.ok(lines.some((l) => l === "  model: (default)"));
 				assert.ok(lines.some((l) => l === "  thinking_level: high"));
@@ -396,6 +398,7 @@ describe("five-tool handler integration", () => {
 				assert.ok(lines.some((l) => l === "  disableContracts: false"));
 				assert.ok(lines.some((l) => l === "  subtaskDepth: 3"));
 				assert.ok(lines.some((l) => l === "  autoSelectSingleGoal: false"));
+				assert.ok(lines.some((l) => l === "  stall timeout (minutes): 0"));
 			} finally {
 				f.cleanup();
 			}
@@ -405,10 +408,10 @@ describe("five-tool handler integration", () => {
 			const f = fixture();
 			try {
 				const selects = [
-					"  disableTasks: (default)",
-					"  disableContracts: (default)",
-					"  disabled: (default)",
-					"  autoSelectSingleGoal: (default)",
+					"  disableTasks: false",
+					"  disableContracts: false",
+					"  auditor disabled: false",
+					"  autoSelectSingleGoal: false",
 					"Done",
 				];
 				const h = createHarness({
@@ -444,8 +447,14 @@ describe("five-tool handler integration", () => {
 		it("edits and clears provider and model text fields", async () => {
 			const f = fixture();
 			try {
-				const selects = ["  provider: (default)", "  model: (default)", "Done"];
-				const inputs = ["anthropic", "claude-sonnet-4"];
+				// Set both via the manual provider/model entry: filter first, then
+				// pick "✎ Enter provider/model manually (advanced)", then type the pair.
+				const selects = [
+					"  provider: (default)", "✎ Enter provider/model manually (advanced)",
+					"  model: (default)", "✎ Enter provider/model manually (advanced)",
+					"Done",
+				];
+				const inputs = ["", "anthropic/claude-sonnet-4", "", "anthropic/claude-sonnet-4"];
 				const h = createHarness({
 					cwd: f.cwd, sessionEntries: f.sessionEntries, hasUI: true,
 					select: async () => selects.shift(),
@@ -456,9 +465,10 @@ describe("five-tool handler integration", () => {
 				const saved = readSettings(f.cwd);
 				assert.equal(saved.provider, "anthropic");
 				assert.equal(saved.model, "claude-sonnet-4");
-				// Clear both by entering an empty value.
-				const selects2 = ["  provider: anthropic", "  model: claude-sonnet-4", "Done"];
-				const inputs2 = ["", ""];
+				// Clear both by returning to the current-session/default choice from
+				// either row: the default choice deletes provider and model together.
+				const selects2 = ["  provider: anthropic", "  Current session / default (system default)", "Done"];
+				const inputs2 = [""];
 				const h2 = createHarness({
 					cwd: f.cwd, sessionEntries: f.sessionEntries, hasUI: true,
 					select: async () => selects2.shift(),
@@ -467,8 +477,8 @@ describe("five-tool handler integration", () => {
 				await start(h2);
 				await h2.commands.get("goal-settings").handler("", h2.ctx);
 				const saved2 = readSettings(f.cwd);
-				assert.equal(saved2.provider, undefined, "empty input clears provider");
-				assert.equal(saved2.model, undefined, "empty input clears model");
+				assert.equal(saved2.provider, undefined, "default choice clears provider");
+				assert.equal(saved2.model, undefined, "default choice clears model");
 			} finally {
 				f.cleanup();
 			}

--- a/tests/task-list-overlay.test.ts
+++ b/tests/task-list-overlay.test.ts
@@ -349,7 +349,7 @@ test("dismisses on escape and enter", async () => {
 	assert.ok(true, "dismiss operations completed without error");
 });
 
-test("keybinding calls showTaskListOverlay with focusedGoalId", async () => {
+test("ctrl+shift+t toggles the unified dashboard expansion (overlay registration removed)", async () => {
 	const goalSource = readFileSync(
 		new URL("../extensions/goal-widget.ts", import.meta.url),
 		"utf-8",
@@ -360,12 +360,12 @@ test("keybinding calls showTaskListOverlay with focusedGoalId", async () => {
 		"goal-widget.ts contains the ctrl+shift+t keybinding",
 	);
 	assert.ok(
-		goalSource.includes("showTaskListOverlay(ctx, core.goalsById, core.focusedGoalId, {"),
-		"goal-widget.ts calls showTaskListOverlay with focusedGoalId (F3 adds the toggle callback)",
+		goalSource.includes("core.toggleDashboardExpanded()"),
+		"ctrl+shift+t toggles the unified dashboard (overlay registration removed)",
 	);
 	assert.ok(
-		goalSource.includes("onToggleTask"),
-		"goal-widget.ts wires the F3 interactive toggle callback",
+		!goalSource.includes("showTaskListOverlay("),
+		"the separate task-list overlay is no longer registered from the keybinding",
 	);
 	assert.ok(
 		goalSource.includes('return { consume: true }'),


### PR DESCRIPTION
# Unified Dashboard and Goal-Lifecycle Experience

## Summary

This PR delivers the unified dashboard and full goal-lifecycle upgrade as **one coherent feature** (16 commits, all reviewable): one shared dashboard presentation model drives the above-editor widget, `/goal-status`, and the completion flow, so they can never drift apart on data or terminology. It adds a scrollable latest-completion-anchored task list, an expanded full-dashboard mode, persisted current-task state, a structured completion audit view, guided-drafting polish, and a pastel one-tone colour system with regression tests pinning every colour region.

Everything shown is derived from persisted goal state and the durable ledger — progress, current task, verification, audit result, and activity are never fabricated for display.

## What's new

### Unified goal dashboard
- **One component, two modes** driven by a shared pure presentation model (`extensions/widgets/goal-dashboard-model.ts`): compact (above-editor summary) and expanded (full dashboard). The widget, `/goal-status`, and the completion flow all render the same model.
- **`Ctrl+Shift+T` toggles** compact ↔ expanded (it previously opened a separate task overlay — the overlay registration is **removed**, its behavior merged into expanded mode). `Esc` collapses back to compact.
- **Expanded mode**: the full task tree with colour-coded markers (✓ complete, ▸ current, ~ skipped, · pending), the current-task block with verification contract and evidence, subtask progress, the goal-level verification contract, a token-budget gauge, and a recent-activity feed derived from the durable ledger.

### Scrollable, latest-completion-anchored task list
- The task list is a **window over the plan-ordered list** that defaults to showing the **most recently completed tasks** (anchored by `completedAt`) rather than the earliest; a new completion re-anchors the window.
- **Compact mode** scrolls with **free `Ctrl+Shift` chords** (`Ctrl+Shift+↑/↓`, `PgUp/PgDn`, `Home`/`End`) that are consumed *only* when the list overflows — the editor's arrows are never touched — with a `Ctrl+Shift+↑↓: scroll` footer hint.
- **Expanded mode** is modal and scrolls with `↑/↓`, `PgUp/PgDn`, `Home`/`End`, with `↑ N more` / `… +N more` indicator rows.
- `/goal-status` renders the same anchored window as a static snapshot; the window and indicators are width-safe at 40–140 columns.

### Persisted current-task state
- Optional `currentTaskId` field on goal records — the **execution focus**, distinct from completion status — plus a `task_started` ledger event and `update_goal_task(status="start")`.
- Normalization accepts a persisted focus **only when it references an existing pending task**; the focus clears when that task is completed, skipped, or removed, and is preserved through task-list restructuring.
- For display only, the dashboard may infer the first pending task and marks it as inferred.
- **Backward compatible**: legacy goal files load without the field and are never rewritten just because it is absent.

### Improved `/goal-status`
- **Standard mode**: a static compact-dashboard rendering plus current-task details, recent activity, and the last audit result — no effective-settings noise.
- **Verbose mode** (`/goal-status verbose`): goal id/revision, full objective, complete task tree with evidence and contracts, recent ledger history, token-budget detail, pause/blocker detail, active/archived paths, the last audit report, and effective settings with provenance.

### Structured completion audit
- During an independent audit the widget shows a **structured audit dashboard**: five check stages and a progress bar; after the audit it shows the approval or changes-required result before returning to the normal view. `Esc` during an audit stops it and lets you choose to continue working or complete without audit.
- Successful archival now emits a durable `goal_archived` ledger event.

### Drafting polish
- Durable proposal summary (objective, plan, tasks) shown in guided drafting; goal-draft proposals always show the task list exactly once; `/goal-tweak` proposals preserve task statuses; the settings menu renders all nine rows.

## Colour system (pastel, one tone, regression-tested)

- **Pastel palette**: task titles in soft amber (`mdHeading`); markers and ids colour-coded — ✓ muted green, ▸ teal, ~ gray, · amber; the current task fully highlighted in the theme accent.
- **One-tone neutral-gray chrome**: corners, top/bottom frame dashes, left/right edges, and interior rules all share a single neutral-gray tone (no blue tinge). The blue-tinged `mdLink` token is **banned from the renderer's colour union at compile time**, so a blue frame cannot regress.
- **Muted progress**: the task progress bar, its empty cells, the `3/5 · 60%` fraction/percent, and the current task's subtask progress are all neutral gray — accent is reserved for genuine emphasis (brand, status symbol, current task).
- **Palette tests** (`tests/goal-dashboard-golden.test.ts`) pin every colour region — frame LHS/RHS symmetry, corner/edge/rules tones, header meta, footer hint, muted percentages, bar fill, and zero `warning`/`borderMuted`/`mdLink` usage.

## Keybindings

| Key | Action |
| --- | --- |
| `Ctrl+Shift+T` | Toggle dashboard compact ↔ expanded (was: task overlay) |
| `↑`/`↓`, `PgUp`/`PgDn`, `Home`/`End` | Scroll the expanded task tree (modal) |
| `Ctrl+Shift+↑`/`↓`, `Ctrl+Shift+PgUp`/`PgDn`, `Ctrl+Shift+Home`/`End` | Scroll the compact task list (only when it overflows) |
| `Esc` | Collapse expanded dashboard; otherwise pause the goal |
| `Esc` (during audit) | Stop the audit; continue working or complete without audit |

No F-keys are used anywhere in the dashboard.

## Width behaviour

Layouts adapt across **wide (≥100)**, **medium (70–99)**, **narrow (50–69)**, and **very narrow (<50)** terminals: full border + multi-field lines at wide, down to the essential summary (status, task progress, current task, contract) at very narrow. The renderer never emits a line wider than the terminal — all truncation is visible-width aware (ANSI, Unicode, double-width characters). Golden tests assert `visibleWidth(line) <= width` for every rendered line at 40, 50, 60, 80, 100, and 140 columns.

## Migration & compatibility

- Existing goal files load unchanged; the new `currentTaskId` is optional and never forces a rewrite.
- The task-list overlay shortcut now toggles the unified dashboard instead of opening a separate overlay.
- All rendering is pure-model (no TUI imports): the model and renderer are independently testable.

## Testing

- **685 tests green** (`npm run check` + `npm run test:all`), `tsc --noEmit` clean.
- New suites: `goal-dashboard-model.test.ts` (presentation model), `goal-dashboard-golden.test.ts` (golden layouts + palette), `goal-audit-dashboard.test.ts`, `goal-status.test.ts`, `goal-task-lifecycle.test.ts`, `goal-activity.test.ts`, and an **end-to-end lifecycle dashboard test** (`tests/e2e/goal-lifecycle-dashboard.test.ts`, discovered via `npm run test:e2e`).
- Golden tests cover every layout mode and every goal state (active, blocked, paused, budget-limited, complete) at 40–140 columns.

## Commits (16)

```
60ce750 feat(goal): unified goal dashboard with shared compact/expanded renderer
b931b06 feat(goal): persist current-task focus and task operations
064904c feat(goal): status dashboard, guided-drafting polish, audit and archival
99204b8 docs(goal): document the unified dashboard, visible status, and drafting
a14c0fa test(goal): end-to-end lifecycle dashboard test and runner discovery
eb5542d feat: anchor task-list viewport to latest completed task
996c838 feat(goal): scrollable dashboard task list with latest-completion anchor
7d9e767 test+docs(goal): anchored task-list window parity, goldens, and docs
cdcfe21 feat(goal): scroll compact task list with free Ctrl+Shift chords instead
4772203 feat(goal): pastel dashboard palette — soft amber tasks, gray borders
ab3e225 feat(goal): light steel-blue frame and richly colour-coded compact dashboard
f4bae6a fix(goal): uniform frame color and exact-width box edges
21f0e2c fix(goal): one-tone frame lines and muted tasks percentage
b2b969b fix(goal): one-tone box chrome — frame, edges, corners and rules unified
51db0c7 fix(goal): chrome is neutral gray, not blue-tinged
b6f2146 fix(goal): mute the tasks progress bar and all progress-tied colors
```

## Files (45 changed, +7595 / −561)

Key files: `extensions/widgets/goal-dashboard-model.ts` (+495), `extensions/widgets/goal-dashboard-renderer.ts` (+622), `extensions/widgets/goal-widget.ts` (rewritten to modal expanded dashboard), `extensions/widgets/auditor-dashboard-model.ts` (+174), `extensions/goal-status.ts` (+185), `extensions/goal-task-tools.ts`, `extensions/goal-record.ts`, `extensions/goal-events.ts`, `extensions/goal-ledger.ts`, `extensions/goal-state.ts`, plus 15 test files and `docs/unified-dashboard.md` / `docs/pi-goal-x-unified-dashboard-plan.md`.
