### PR TITLE
goal: configure task dashboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,22 @@ Settings are stored in:
 
 Use `/goal-settings` to configure task lists, verification contracts, subtask depth, automatic goal selection, and completion auditing. Goal objectives have no hard length limit by default; set `objectiveMaxChars` (or `PI_GOAL_OBJECTIVE_MAX_CHARS`, `0` = no limit) to cap objective length across `create_goal`, `propose_goal_draft`, and `/goal-tweak`.
 
+Configure the task shortcuts in the same file when the terminal captures the defaults:
+
+```json
+{
+  "keybindings": {
+    "dashboard": {
+      "toggleExpand": "ctrl+shift+t",
+      "scrollUp": "ctrl+shift+up",
+      "scrollDown": "ctrl+shift+down"
+    }
+  }
+}
+```
+
+The default task bindings are `ctrl+shift+t`, `ctrl+shift+up`, and `ctrl+shift+down`. Use pi key names such as `ctrl+shift+up`.
+
 ## License
 
 MIT

--- a/docs/unified-dashboard.md
+++ b/docs/unified-dashboard.md
@@ -227,6 +227,11 @@ auditor's findings, and returns to the normal dashboard so work can continue.
 | `Esc` | Collapse the expanded dashboard; otherwise pause the goal |
 | `Esc` (during audit) | Stop the audit and choose to continue working or complete without audit |
 
+Configure the three task shortcuts with `keybindings.dashboard.toggleExpand`,
+`keybindings.dashboard.scrollUp`, and `keybindings.dashboard.scrollDown` in
+`.pi/pi-goal-x-settings.json`. The defaults are `ctrl+shift+t`,
+`ctrl+shift+up`, and `ctrl+shift+down`.
+
 ## Width behavior
 
 Layout modes (§5.5):

--- a/extensions/goal-commands.ts
+++ b/extensions/goal-commands.ts
@@ -278,7 +278,9 @@ export function registerGoalCommands(core: GoalCore): void {
 		if (key === "subtaskDepth") return config.subtaskDepth !== undefined ? String(config.subtaskDepth) : "1";
 		if (key === "stallTimeoutMinutes") return config.stallTimeoutMinutes !== undefined ? String(config.stallTimeoutMinutes) : "0";
 		if (key === "objectiveMaxChars") return config.objectiveMaxChars !== undefined ? String(config.objectiveMaxChars) : "0";
-		return config[key] ?? "(default)";
+		if (key === "keybindings") return config.keybindings ? `${config.keybindings.dashboard.toggleExpand}, ${config.keybindings.dashboard.scrollUp}, ${config.keybindings.dashboard.scrollDown}` : "(default)";
+		const value = config[key];
+		return typeof value === "string" ? value : "(default)";
 	}
 
 	function settingsLines(config: GoalSettings): string[] {

--- a/extensions/goal-settings.ts
+++ b/extensions/goal-settings.ts
@@ -9,15 +9,49 @@
  *
  * The file may contain:
  *   disableTasks, disableContracts, subtaskDepth,
- *   provider, model, thinkingLevel, disabled, objectiveMaxChars
+ *   provider, model, thinkingLevel, disabled, objectiveMaxChars, keybindings
+ *
+ * `keybindings.dashboard` accepts `toggleExpand`, `scrollUp`, and `scrollDown`.
  *
  * additionalProperties: false — unknown keys are rejected.
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { KeyId } from "@earendil-works/pi-tui";
 
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+export interface GoalDashboardKeybindings {
+	toggleExpand: KeyId;
+	scrollUp: KeyId;
+	scrollDown: KeyId;
+}
+
+export interface GoalKeybindings {
+	dashboard: GoalDashboardKeybindings;
+}
+
+export const DEFAULT_GOAL_KEYBINDINGS: GoalKeybindings = {
+	dashboard: {
+		toggleExpand: "ctrl+shift+t",
+		scrollUp: "ctrl+shift+up",
+		scrollDown: "ctrl+shift+down",
+	},
+};
+
+export function formatGoalKeybinding(key: string): string {
+	return key.split("+").map((part) => ({
+		ctrl: "Ctrl",
+		control: "Ctrl",
+		shift: "Shift",
+		alt: "Alt",
+		up: "↑",
+		down: "↓",
+		left: "←",
+		right: "→",
+	}[part.toLowerCase()] ?? part.toUpperCase())).join("+");
+}
 
 export interface GoalSettings {
 	disableTasks?: boolean;
@@ -38,6 +72,8 @@ export interface GoalSettings {
 	 * /goal-tweak).
 	 */
 	objectiveMaxChars?: number;
+	/** Keyboard shortcuts for the compact task list and dashboard expansion. */
+	keybindings?: GoalKeybindings;
 }
 
 export const PI_GOAL_SETTINGS_FILE_ENV = "PI_GOAL_SETTINGS_FILE";
@@ -84,7 +120,11 @@ const ALLOWED_SETTINGS_KEYS = new Set([
 	"auditorProjectResources",
 	"stallTimeoutMinutes",
 	"objectiveMaxChars",
+	"keybindings",
 ]);
+
+const ALLOWED_KEYBINDING_KEYS = new Set(["dashboard"]);
+const ALLOWED_DASHBOARD_KEYBINDING_KEYS = new Set(["toggleExpand", "scrollUp", "scrollDown"]);
 
 /**
  * Resolve the path to the unified settings file.
@@ -128,6 +168,31 @@ function asNonNegativeInt(value: unknown): number | undefined {
 	return undefined;
 }
 
+function asKeybinding(value: unknown): KeyId | undefined {
+	const key = asNonEmptyString(value);
+	if (!key) return undefined;
+	return key as KeyId;
+}
+
+function parseKeybindings(value: unknown): GoalKeybindings | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const record = value as Record<string, unknown>;
+	const unknownKeys = Object.keys(record).filter((key) => !ALLOWED_KEYBINDING_KEYS.has(key));
+	if (unknownKeys.length > 0) throw new Error(`Unknown keybindings key(s): ${unknownKeys.join(", ")}`);
+	const dashboard = record.dashboard;
+	if (!dashboard || typeof dashboard !== "object" || Array.isArray(dashboard)) return undefined;
+	const dashboardRecord = dashboard as Record<string, unknown>;
+	const unknownDashboardKeys = Object.keys(dashboardRecord).filter((key) => !ALLOWED_DASHBOARD_KEYBINDING_KEYS.has(key));
+	if (unknownDashboardKeys.length > 0) throw new Error(`Unknown dashboard keybinding(s): ${unknownDashboardKeys.join(", ")}`);
+	return {
+		dashboard: {
+			toggleExpand: asKeybinding(dashboardRecord.toggleExpand) ?? DEFAULT_GOAL_KEYBINDINGS.dashboard.toggleExpand,
+			scrollUp: asKeybinding(dashboardRecord.scrollUp) ?? DEFAULT_GOAL_KEYBINDINGS.dashboard.scrollUp,
+			scrollDown: asKeybinding(dashboardRecord.scrollDown) ?? DEFAULT_GOAL_KEYBINDINGS.dashboard.scrollDown,
+		},
+	};
+}
+
 function asThinkingLevel(value: unknown): ThinkingLevel | undefined {
 	const text = asNonEmptyString(value);
 	return text && THINKING_LEVELS.has(text) ? text as ThinkingLevel : undefined;
@@ -164,6 +229,8 @@ export function parseGoalSettings(raw: unknown): GoalSettings {
 	if (stallTimeoutMinutes !== undefined) settings.stallTimeoutMinutes = stallTimeoutMinutes;
 	const objectiveMaxChars = asNonNegativeInt(record.objectiveMaxChars);
 	if (objectiveMaxChars !== undefined) settings.objectiveMaxChars = objectiveMaxChars;
+	const keybindings = parseKeybindings(record.keybindings);
+	if (keybindings) settings.keybindings = keybindings;
 	return settings;
 }
 
@@ -207,6 +274,7 @@ export function loadGoalSettings(cwd: string, env: NodeJS.ProcessEnv = process.e
 		auditorProjectResources: fileConfig.auditorProjectResources ?? false,
 		stallTimeoutMinutes: fileConfig.stallTimeoutMinutes,
 		objectiveMaxChars: asNonNegativeInt(env.PI_GOAL_OBJECTIVE_MAX_CHARS) ?? fileConfig.objectiveMaxChars,
+		keybindings: fileConfig.keybindings ?? DEFAULT_GOAL_KEYBINDINGS,
 	};
 }
 
@@ -250,6 +318,7 @@ export function effectiveSettingsReport(cwd: string, env: NodeJS.ProcessEnv = pr
 		{ key: "auditorProjectResources", label: "auditor project resources", format: (v) => (v.auditorProjectResources === true ? "true" : "false") },
 		{ key: "stallTimeoutMinutes", label: "stall timeout (minutes)", format: (v) => String(v.stallTimeoutMinutes ?? 0) },
 		{ key: "objectiveMaxChars", label: "max objective length (0 = none)", format: (v) => String(v.objectiveMaxChars ?? 0) },
+		{ key: "keybindings", label: "dashboard keybindings", format: (v) => `${v.keybindings?.dashboard.toggleExpand ?? DEFAULT_GOAL_KEYBINDINGS.dashboard.toggleExpand}, ${v.keybindings?.dashboard.scrollUp ?? DEFAULT_GOAL_KEYBINDINGS.dashboard.scrollUp}, ${v.keybindings?.dashboard.scrollDown ?? DEFAULT_GOAL_KEYBINDINGS.dashboard.scrollDown}` },
 	];
 	for (const row of rows) {
 		const envVar = envOverrideFor(row.key, env);
@@ -286,6 +355,7 @@ export function saveGoalSettingsFileConfig(cwd: string, settings: GoalSettings):
 	if (settings.auditorProjectResources === true) clean.auditorProjectResources = true;
 	if (settings.stallTimeoutMinutes !== undefined) clean.stallTimeoutMinutes = settings.stallTimeoutMinutes;
 	if (settings.objectiveMaxChars !== undefined) clean.objectiveMaxChars = settings.objectiveMaxChars;
+	if (settings.keybindings) clean.keybindings = parseKeybindings(settings.keybindings);
 	const configPath = goalSettingsPath(cwd);
 	fs.mkdirSync(path.dirname(configPath), { recursive: true });
 	settingsFileCache.delete(configPath);
@@ -301,6 +371,7 @@ export function saveGoalSettingsFileConfig(cwd: string, settings: GoalSettings):
 	if (settings.auditorProjectResources === true) persisted.auditorProjectResources = true;
 	if (clean.stallTimeoutMinutes !== undefined) persisted.stallTimeoutMinutes = clean.stallTimeoutMinutes;
 	if (clean.objectiveMaxChars !== undefined) persisted.objectiveMaxChars = clean.objectiveMaxChars;
+	if (clean.keybindings) persisted.keybindings = clean.keybindings;
 	fs.writeFileSync(configPath, `${JSON.stringify(persisted, null, 2)}\n`, "utf8");
 	return clean;
 }

--- a/extensions/goal-widget.ts
+++ b/extensions/goal-widget.ts
@@ -111,6 +111,8 @@ export async function toggleTaskViaService(core: GoalCore, ctx: ExtensionContext
 export function syncTerminalInputPause(core: GoalCore, ctx: ExtensionContext): void {
 		if (!ctx.hasUI) return;
 		core.terminalInputUnsubscribe?.();
+		const settings = loadGoalSettings(typeof ctx.cwd === "string" ? ctx.cwd : process.cwd());
+		const keybindings = settings.keybindings!.dashboard;
 		core.terminalInputUnsubscribe = ctx.ui.onTerminalInput((data) => {
 			// If an audit is running, Escape aborts the audit instead of pausing.
 			// Must return { consume: true } so the TUI doesn't also process the key
@@ -157,7 +159,7 @@ export function syncTerminalInputPause(core: GoalCore, ctx: ExtensionContext): v
 			// Ctrl+Shift+T — toggle the unified dashboard between compact and
 			// expanded task views (the task-list overlay is merged into the
 			// dashboard; §10).
-			if (matchesKey(data, "ctrl+shift+t")) {
+			if (matchesKey(data, keybindings.toggleExpand)) {
 				core.toggleDashboardExpanded();
 				return { consume: true };
 			}
@@ -182,8 +184,8 @@ export function syncTerminalInputPause(core: GoalCore, ctx: ExtensionContext): v
 					return { consume: true };
 				}
 			}
-			if (matchesKey(data, "ctrl+shift+up") || matchesKey(data, "ctrl+shift+down") || matchesKey(data, "ctrl+shift+pageUp") || matchesKey(data, "ctrl+shift+pageDown") || matchesKey(data, "ctrl+shift+home") || matchesKey(data, "ctrl+shift+end")) {
-				const key = matchesKey(data, "ctrl+shift+up") ? "up" : matchesKey(data, "ctrl+shift+down") ? "down" : matchesKey(data, "ctrl+shift+pageUp") ? "pageUp" : matchesKey(data, "ctrl+shift+pageDown") ? "pageDown" : matchesKey(data, "ctrl+shift+home") ? "home" : "end";
+			if (matchesKey(data, keybindings.scrollUp) || matchesKey(data, keybindings.scrollDown) || matchesKey(data, "ctrl+shift+pageUp") || matchesKey(data, "ctrl+shift+pageDown") || matchesKey(data, "ctrl+shift+home") || matchesKey(data, "ctrl+shift+end")) {
+				const key = matchesKey(data, keybindings.scrollUp) ? "up" : matchesKey(data, keybindings.scrollDown) ? "down" : matchesKey(data, "ctrl+shift+pageUp") ? "pageUp" : matchesKey(data, "ctrl+shift+pageDown") ? "pageDown" : matchesKey(data, "ctrl+shift+home") ? "home" : "end";
 				if (core.goalWidgetComponentRef?.current?.handleCompactScrollKey(key)) {
 					return { consume: true };
 				}

--- a/extensions/widgets/goal-dashboard-renderer.ts
+++ b/extensions/widgets/goal-dashboard-renderer.ts
@@ -26,6 +26,7 @@ import {
 } from "./goal-dashboard-model.ts";
 import type { GoalActivityItem } from "../goal-activity.ts";
 import { truncateText } from "../goal-core.ts";
+import { DEFAULT_GOAL_KEYBINDINGS, formatGoalKeybinding, type GoalDashboardKeybindings } from "../goal-settings.ts";
 
 // mdLink is deliberately excluded: the chrome must stay neutral gray, not
 // blue-tinged ("more grey than blue").
@@ -291,7 +292,7 @@ export function renderCompactDashboard(
 	model: GoalDashboardModel,
 	theme: Theme,
 	width: number,
-	opts: { footerHint?: string; scrollOffset?: number } = {},
+	opts: { footerHint?: string; scrollOffset?: number; keybindings?: GoalDashboardKeybindings } = {},
 ): string[] {
 	const safeWidth = Math.max(10, width);
 	const mode = layoutMode(safeWidth);
@@ -397,14 +398,22 @@ export function renderCompactDashboard(
 		lines.push(boxLine(theme, safeWidth, `${dim(theme, `File     ${model.filePath}`)}`));
 	}
 
+	const keybindings = opts.keybindings ?? DEFAULT_GOAL_KEYBINDINGS.dashboard;
+	const toggleShortcut = formatGoalKeybinding(keybindings.toggleExpand);
+	const scrollShortcut = `${formatGoalKeybinding(keybindings.scrollUp)}/${formatGoalKeybinding(keybindings.scrollDown)}`;
+	const usesDefaultScrollKeys = keybindings.scrollUp === DEFAULT_GOAL_KEYBINDINGS.dashboard.scrollUp && keybindings.scrollDown === DEFAULT_GOAL_KEYBINDINGS.dashboard.scrollDown;
+	const scrollHint = usesDefaultScrollKeys
+		? mode === "minimal" ? "↑↓" : "Ctrl+Shift+↑↓"
+		: scrollShortcut;
+	const expandHint = mode === "wide" || mode === "medium"
+		? `${toggleShortcut}: expand tasks`
+		: `${toggleShortcut}: expand`;
 	const footerHint = opts.footerHint
 		?? (listOverflows
-			? mode === "minimal"
-				? "↑↓: scroll"
-				: mode === "narrow"
-					? "Ctrl+Shift+↑↓: scroll"
-					: "Ctrl+Shift+T: expand · Ctrl+Shift+↑↓: scroll"
-			: spec.footerHint);
+			? mode === "wide" || mode === "medium"
+				? `${toggleShortcut}: expand · ${scrollHint}: scroll`
+				: `${scrollHint}: scroll`
+			: expandHint);
 	// The auditor dot sits at the bottom-right of the border: green when the
 	// focused goal's independent auditor is on, muted gray when off. In
 	// wide/medium a right-aligned note (same frame tone as the hint) explains
@@ -434,7 +443,7 @@ export function renderExpandedDashboard(
 	model: GoalDashboardModel,
 	theme: Theme,
 	width: number,
-	opts: { scrollOffset?: number; rows?: number } = {},
+	opts: { scrollOffset?: number; rows?: number; keybindings?: GoalDashboardKeybindings } = {},
 ): string[] {
 	const safeWidth = Math.max(10, width);
 	const mode = layoutMode(safeWidth);
@@ -497,7 +506,8 @@ export function renderExpandedDashboard(
 		lines.push(...renderActivityBlock(model.recentActivity, theme, safeWidth));
 	}
 
-	lines.push(boxFooter(theme, safeWidth, "Esc/Ctrl+Shift+T: collapse"));
+	const toggleShortcut = formatGoalKeybinding(opts.keybindings?.toggleExpand ?? DEFAULT_GOAL_KEYBINDINGS.dashboard.toggleExpand);
+	lines.push(boxFooter(theme, safeWidth, `Esc/${toggleShortcut}: collapse`));
 	return lines;
 }
 

--- a/extensions/widgets/goal-widget.ts
+++ b/extensions/widgets/goal-widget.ts
@@ -9,7 +9,7 @@ import {
 	type GoalDisplayRecordLike,
 } from "../goal-core.ts";
 import type { GoalRecord, GoalTask, GoalTaskList, TaskStatus } from "../goal-record.ts";
-import type { GoalSettings } from "../goal-settings.ts";
+import type { GoalDashboardKeybindings, GoalSettings } from "../goal-settings.ts";
 import { sisyphusStepProgress } from "../goal-policy.ts";
 import type { GoalLedgerEvent } from "../goal-ledger.ts";
 import {
@@ -190,7 +190,7 @@ export function renderAuditResultCardView(
 	return renderAuditResultCard(deriveAuditResultCard(view.verdict, view.report), theme, width);
 }
 
-export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Theme, width: number, options: { openGoalCount?: number; auditorProgress?: AuditorWidgetProgress | null; disableTasks?: boolean; stalled?: boolean; ledgerEvents?: GoalLedgerEvent[]; expanded?: boolean; debug?: boolean; model?: GoalDashboardModel | null; compactScrollOffset?: number; expandedScrollOffset?: number; expandedTaskRows?: number } = {}): string[] {
+export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Theme, width: number, options: { openGoalCount?: number; auditorProgress?: AuditorWidgetProgress | null; disableTasks?: boolean; stalled?: boolean; ledgerEvents?: GoalLedgerEvent[]; expanded?: boolean; debug?: boolean; model?: GoalDashboardModel | null; compactScrollOffset?: number; expandedScrollOffset?: number; expandedTaskRows?: number; keybindings?: GoalDashboardKeybindings } = {}): string[] {
 	// When auditor progress is active, show the structured audit dashboard
 	// instead of the normal goal widget (§15.3).
 	if (options.auditorProgress) {
@@ -213,8 +213,8 @@ export function renderGoalWidgetLines(goal: GoalWidgetRecord | null, theme: Them
 	});
 	if (!model) return [];
 	const lines = options.expanded
-		? renderExpandedDashboard(model, theme, safeWidth, { scrollOffset: options.expandedScrollOffset, rows: options.expandedTaskRows })
-		: renderCompactDashboard(model, theme, safeWidth, { scrollOffset: options.compactScrollOffset });
+		? renderExpandedDashboard(model, theme, safeWidth, { scrollOffset: options.expandedScrollOffset, rows: options.expandedTaskRows, keybindings: options.keybindings })
+		: renderCompactDashboard(model, theme, safeWidth, { scrollOffset: options.compactScrollOffset, keybindings: options.keybindings });
 	return clampLinesToWidth(lines, width);
 }
 
@@ -344,6 +344,7 @@ export class GoalWidgetComponent implements Component {
 			compactScrollOffset: this.compactScrollOffset,
 			expandedScrollOffset: this.expandedScrollOffset,
 			expandedTaskRows: expandedTaskViewportRows(this.lastRenderWidth),
+			keybindings: settings.keybindings?.dashboard,
 		});
 		if (this.getDebugMode()) {
 			lines.push(...this.renderDebugPanel(width));

--- a/tests/goal-settings.test.ts
+++ b/tests/goal-settings.test.ts
@@ -75,6 +75,23 @@ test("parseGoalSettings: unknown keys rejected", () => {
 	);
 });
 
+test("parseGoalSettings: task keybindings use pi-tui key names", () => {
+	assert.deepEqual(parseGoalSettings({ keybindings: { dashboard: {
+		toggleExpand: "ctrl+shift+t",
+		scrollUp: "ctrl+shift+up",
+		scrollDown: "ctrl+shift+down",
+	} } }), { keybindings: { dashboard: {
+		toggleExpand: "ctrl+shift+t",
+		scrollUp: "ctrl+shift+up",
+		scrollDown: "ctrl+shift+down",
+	} } });
+	assert.equal(loadGoalSettings("/tmp/does-not-exist", {}).keybindings?.dashboard.toggleExpand, "ctrl+shift+t");
+});
+
+test("parseGoalSettings: unknown task keybindings are rejected", () => {
+	assert.throws(() => parseGoalSettings({ keybindings: { dashboard: { expand: "ctrl+t" } } }), /Unknown dashboard keybinding/);
+});
+
 test("parseGoalSettings: multiple unknown keys rejected", () => {
 	assert.throws(
 		() => parseGoalSettings({ disableTasks: true, foo: "bar", baz: 42 }),
@@ -249,6 +266,21 @@ test("loadGoalSettings: objectiveMaxChars defaults to no limit and honors the en
 		assert.equal(loadGoalSettings(dir, { PI_GOAL_OBJECTIVE_MAX_CHARS: "8000" }).objectiveMaxChars, 8000, "env var overrides file");
 	});
 	assert.equal(loadGoalSettings("/tmp/does-not-exist", {}).objectiveMaxChars, undefined, "unset = no limit");
+});
+
+test("saveGoalSettingsFileConfig: task keybindings round-trip", () => {
+	withTempDir((dir) => {
+		saveGoalSettingsFileConfig(dir, { keybindings: { dashboard: {
+			toggleExpand: "ctrl+shift+t",
+			scrollUp: "ctrl+shift+up",
+			scrollDown: "ctrl+shift+down",
+		} } });
+		assert.deepEqual(loadGoalSettingsFileConfig(dir).keybindings, { dashboard: {
+			toggleExpand: "ctrl+shift+t",
+			scrollUp: "ctrl+shift+up",
+			scrollDown: "ctrl+shift+down",
+		} });
+	});
 });
 
 test("saveGoalSettingsFileConfig: objectiveMaxChars persists (including 0) and clears", () => {

--- a/tests/task-list-overlay.test.ts
+++ b/tests/task-list-overlay.test.ts
@@ -349,19 +349,19 @@ test("dismisses on escape and enter", async () => {
 	assert.ok(true, "dismiss operations completed without error");
 });
 
-test("ctrl+shift+t toggles the unified dashboard expansion (overlay registration removed)", async () => {
+test("configured task shortcut toggles the unified dashboard expansion (overlay registration removed)", async () => {
 	const goalSource = readFileSync(
 		new URL("../extensions/goal-widget.ts", import.meta.url),
 		"utf-8",
 	);
 
 	assert.ok(
-		goalSource.includes('matchesKey(data, "ctrl+shift+t")'),
-		"goal-widget.ts contains the ctrl+shift+t keybinding",
+		goalSource.includes("matchesKey(data, keybindings.toggleExpand)"),
+		"goal-widget.ts reads the configured dashboard keybinding",
 	);
 	assert.ok(
 		goalSource.includes("core.toggleDashboardExpanded()"),
-		"ctrl+shift+t toggles the unified dashboard (overlay registration removed)",
+		"the configured shortcut toggles the unified dashboard (overlay registration removed)",
 	);
 	assert.ok(
 		!goalSource.includes("showTaskListOverlay("),


### PR DESCRIPTION
## Summary

- add project settings for the task dashboard expansion and compact-list scrolling shortcuts
- keep `Ctrl+Shift+T`, `Ctrl+Shift+Up`, and `Ctrl+Shift+Down` as the defaults
- show configured shortcuts in the dashboard footer

## Configuration

Some KiTTY defaults reserve `Ctrl+Shift` combinations before pi-goal-x
receives them. Users can replace the defaults with free bindings such as:

```json
{
  "keybindings": {
    "dashboard": {
      "toggleExpand": "ctrl+alt+t",
      "scrollUp": "ctrl+alt+up",
      "scrollDown": "ctrl+alt+down"
    }
  }
}
```

Users with terminal or window-manager conflicts can choose another free
modifier set. The values must use pi key names such as `up` and `down`.

## Validation

- `npm run check`
- `npm test` (707 tests)
