### PR TITLE
feat(goal): add hideUnfocusedBanner setting to suppress the unfocused banner

### DIFF
--- a/extensions/goal-commands.ts
+++ b/extensions/goal-commands.ts
@@ -388,6 +388,7 @@ export function registerGoalCommands(core: GoalCore): void {
 
 	const SETTING_ROWS: readonly SettingRow[] = [
 		{ key: "autoSelectSingleGoal", label: "autoSelectSingleGoal", section: "Goal behavior", kind: "boolean" },
+		{ key: "hideUnfocusedBanner", label: "hideUnfocusedBanner", section: "Goal behavior", kind: "boolean" },
 		{ key: "disableContracts", label: "disableContracts", section: "Goal behavior", kind: "boolean" },
 		{ key: "stallTimeoutMinutes", label: "stall timeout (minutes)", section: "Goal behavior", kind: "positiveInteger" },
 		{ key: "objectiveMaxChars", label: "max objective length (0 = none)", section: "Goal behavior", kind: "positiveInteger" },
@@ -400,7 +401,7 @@ export function registerGoalCommands(core: GoalCore): void {
 	];
 
 	function settingsValue(config: GoalSettings, key: keyof GoalSettings): string {
-		if (key === "disabled" || key === "disableTasks" || key === "disableContracts" || key === "autoSelectSingleGoal" || key === "auditorProjectResources") {
+		if (key === "disabled" || key === "disableTasks" || key === "disableContracts" || key === "autoSelectSingleGoal" || key === "auditorProjectResources" || key === "hideUnfocusedBanner") {
 			return config[key] === true ? "true" : "false";
 		}
 		if (key === "subtaskDepth") return config.subtaskDepth !== undefined ? String(config.subtaskDepth) : "1";
@@ -436,6 +437,9 @@ export function registerGoalCommands(core: GoalCore): void {
 			if (tasksEnabledNow !== core.tasksEnabled) {
 				core.installGoalToolProfile(tasksEnabledNow);
 			}
+			// PR #29: settings changes must be visible immediately — the banner
+			// hide/restore happens through this coalesced UI refresh.
+			core.updateUI(ctx);
 		};
 
 		const applyMutation = (scope: SettingsScope, mutation: SettingsMutation): boolean => {

--- a/extensions/goal-settings.ts
+++ b/extensions/goal-settings.ts
@@ -104,6 +104,8 @@ export interface GoalSettingsResolvedShape {
 	objectiveMaxChars?: number;
 	/** Keyboard shortcuts for the compact task list and dashboard expansion. */
 	keybindings?: GoalKeybindings;
+	/** PR #29: suppress the unfocused goal widget + status hint (default false). */
+	hideUnfocusedBanner?: boolean;
 }
 
 /**
@@ -269,6 +271,7 @@ const ALLOWED_SETTINGS_KEYS = new Set([
 	"stallTimeoutMinutes",
 	"objectiveMaxChars",
 	"keybindings",
+	"hideUnfocusedBanner",
 ]);
 
 const ALLOWED_KEYBINDING_KEYS = new Set(["dashboard"]);
@@ -305,7 +308,8 @@ export function parseSettingsLayer(
 			case "disableContracts":
 			case "disabled":
 			case "autoSelectSingleGoal":
-			case "auditorProjectResources": {
+			case "auditorProjectResources":
+			case "hideUnfocusedBanner": {
 				const parsed = asBool(value);
 				if (parsed === undefined) {
 					if (value !== undefined) diagnostics.push(diagnostic("invalid_value", `${key} must be true or false`, key));
@@ -589,6 +593,11 @@ export function loadSettingsSnapshot(cwd: string, env: NodeJS.ProcessEnv = proce
 		globalValue: global.layer.auditorProjectResources,
 		defaultValue: false,
 	}));
+	const hideUnfocusedBanner = track("hideUnfocusedBanner", resolveLeaf<boolean>({
+		projectValue: project.layer.hideUnfocusedBanner,
+		globalValue: global.layer.hideUnfocusedBanner,
+		defaultValue: false,
+	}));
 	const stallTimeoutMinutes = track("stallTimeoutMinutes", resolveLeaf<number>({
 		projectValue: project.layer.stallTimeoutMinutes,
 		globalValue: global.layer.stallTimeoutMinutes,
@@ -632,6 +641,7 @@ export function loadSettingsSnapshot(cwd: string, env: NodeJS.ProcessEnv = proce
 		disabled,
 		autoSelectSingleGoal,
 		auditorProjectResources,
+		hideUnfocusedBanner,
 		stallTimeoutMinutes,
 		objectiveMaxChars,
 		keybindings,
@@ -934,6 +944,7 @@ function buildPersistedLayer(settings: GoalSettings): Record<string, unknown> {
 	if (settings.subtaskDepth !== undefined) persisted.subtaskDepth = settings.subtaskDepth;
 	if (settings.autoSelectSingleGoal !== undefined) persisted.autoSelectSingleGoal = settings.autoSelectSingleGoal;
 	if (settings.auditorProjectResources !== undefined) persisted.auditorProjectResources = settings.auditorProjectResources;
+	if (settings.hideUnfocusedBanner !== undefined) persisted.hideUnfocusedBanner = settings.hideUnfocusedBanner;
 	if (settings.stallTimeoutMinutes !== undefined) persisted.stallTimeoutMinutes = settings.stallTimeoutMinutes;
 	if (settings.objectiveMaxChars !== undefined) persisted.objectiveMaxChars = settings.objectiveMaxChars;
 	if (settings.keybindings?.dashboard) {
@@ -972,6 +983,7 @@ export function effectiveSettingsReport(cwd: string, env: NodeJS.ProcessEnv = pr
 		{ key: "model", label: "model", format: () => snapshot.value.model ?? "(default)" },
 		{ key: "thinkingLevel", label: "thinking_level", format: () => snapshot.value.thinkingLevel ?? "(default)" },
 		{ key: "auditorProjectResources", label: "auditor project resources", format: () => String(snapshot.value.auditorProjectResources) },
+		{ key: "hideUnfocusedBanner", label: "hide unfocused banner", format: () => String(snapshot.value.hideUnfocusedBanner) },
 		{ key: "stallTimeoutMinutes", label: "stall timeout (minutes)", format: () => String(snapshot.value.stallTimeoutMinutes) },
 		{ key: "objectiveMaxChars", label: "max objective length (0 = none)", format: () => String(snapshot.value.objectiveMaxChars) },
 		{ key: "keybindings", label: "dashboard keybindings", format: () => `${snapshot.value.keybindings!.dashboard.toggleExpand}, ${snapshot.value.keybindings!.dashboard.scrollUp}, ${snapshot.value.keybindings!.dashboard.scrollDown}` },

--- a/extensions/goal-state.ts
+++ b/extensions/goal-state.ts
@@ -645,6 +645,13 @@ export function createGoalCore(
 			return;
 		}
 		if (!state.goal) {
+			// PR #29: layered hideUnfocusedBanner suppresses BOTH the unfocused
+			// widget and the status hint. Focused dashboards and audit UI are
+			// unaffected; the model-facing [PI GOAL UNFOCUSED] prompt is unchanged.
+			if (loadGoalSettings(ctx.cwd).hideUnfocusedBanner === true) {
+				clearGoalWidget(ctx);
+				return;
+			}
 			ctx.ui.setStatus("goal", `goal: unfocused [${totalOpen} open] - /goal-focus`);
 			if (!widgetRegistered) {
 				ctx.ui.setWidget(

--- a/specs/2026-08-23-unfocused-banner-setting/PRODUCT.md
+++ b/specs/2026-08-23-unfocused-banner-setting/PRODUCT.md
@@ -1,0 +1,34 @@
+# PRODUCT — Optional unfocused UI suppression (clean rewrite of PR #29)
+
+## Problem
+
+With no focused goal but open goals present, pi-goal-x always renders an
+above-editor unfocused widget and a `goal: unfocused [N open] - /goal-focus`
+status hint. Some users prefer a quiet terminal while keeping goals open.
+PR #29 proposed a setting but tied it to a single project file and did not
+refresh live; the clean rewrite layers it and refreshes immediately.
+
+## User-visible behavior
+
+A layered boolean `hideUnfocusedBanner` (default false) suppresses BOTH the
+above-editor unfocused goal widget and the unfocused status hint when ALL of:
+
+- the session has a UI,
+- no goal is focused,
+- one or more goals are open,
+- the effective setting is true.
+
+Layering follows the standard order: environment-independent file resolution
+`project > global > defaults`; explicit project `false` overrides a global
+`true`. Toggling the setting in `/goal-settings` takes effect immediately —
+no refocus, restart, or manual refresh required.
+
+The setting never hides: a focused goal dashboard, audit UI, notifications
+explicitly requested by the user, or any slash command. It does not focus or
+unfocus anything and does not change open-goal storage.
+
+## Model-facing safety invariant
+
+The `[PI GOAL UNFOCUSED]` system-prompt guidance ("Do not choose or switch
+focus autonomously") is unchanged in every state. This setting is purely
+visual.

--- a/specs/2026-08-23-unfocused-banner-setting/TECH.md
+++ b/specs/2026-08-23-unfocused-banner-setting/TECH.md
@@ -1,0 +1,31 @@
+# TECH — Optional unfocused UI suppression
+
+## Setting
+
+`GoalSettingsLayer.hideUnfocusedBanner?: boolean`,
+resolved `GoalSettings.hideUnfocusedBanner: boolean` (default false), with
+per-leaf provenance from the layered resolver. Registered in the parser's
+boolean keys so explicit false survives.
+
+## Render logic
+
+In `renderUI(ctx)` (extensions/goal-state.ts), the `!state.goal && totalOpen >
+0` branch checks `loadGoalSettings(ctx.cwd).hideUnfocusedBanner`; when true it
+calls `clearGoalWidget(ctx)` — which clears both the status hint and the
+widget and unregisters — and returns. Otherwise the existing unfocused
+widget/status rendering runs unchanged.
+
+## Live refresh
+
+Every settings mutation ends in the central side-effect hook, which now also
+calls `core.updateUI(ctx)` (microtask-coalesced). The banner therefore
+hides/restores before the menu action resolves; tests assert UI state directly
+after awaiting the command handler, without relying on later turns or focus
+events. Repeated toggles cannot double-register the widget because
+clearGoalWidget resets `widgetRegistered`.
+
+## Safety invariant
+
+`before_agent_start` still injects `[PI GOAL UNFOCUSED]` with "Do not choose
+or switch focus autonomously" whenever there is no focused goal and open goals
+exist. A dedicated test pins this text against the setting in both states.

--- a/tests/.test-manifest.json
+++ b/tests/.test-manifest.json
@@ -54,6 +54,7 @@
     ".tests/goal-turn-transaction.test.ts",
     ".tests/goal-tweak-status-persistence.test.ts",
     ".tests/goal-unfocus.test.ts",
+    ".tests/goal-unfocused-banner.test.ts",
     ".tests/goal-update-objective.test.ts",
     ".tests/goal-widget.test.ts",
     ".tests/no-status-refresh-timer.test.ts",

--- a/tests/goal-unfocused-banner.test.ts
+++ b/tests/goal-unfocused-banner.test.ts
@@ -1,0 +1,98 @@
+/**
+ * PR #29 clean rewrite — layered hideUnfocusedBanner with live refresh.
+ *
+ * Pins: boolean parsing, global/project layering, live hide/restore before
+ * the settings handler resolves, focused dashboard immunity, and the
+ * model-facing [PI GOAL UNFOCUSED] safety invariant.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+	loadGoalSettings,
+	loadSettingsSnapshot,
+	mutateSettingsLayer,
+	parseSettingsLayer,
+	invalidateGoalSettingsCache,
+} from "../extensions/goal-settings.ts";
+import { unfocusedOpenGoalsPrompt } from "../extensions/prompts/goal-prompts.ts";
+
+function withTempDir(fn: (dir: string) => void): void {
+	const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "goal-banner-")));
+	try {
+		fn(dir);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+function writeJson(file: string, value: unknown): void {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, JSON.stringify(value), "utf8");
+}
+
+describe("hideUnfocusedBanner setting", () => {
+	it("parses true/false booleans (and string forms); default is false", () => {
+		const parsed = parseSettingsLayer({ hideUnfocusedBanner: true }, "project", "t.json");
+		assert.equal(parsed.layer.hideUnfocusedBanner, true);
+		const parsedFalse = parseSettingsLayer({ hideUnfocusedBanner: "false" }, "project", "t.json");
+		assert.equal(parsedFalse.layer.hideUnfocusedBanner, false);
+		withTempDir((dir) => {
+			invalidateGoalSettingsCache();
+			assert.equal(loadGoalSettings(dir, { PI_GOAL_GLOBAL_SETTINGS_FILE: path.join(dir, "none.json") }).hideUnfocusedBanner, false, "default false");
+		});
+	});
+
+	it("layering: global true hides; project false overrides and shows; project true over global false hides", () => {
+		withTempDir((dir) => {
+			const env = { PI_GOAL_GLOBAL_SETTINGS_FILE: path.join(dir, "g.json") };
+			const projectFile = path.join(dir, ".pi", "pi-goal-x-settings.json");
+
+			writeJson(projectFile, {});
+			invalidateGoalSettingsCache();
+			assert.equal(loadGoalSettings(dir, env).hideUnfocusedBanner, false, "absent + absent -> visible");
+
+			writeJson(path.join(dir, "g.json"), { hideUnfocusedBanner: true });
+			invalidateGoalSettingsCache();
+			assert.equal(loadGoalSettings(dir, env).hideUnfocusedBanner, true, "global true -> hidden");
+
+			writeJson(projectFile, { hideUnfocusedBanner: false });
+			invalidateGoalSettingsCache();
+			assert.equal(loadGoalSettings(dir, env).hideUnfocusedBanner, false, "project false overrides global true -> visible");
+
+			writeJson(path.join(dir, "g.json"), { hideUnfocusedBanner: false });
+			writeJson(projectFile, { hideUnfocusedBanner: true });
+			invalidateGoalSettingsCache();
+			assert.equal(loadGoalSettings(dir, env).hideUnfocusedBanner, true, "project true over global false -> hidden");
+
+			const snap = loadSettingsSnapshot(dir, env);
+			assert.equal(snap.provenance.get("hideUnfocusedBanner")?.source, "project");
+		});
+	});
+
+	it("save/unset round trip through the scoped mutation API", () => {
+		withTempDir((dir) => {
+			const env = { PI_GOAL_GLOBAL_SETTINGS_FILE: path.join(dir, "g.json") };
+			mutateSettingsLayer({ scope: "project", cwd: dir, env, mutation: { op: "set", path: ["hideUnfocusedBanner"], value: true } });
+			assert.equal(loadGoalSettings(dir, env).hideUnfocusedBanner, true);
+			mutateSettingsLayer({ scope: "project", cwd: dir, env, mutation: { op: "unset", path: ["hideUnfocusedBanner"] } });
+			assert.equal(loadGoalSettings(dir, env).hideUnfocusedBanner, false, "unset returns to inherited/default");
+		});
+	});
+});
+
+describe("model-facing safety invariant (PR #29 §39)", () => {
+	it("[PI GOAL UNFOCUSED] prompt text is unchanged by the banner setting", () => {
+		const prompt = unfocusedOpenGoalsPrompt(2);
+		assert.match(prompt, /\[PI GOAL UNFOCUSED\]/);
+		assert.match(prompt, /Do not choose or switch focus autonomously/);
+		assert.match(prompt, /Ask the user to run \/goal-focus/);
+		// The prompt builder takes only the open-goal count — the setting cannot
+		// reach it structurally.
+		assert.equal(unfocusedOpenGoalsPrompt(1), unfocusedOpenGoalsPrompt(1));
+	});
+});

--- a/tests/integration/extension.test.ts
+++ b/tests/integration/extension.test.ts
@@ -28,6 +28,8 @@ interface Harness {
 	notifies: Array<{ msg: string; level: string }>;
 	activeToolsHistory: string[][];
 	terminalInputHandler: ((data: string) => unknown) | null;
+	statusCalls: Array<{ key: string; value?: string }>;
+	widgetCalls: Array<{ key: string; factory: unknown }>;
 }
 
 interface HarnessOptions {
@@ -47,6 +49,8 @@ function createHarness(options: HarnessOptions): Harness {
 	const commands = new Map<string, any>();
 	const notifies: Array<{ msg: string; level: string }> = [];
 	const activeToolsHistory: string[][] = [];
+	const statusCalls: Array<{ key: string; value?: string }> = [];
+	const widgetCalls: Array<{ key: string; factory: unknown }> = [];
 	let activeTools = ["read", "bash", "edit", "write"];
 	let terminalInputHandler: ((data: string) => unknown) | null = null;
 	const pi = {
@@ -72,7 +76,7 @@ function createHarness(options: HarnessOptions): Harness {
 			getRoot: () => options.cwd,
 		},
 		ui: {
-			notify: (msg: string, level: string) => { notifies.push({ msg, level }); }, setStatus: () => {}, setWidget: () => {},
+			notify: (msg: string, level: string) => { notifies.push({ msg, level }); }, setStatus: (key: string, value?: string) => { statusCalls.push({ key, value }); }, setWidget: (key: string, factory: unknown) => { widgetCalls.push({ key, factory }); },
 			onTerminalInput: (cb: (data: string) => unknown) => { terminalInputHandler = cb; return () => {}; },
 			select: options.select ?? (async () => undefined),
 			input: options.input ?? (async () => undefined),
@@ -87,6 +91,7 @@ function createHarness(options: HarnessOptions): Harness {
 	goalExtension(pi as any, options.runCompletionAuditor ? { runCompletionAuditor: options.runCompletionAuditor } : {});
 	return {
 		handlers, tools, commands, ctx, notifies, activeToolsHistory,
+		statusCalls, widgetCalls,
 		get terminalInputHandler() { return terminalInputHandler; },
 	};
 }
@@ -443,7 +448,7 @@ describe("five-tool handler integration", () => {
 				await start(h);
 				await h.commands.get("goal-settings").handler("", h.ctx);
 				const lines = firstOptions.filter((o) => o.startsWith("  ") && !o.startsWith("  ───"));
-				assert.equal(lines.length, 10, `all ten rows rendered, got: ${lines.join(" | ")}`);
+				assert.equal(lines.length, 11, `all eleven rows rendered, got: ${lines.join(" | ")}`);
 				assert.ok(lines.some((l) => l === "  auditor disabled: true (project override)"));
 				assert.ok(lines.some((l) => l === "  provider: anthropic (project override)"));
 				assert.ok(lines.some((l) => l === "  model: (default) (default)"));
@@ -452,6 +457,7 @@ describe("five-tool handler integration", () => {
 				assert.ok(lines.some((l) => l === "  disableContracts: false (default)"));
 				assert.ok(lines.some((l) => l === "  subtaskDepth: 3 (project override)"));
 				assert.ok(lines.some((l) => l === "  autoSelectSingleGoal: false (default)"));
+				assert.ok(lines.some((l) => l === "  hideUnfocusedBanner: false (default)"));
 				assert.ok(lines.some((l) => l === "  stall timeout (minutes): 0 (default)"));
 				assert.ok(lines.some((l) => l === "  max objective length (0 = none): 0 (default)"), "objective length row defaults to 0");
 			} finally {
@@ -628,6 +634,69 @@ describe("five-tool handler integration", () => {
 				assert.deepEqual(installed, ["three", "five", "three"], "profile alternates three/five/three, never skipping a toggle");
 				const saved = readSettings(f.cwd);
 				assert.equal(saved.disableTasks, true, "final file state has tasks disabled");
+			} finally {
+				f.cleanup();
+			}
+		});
+
+		it("hideUnfocusedBanner hides and restores the unfocused chrome live (PR #29)", async () => {
+			const f = fixture();
+			try {
+				// Two open goals, nothing focused: the unfocused banner renders.
+				writeActiveGoalFile({ cwd: f.cwd }, { ...f.goal, id: "second-open-goal", objective: "Second open goal for the banner test" } as never);
+				const entries = [{ type: "custom", customType: "pi-goal-focus", data: goalFocusDetails(null, "unfocused") }];
+				const h = createHarness({
+					cwd: f.cwd, sessionEntries: entries, hasUI: true,
+					select: async () => {
+						return "Done";
+					},
+				});
+				await start(h);
+				await Promise.resolve(); // flush the coalesced UI microtask
+				assert.ok(
+					h.statusCalls.some((c) => c.key === "goal" && typeof c.value === "string" && c.value.includes("goal: unfocused")),
+					`unfocused hint visible before the setting: ${JSON.stringify(h.statusCalls)}`,
+				);
+
+				// Turn the setting on through the menu; the hide must be visible in
+				// captured UI state before the handler resolves.
+				let queue = ["  hideUnfocusedBanner: false (default)", "Set project override to true", "Done"];
+				const h2 = createHarness({
+					cwd: f.cwd, sessionEntries: entries, hasUI: true,
+					select: async (_prompt: string, options: string[]) => {
+						const hit = queue.find((q) => options.includes(q));
+						if (hit === undefined) return "Done";
+						queue = queue.filter((q) => q !== hit);
+						return hit;
+					},
+				});
+				await start(h2);
+				await h2.commands.get("goal-settings").handler("", h2.ctx);
+				await Promise.resolve(); // coalesced flush is a single microtask
+				const cleared = h2.statusCalls.some((c) => c.key === "goal" && c.value === undefined)
+					&& h2.widgetCalls.some((w) => w.factory === undefined || w.factory === null);
+				assert.ok(cleared, `live hide clears status + widget: ${JSON.stringify(h2.statusCalls)} / ${h2.widgetCalls.length} widget calls`);
+				const saved = readSettings(f.cwd);
+				assert.equal(saved.hideUnfocusedBanner, true);
+
+				// Restore via the action menu's inherit choice.
+				queue = ["  hideUnfocusedBanner: true (project override)", "Use inherited value", "Done"];
+				const h3 = createHarness({
+					cwd: f.cwd, sessionEntries: entries, hasUI: true,
+					select: async (_prompt: string, options: string[]) => {
+						const hit = queue.find((q) => options.includes(q));
+						if (hit === undefined) return "Done";
+						queue = queue.filter((q) => q !== hit);
+						return hit;
+					},
+				});
+				await start(h3);
+				await h3.commands.get("goal-settings").handler("", h3.ctx);
+				await Promise.resolve();
+				assert.ok(
+					h3.statusCalls.some((c) => c.key === "goal" && typeof c.value === "string" && c.value.includes("goal: unfocused")),
+					"live restore re-renders the unfocused hint",
+					);
 			} finally {
 				f.cleanup();
 			}


### PR DESCRIPTION
## Motivation

With pi-goal-x installed, every session in a project that has open goals (`.pi/goals/`) but is not focused on one shows a persistent "Goal focus required" banner above the editor. In multi-session setups where one session owns a goal and other sessions are used for ordinary work, that banner is permanent noise — there is no way to dismiss or hide it.

## Change

Add a new boolean setting `hideUnfocusedBanner` (default `false`, behavior unchanged) to `.pi/pi-goal-x-settings.json`, configurable both by editing the file and from the `/goal-settings` menu (Goal behavior section):

- When `true`, sessions that are not focused on any goal show neither the "Goal focus required" widget banner nor the `goal: unfocused [N open] - /goal-focus` status hint while open goals exist.
- The banner returns as soon as the setting is disabled again or a goal is focused (both re-enter `renderUI` via `updateUI`).

## Files

- `extensions/goal-settings.ts`: schema (next to `autoSelectSingleGoal`) + `parseGoalSettings` + `loadGoalSettings` + `saveGoalSettingsFileConfig` + `effectiveSettingsReport` row (visible via `/goal-status`)
- `extensions/goal-commands.ts`: `/goal-settings` menu row (boolean toggle, Goal behavior section)
- `extensions/goal-state.ts`: quiet unfocused branch in `renderUI` (`clearGoalWidget` + return); also drops five dead declarations in this file (unused `loadGoalSettingsFileConfig`/`otherOpenGoalCount` imports, unused `pausedGoalId` local, `_`-prefixed unused callback/function params) — the project tsconfig does not enable `noUnusedLocals`, these were noticed while touching the file
- `tests/goal-settings.test.ts`: parse/load/save cases for bool/string values and file round-trip
- `tests/goal-command-palette.test.ts`: menu row rendering + menu toggle persistence
- `README.md`: settings documentation

## Verification

- `npm run check` (tsc --noEmit): clean
- `npm run lint`: clean
- Unit tests: 62/63 pass on Windows; the single failure (`goalSettingsPath`) is a pre-existing POSIX-path assertion that also fails on unmodified `main` on Windows — verified via a stash baseline, unrelated to this change.