### PR TITLE
Fix Pi 0.84 lifecycle and fullscreen regressions

### DIFF
--- a/extensions/goal-events.ts
+++ b/extensions/goal-events.ts
@@ -34,10 +34,12 @@ import type { GoalMutationOutcome } from "./goal-service.ts";
  * The goal extension's lifecycle event handlers (context, turn_start,
  * tool_call, tool_execution_end, turn_end, message_end, session_start,
  * session_before_compact, session_compact, session_tree, before_agent_start,
- * agent_end, session_shutdown). All state flows through the GoalCore.
+ * agent_end, agent_settled, session_shutdown). All state flows through the
+ * GoalCore.
  */
 export function registerGoalEvents(core: GoalCore): void {
 	const { pi } = core;
+	let continuationAfterSettleFor: string | null = null;
 
 	pi.on("context", async (event): Promise<{ messages: typeof event.messages } | undefined> => {
 		let changed = false;
@@ -418,6 +420,7 @@ export function registerGoalEvents(core: GoalCore): void {
 	pi.on("agent_end", async (event, ctx) => {
 		const endedGoalId = core.runningGoalId;
 		core.runningGoalId = null;
+		continuationAfterSettleFor = null;
 
 		// Account for any tokens from aborted in-flight assistant messages so
 		// they are not silently lost (but charge them to the original goal).
@@ -446,10 +449,23 @@ export function registerGoalEvents(core: GoalCore): void {
 		}
 		core.persist(ctx);
 		core.updateUI(ctx);
-		core.queueContinuation(ctx);
+		// agent_end runs before pi finishes retries, compaction, terminating-tool
+		// settlement, and queued messages. Starting the continuation timer here
+		// can poll a stale busy context for minutes on pi 0.84. agent_settled is
+		// available in both supported SDK lines (0.83 and 0.84) and is the first
+		// point where pi guarantees no automatic work remains.
+		continuationAfterSettleFor = core.state.goal.id;
+	});
+
+	pi.on("agent_settled", async (_event, ctx) => {
+		const goalId = continuationAfterSettleFor;
+		continuationAfterSettleFor = null;
+		if (!goalId || !core.isActionableContinuationGoal(goalId)) return;
+		core.queueContinuation(ctx, true);
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
+		continuationAfterSettleFor = null;
 		core.accountProgress(ctx);
 		core.clearContinuationTimer();
 		core.terminalInputUnsubscribe?.();

--- a/extensions/goal-questionnaire.ts
+++ b/extensions/goal-questionnaire.ts
@@ -29,6 +29,20 @@ export interface GoalQuestionnaireResult {
 
 export type ProposalDecision = "confirm" | "continue" | "cancel";
 
+/**
+ * Bound a custom dialog using the regular renderer's frame cache when
+ * available. The pi 0.84 fullscreen renderer does not expose that cache, so
+ * reserve four rows for host chrome and use the remaining terminal height.
+ */
+export function computeDialogLineLimit(args: { terminalRows?: number; baseFrameLines?: number }): number | undefined {
+	const rows = args.terminalRows;
+	if (!rows || rows <= 0) return undefined;
+	if (args.baseFrameLines && args.baseFrameLines > 0) {
+		return Math.min(rows, Math.max(10, rows - args.baseFrameLines + 1));
+	}
+	return Math.min(rows, Math.max(4, rows - 4));
+}
+
 export function normalizeQuestionnaireQuestions(rawQuestions: GoalQuestionnaireQuestion[]): GoalQuestionnaireQuestion[] {
 	const seenIds = new Set<string>();
 	return rawQuestions.map((q, i) => {
@@ -114,7 +128,7 @@ export async function runGoalQuestionnaire(ctx: ExtensionContext, rawQuestions: 
 		const tuiInfo = tui as unknown as { terminal?: { rows?: number }; previousLines?: string[] };
 		const terminalRows = tuiInfo.terminal?.rows;
 		const baseFrame = tuiInfo.previousLines?.length;
-		const maxDialogLines = terminalRows && baseFrame ? Math.max(10, terminalRows - baseFrame + 1) : undefined;
+		const maxDialogLines = computeDialogLineLimit({ terminalRows, baseFrameLines: baseFrame });
 		let currentTab = 0;
 		let optionIndex = 0;
 		let inputMode = false;

--- a/tests/goal-questionnaire.test.ts
+++ b/tests/goal-questionnaire.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+	computeDialogLineLimit,
 	formatQuestionnaireAnswers,
 	isHeadlessQuestionSufficientForDraft,
 	normalizeQuestionnaireQuestions,
@@ -24,6 +25,16 @@ test("normalizeQuestionnaireQuestions trims ids, de-duplicates, filters options,
 			{ id: "q3", question: "Empty id?", options: [], recommended: undefined, allowCustom: true },
 		],
 	);
+});
+
+test("dialog line limit supports pi 0.83 frames and pi 0.84 docked/fullscreen frames", () => {
+	assert.equal(computeDialogLineLimit({ terminalRows: 46, baseFrameLines: 38 }), 10);
+	assert.equal(computeDialogLineLimit({ terminalRows: 46, baseFrameLines: 20 }), 27);
+	assert.equal(computeDialogLineLimit({ terminalRows: 46 }), 42);
+	assert.equal(computeDialogLineLimit({ terminalRows: 8 }), 4);
+	assert.equal(computeDialogLineLimit({ terminalRows: 8, baseFrameLines: 20 }), 8);
+	assert.equal(computeDialogLineLimit({ terminalRows: 3 }), 3);
+	assert.equal(computeDialogLineLimit({}), undefined);
 });
 
 test("formatQuestionnaireAnswers emits stable Q/A records with context and options", () => {

--- a/tests/goal-stale-continuation-golden.test.ts
+++ b/tests/goal-stale-continuation-golden.test.ts
@@ -294,6 +294,7 @@ test("provider-error guard: agent_end with an error message never queues a conti
 		await startSession(h.handlers, h.ctx, sessionEntriesFor(goal));
 
 		await h.handlers["agent_end"]({ messages: [{ role: "assistant", stopReason: "error" }] }, idleCtx(h.ctx));
+		await h.handlers["agent_settled"]({}, idleCtx(h.ctx));
 
 		assert.equal(await countCheckpoints(h), 0, "agent_end with an error message must not queue a continuation");
 	} finally {
@@ -301,15 +302,17 @@ test("provider-error guard: agent_end with an error message never queues a conti
 	}
 });
 
-test("provider-error guard: agent_end without errors still queues a continuation", async () => {
+test("successful agent_end waits for agent_settled before queuing a continuation", async () => {
 	const { cwd, goal } = fixtureCwd();
 	const h = createHarness(cwd);
 	try {
 		await startSession(h.handlers, h.ctx, sessionEntriesFor(goal));
 
 		await h.handlers["agent_end"]({ messages: [{ role: "assistant", stopReason: "end_turn" }] }, idleCtx(h.ctx));
+		assert.equal(await countCheckpoints(h), 0, "agent_end runs before pi is truly idle");
 
-		assert.equal(await countCheckpoints(h), 1, "agent_end without errors must queue a continuation");
+		await h.handlers["agent_settled"]({}, idleCtx(h.ctx));
+		assert.equal(await countCheckpoints(h), 1, "agent_settled queues the continuation without idle polling");
 	} finally {
 		// temp dir cleanup is best-effort.
 	}


### PR DESCRIPTION
## Summary

- Bound questionnaire dialogs in Pi 0.84 fullscreen mode, where the regular renderer's `previousLines` frame cache is unavailable.
- Queue goal auto-continuations from `agent_settled` instead of `agent_end`, after retries, compaction, and queued messages finish.
- Preserve the Pi 0.83 sizing path and continuation error guards, with explicit coverage for very small terminals.

## Problem

Pi 0.84's fullscreen renderer clips an unbounded custom questionnaire from the top, which can hide its controls. Pi can also perform automatic work after `agent_end`; scheduling a continuation there can leave the timer polling a busy context instead of advancing the goal.

Use the terminal height when the fullscreen renderer has no frame cache, and defer successful-run continuations to Pi's documented settled boundary. Recheck the goal before scheduling so provider errors and stale goals remain inert.

## Validation

- `npm run check` with Pi SDK 0.83.0, 0.84.0, and 0.84.1
- `npm test`: 691/691 pass on each SDK version
- `npm run test:integration`: 28/28 pass on each SDK version
- `npm run test:serial`: 691/691 pass with Pi SDK 0.84.1
