### PR TITLE
feat(goal): add hideUnfocusedBanner setting to suppress the unfocused banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ Settings are stored in:
 
 Use `/goal-settings` to configure task lists, verification contracts, subtask depth, automatic goal selection, and completion auditing. Goal objectives have no hard length limit by default; set `objectiveMaxChars` (or `PI_GOAL_OBJECTIVE_MAX_CHARS`, `0` = no limit) to cap objective length across `create_goal`, `propose_goal_draft`, and `/goal-tweak`.
 
+Set `hideUnfocusedBanner: true` in `.pi/pi-goal-x-settings.json` to suppress the "Goal focus required" banner (and the matching status-line hint) in sessions that are not focused on any goal while open goals exist. The banner returns as soon as the setting is disabled again or a goal is focused.
+
 Configure the task shortcuts in the same file when the terminal captures the defaults:
 
 ```json

--- a/extensions/goal-settings.ts
+++ b/extensions/goal-settings.ts
@@ -287,6 +287,7 @@ export function loadGoalSettings(cwd: string, env: NodeJS.ProcessEnv = process.e
 		thinkingLevel: fileConfig.thinkingLevel,
 		disabled: fileConfig.disabled,
 		autoSelectSingleGoal: fileConfig.autoSelectSingleGoal ?? false,
+		hideUnfocusedBanner: fileConfig.hideUnfocusedBanner ?? false,
 		auditorProjectResources: fileConfig.auditorProjectResources ?? false,
 		stallTimeoutMinutes: fileConfig.stallTimeoutMinutes,
 		objectiveMaxChars: asNonNegativeInt(env.PI_GOAL_OBJECTIVE_MAX_CHARS) ?? fileConfig.objectiveMaxChars,

--- a/extensions/goal-settings.ts
+++ b/extensions/goal-settings.ts
@@ -9,7 +9,8 @@
  *
  * The file may contain:
  *   disableTasks, disableContracts, subtaskDepth,
- *   provider, model, thinkingLevel, disabled, objectiveMaxChars, keybindings
+ *   provider, model, thinkingLevel, disabled, objectiveMaxChars, keybindings,
+ *   hideUnfocusedBanner
  *
  * `keybindings.dashboard` accepts `toggleExpand`, `scrollUp`, and `scrollDown`.
  *
@@ -80,6 +81,13 @@ export interface GoalSettings {
 	objectiveMaxChars?: number;
 	/** Keyboard shortcuts for the compact task list and dashboard expansion. */
 	keybindings?: GoalKeybindings;
+	/**
+	 * When true, sessions that are not focused on any goal show no
+	 * "Goal focus required" banner/status hint while open goals exist.
+	 * The banner returns when the setting is disabled again or a goal
+	 * is focused. Default: false (banner shown).
+	 */
+	hideUnfocusedBanner?: boolean;
 }
 
 export const PI_GOAL_SETTINGS_FILE_ENV = "PI_GOAL_SETTINGS_FILE";
@@ -123,6 +131,7 @@ const ALLOWED_SETTINGS_KEYS = new Set([
 	"thinking_level",
 	"disabled",
 	"autoSelectSingleGoal",
+	"hideUnfocusedBanner",
 	"auditorProjectResources",
 	"stallTimeoutMinutes",
 	"objectiveMaxChars",
@@ -230,6 +239,7 @@ export function parseGoalSettings(raw: unknown): GoalSettings {
 	if (thinkingLevel !== undefined) settings.thinkingLevel = thinkingLevel;
 	if (record.disabled === true || record.disabled === "true") settings.disabled = true;
 	if (record.autoSelectSingleGoal === true || record.autoSelectSingleGoal === "true") settings.autoSelectSingleGoal = true;
+	if (record.hideUnfocusedBanner === true || record.hideUnfocusedBanner === "true") settings.hideUnfocusedBanner = true;
 	if (record.auditorProjectResources === true || record.auditorProjectResources === "true") settings.auditorProjectResources = true;
 	const stallTimeoutMinutes = asPositiveInt(record.stallTimeoutMinutes);
 	if (stallTimeoutMinutes !== undefined) settings.stallTimeoutMinutes = stallTimeoutMinutes;
@@ -314,6 +324,7 @@ export function effectiveSettingsReport(cwd: string, env: NodeJS.ProcessEnv = pr
 	const lines = ["Settings (provenance):"];
 	const rows: Array<{ key: keyof GoalSettings; label: string; format: (v: GoalSettings) => string }> = [
 		{ key: "autoSelectSingleGoal", label: "autoSelectSingleGoal", format: (v) => (v.autoSelectSingleGoal === true ? "true" : "false") },
+		{ key: "hideUnfocusedBanner", label: "hideUnfocusedBanner", format: (v) => (v.hideUnfocusedBanner === true ? "true" : "false") },
 		{ key: "disableContracts", label: "disableContracts", format: (v) => (v.disableContracts === true ? "true" : "false") },
 		{ key: "disableTasks", label: "disableTasks", format: (v) => (v.disableTasks === true ? "true" : "false") },
 		{ key: "subtaskDepth", label: "subtaskDepth", format: (v) => String(v.subtaskDepth ?? 1) },

--- a/extensions/goal-state.ts
+++ b/extensions/goal-state.ts
@@ -645,6 +645,15 @@ export function createGoalCore(
 			return;
 		}
 		if (!state.goal) {
+			// Optional quiet mode: with hideUnfocusedBanner the unfocused
+			// widget + status hint are suppressed entirely while open goals
+			// exist, so a session that never focuses stays silent. The
+			// banner returns as soon as the setting is turned off again or
+			// a goal is focused (both re-enter renderUI via updateUI).
+			if (loadGoalSettings(ctx.cwd).hideUnfocusedBanner === true) {
+				clearGoalWidget(ctx);
+				return;
+			}
 			ctx.ui.setStatus("goal", `goal: unfocused [${totalOpen} open] - /goal-focus`);
 			if (!widgetRegistered) {
 				ctx.ui.setWidget(

--- a/tests/goal-settings.test.ts
+++ b/tests/goal-settings.test.ts
@@ -69,6 +69,13 @@ test("parseGoalSettings: autoSelectSingleGoal accepted as bool or string", () =>
 	assert.deepEqual(parseGoalSettings({ autoSelectSingleGoal: "false" }), {});
 });
 
+test("parseGoalSettings: hideUnfocusedBanner accepted as bool or string", () => {
+	assert.deepEqual(parseGoalSettings({ hideUnfocusedBanner: true }), { hideUnfocusedBanner: true });
+	assert.deepEqual(parseGoalSettings({ hideUnfocusedBanner: "true" }), { hideUnfocusedBanner: true });
+	assert.deepEqual(parseGoalSettings({ hideUnfocusedBanner: false }), {});
+	assert.deepEqual(parseGoalSettings({ hideUnfocusedBanner: "false" }), {});
+});
+
 test("parseGoalSettings: unknown keys rejected", () => {
 	assert.throws(
 		() => parseGoalSettings({ disableTasks: true, disableContracts: false, foo: "bar" }),

--- a/tests/goal-settings.test.ts
+++ b/tests/goal-settings.test.ts
@@ -232,6 +232,24 @@ test("loadGoalSettings: env var absent falls back to file", () => {
 		assert.equal(result.disableTasks, true);
 		assert.equal(result.disableContracts, true);
 	});
+
+
+test("loadGoalSettings: hideUnfocusedBanner read from file", () => {
+	withTempDir((dir) => {
+		const configPath = goalSettingsPath(dir);
+		fs.mkdirSync(path.dirname(configPath), { recursive: true });
+		fs.writeFileSync(configPath, JSON.stringify({ hideUnfocusedBanner: true }), "utf8");
+		const result = loadGoalSettings(dir, {});
+		assert.equal(result.hideUnfocusedBanner, true, "file value surfaced by loadGoalSettings");
+	});
+});
+
+test("loadGoalSettings: hideUnfocusedBanner defaults to false", () => {
+	withTempDir((dir) => {
+		const result = loadGoalSettings(dir, {});
+		assert.equal(result.hideUnfocusedBanner, false, "hideUnfocusedBanner defaults to false");
+	});
+});
 });
 
 test("loadGoalSettings: env var non-true values treated as absent", () => {


### PR DESCRIPTION
## Motivation

With pi-goal-x installed, every session in a project that has open goals (`.pi/goals/`) but is not focused on one shows a persistent "Goal focus required" banner above the editor. In multi-session setups where one session owns a goal and other sessions are used for ordinary work, that banner is permanent noise — there is no way to dismiss or hide it.

## Change

Add a new boolean setting `hideUnfocusedBanner` to `.pi/pi-goal-x-settings.json` (default `false`, behavior unchanged):

- When `true`, sessions that are not focused on any goal show neither the "Goal focus required" widget banner nor the `goal: unfocused [N open] - /goal-focus` status hint while open goals exist.
- The banner returns as soon as the setting is disabled again or a goal is focused (both re-enter `renderUI` via `updateUI`).

## Files

- `extensions/goal-settings.ts`: schema + `parseGoalSettings` + `effectiveSettingsReport` row (visible via `/goal-status`)
- `extensions/goal-state.ts`: quiet unfocused branch in `renderUI` (`clearGoalWidget` + return)
- `tests/goal-settings.test.ts`: parse cases for bool/string values
- `README.md`: settings documentation

## Verification

- `npm run check` (tsc --noEmit): clean
- `npm run lint`: clean
- Unit tests: `tests/goal-settings.test.ts` 50/51 pass; the single failure (`goalSettingsPath`) is a pre-existing POSIX-path assertion that also fails on unmodified `main` under Windows — verified via a stash baseline, unrelated to this change.