### PR TITLE
feat(context): complete model-context measurement harness (PR D)

### DIFF
--- a/experiments/context/README.md
+++ b/experiments/context/README.md
@@ -1,0 +1,27 @@
+# Model-context accounting (PR D)
+
+Measures the COMPLETE model-facing request — extension-injected system block,
+post-hook message list, and ACTIVE tool schemas — not isolated prompt strings.
+
+    npm run context:measure   # re-capture all fixtures -> baseline-main.json
+    npm run context:gate      # deterministic equality + invariants (CI-safe)
+
+## Layout
+
+- `fixtures.mjs` — 22 deterministic scenarios (fixed ids/timestamps).
+- `capture-context.mjs` — drives the real extension handlers over a fixture;
+  returns { baseSystem, extensionSystem, messages, tools }. Pure function
+  calls; no network, no child agent, no live model.
+- `measure-context.mjs` — ContextSizeBreakdown + serializeRequest.
+- `semantic-invariants.mjs` — SemanticOccurrenceCounts (objective, contracts,
+  current task, lifecycle policy markers, checkpoint/unfocused/stale markers).
+- `run-measure.mjs` / `run-gate.mjs` — the two npm scripts.
+- `baseline-main.json` — committed artifact; update ONLY with a spec rationale
+  in specs/2026-08-23-model-context-accounting/CONTEXT-BASELINE.md.
+
+## Notes
+
+- estimatedTokens = chars/4 heuristic (documented estimate, not live usage).
+- Tool schemas are ~7.3K chars on every request — the component B4 never saw.
+- Post-issue-#30 invariant enforced by the gate: historical checkpoint payload
+  visible to the provider must be 0 chars on every fixture.

--- a/experiments/context/baseline-main.json
+++ b/experiments/context/baseline-main.json
@@ -1,0 +1,692 @@
+{
+  "generatedAtCommit": "main",
+  "measuredAt": "2026-08-23",
+  "fixtures": [
+    {
+      "fixture": "active-regular-10-tasks",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 2176,
+        "goalStateChars": 2176,
+        "checkpointChars": 70,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 202,
+        "totalSerializedChars": 9655,
+        "estimatedTokens": 2414
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "active-regular-50-tasks",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 2466,
+        "goalStateChars": 2466,
+        "checkpointChars": 70,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 202,
+        "totalSerializedChars": 9945,
+        "estimatedTokens": 2487
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "active-regular-no-tasks",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 1441,
+        "goalStateChars": 1441,
+        "checkpointChars": 70,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 202,
+        "totalSerializedChars": 8920,
+        "estimatedTokens": 2230
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "audit-rejection-and-rework",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 0,
+        "goalStateChars": 0,
+        "checkpointChars": 74,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 206,
+        "totalSerializedChars": 7483,
+        "estimatedTokens": 1871
+      },
+      "semantic": {
+        "objective": 0,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 2,
+        "neverEditObjective": 0,
+        "blockerPolicyUpdateGoal": 0,
+        "completionPolicyUpdateGoal": 0,
+        "goalActiveMarker": 0,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "blocked-goal",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 1449,
+        "goalStateChars": 1449,
+        "checkpointChars": 69,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 201,
+        "totalSerializedChars": 8927,
+        "estimatedTokens": 2232
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "completion-audit",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 0,
+        "goalStateChars": 0,
+        "checkpointChars": 78,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 210,
+        "totalSerializedChars": 7487,
+        "estimatedTokens": 1872
+      },
+      "semantic": {
+        "objective": 0,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 2,
+        "neverEditObjective": 0,
+        "blockerPolicyUpdateGoal": 0,
+        "completionPolicyUpdateGoal": 0,
+        "goalActiveMarker": 0,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "current-contracted-task",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 2595,
+        "goalStateChars": 2595,
+        "checkpointChars": 77,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 209,
+        "totalSerializedChars": 10081,
+        "estimatedTokens": 2521
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 1,
+        "currentTask": 1,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 4,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "get-goal-default-and-verbose",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 2213,
+        "goalStateChars": 2213,
+        "checkpointChars": 70,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 202,
+        "totalSerializedChars": 9692,
+        "estimatedTokens": 2423
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 1,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 4,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "guided-drafting-question",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 0,
+        "goalStateChars": 0,
+        "checkpointChars": 0,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 111,
+        "totalSerializedChars": 7409,
+        "estimatedTokens": 1853
+      },
+      "semantic": {
+        "objective": 0,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 2,
+        "neverEditObjective": 0,
+        "blockerPolicyUpdateGoal": 0,
+        "completionPolicyUpdateGoal": 0,
+        "goalActiveMarker": 0,
+        "checkpointMarker": 0,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "guided-proposal",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 0,
+        "goalStateChars": 0,
+        "checkpointChars": 0,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 113,
+        "totalSerializedChars": 7411,
+        "estimatedTokens": 1853
+      },
+      "semantic": {
+        "objective": 0,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 2,
+        "neverEditObjective": 0,
+        "blockerPolicyUpdateGoal": 0,
+        "completionPolicyUpdateGoal": 0,
+        "goalActiveMarker": 0,
+        "checkpointMarker": 0,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "half-complete-tree",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 2081,
+        "goalStateChars": 2081,
+        "checkpointChars": 75,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 207,
+        "totalSerializedChars": 9565,
+        "estimatedTokens": 2392
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "latest-auditor-rejection",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 877,
+        "goalStateChars": 877,
+        "checkpointChars": 79,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 211,
+        "totalSerializedChars": 8365,
+        "estimatedTokens": 2092
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 0,
+        "blockerPolicyUpdateGoal": 0,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 0,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 1,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "long-objective",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 4439,
+        "goalStateChars": 4439,
+        "checkpointChars": 76,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 208,
+        "totalSerializedChars": 11924,
+        "estimatedTokens": 2981
+      },
+      "semantic": {
+        "objective": 0,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "nested-tasks",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 2615,
+        "goalStateChars": 2615,
+        "checkpointChars": 74,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 206,
+        "totalSerializedChars": 10098,
+        "estimatedTokens": 2525
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "paused-goal",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 570,
+        "goalStateChars": 570,
+        "checkpointChars": 68,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 200,
+        "totalSerializedChars": 8047,
+        "estimatedTokens": 2012
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 2,
+        "neverEditObjective": 0,
+        "blockerPolicyUpdateGoal": 0,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 0,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 1,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "post-compaction-turn",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 1894,
+        "goalStateChars": 1894,
+        "checkpointChars": 0,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 41,
+        "totalSerializedChars": 9228,
+        "estimatedTokens": 2307
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 0,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "sisyphus-ordered-objective",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 2053,
+        "goalStateChars": 2053,
+        "checkpointChars": 70,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 202,
+        "totalSerializedChars": 9532,
+        "estimatedTokens": 2383
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "stale-checkpoint",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 386,
+        "goalStateChars": 386,
+        "checkpointChars": 68,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 76,
+        "totalSerializedChars": 7767,
+        "estimatedTokens": 1942
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 2,
+        "neverEditObjective": 0,
+        "blockerPolicyUpdateGoal": 0,
+        "completionPolicyUpdateGoal": 0,
+        "goalActiveMarker": 0,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 1,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "token-budget-at-limit",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 239,
+        "goalStateChars": 239,
+        "checkpointChars": 74,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 206,
+        "totalSerializedChars": 7722,
+        "estimatedTokens": 1931
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 2,
+        "neverEditObjective": 0,
+        "blockerPolicyUpdateGoal": 0,
+        "completionPolicyUpdateGoal": 0,
+        "goalActiveMarker": 0,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 1,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "token-budget-seventy-five-percent",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 1505,
+        "goalStateChars": 1505,
+        "checkpointChars": 74,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 206,
+        "totalSerializedChars": 8988,
+        "estimatedTokens": 2247
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "token-budget-zero-percent",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 1493,
+        "goalStateChars": 1493,
+        "checkpointChars": 73,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 205,
+        "totalSerializedChars": 8975,
+        "estimatedTokens": 2244
+      },
+      "semantic": {
+        "objective": 1,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 3,
+        "neverEditObjective": 2,
+        "blockerPolicyUpdateGoal": 1,
+        "completionPolicyUpdateGoal": 1,
+        "goalActiveMarker": 1,
+        "checkpointMarker": 1,
+        "unfocusedSafety": 0,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    },
+    {
+      "fixture": "unfocused-multiple-goals",
+      "breakdown": {
+        "baseSystemChars": 49,
+        "extensionSystemChars": 240,
+        "goalStateChars": 240,
+        "checkpointChars": 0,
+        "historicalCheckpointChars": 0,
+        "toolSchemaChars": 7262,
+        "messageChars": 13,
+        "totalSerializedChars": 7558,
+        "estimatedTokens": 1890
+      },
+      "semantic": {
+        "objective": 0,
+        "verificationContract": 0,
+        "currentTask": 0,
+        "lifecyclePolicyThirdBlocker": 0,
+        "independentAuditor": 2,
+        "neverEditObjective": 0,
+        "blockerPolicyUpdateGoal": 0,
+        "completionPolicyUpdateGoal": 0,
+        "goalActiveMarker": 0,
+        "checkpointMarker": 0,
+        "unfocusedSafety": 1,
+        "pausedMarker": 0,
+        "budgetLimitedMarker": 0,
+        "staleMarker": 0,
+        "postCompactionMarker": 0
+      }
+    }
+  ],
+  "totals": {
+    "totalSerializedChars": 194779,
+    "estimatedTokens": 48702
+  }
+}

--- a/experiments/context/capture-context.mjs
+++ b/experiments/context/capture-context.mjs
@@ -1,0 +1,159 @@
+/**
+ * Composed-request capture (PR D). Drives the REAL extension handlers over a
+ * fixture and returns the complete model-facing request parts:
+ *
+ *   baseSystem       — the host system prompt before extension injection
+ *   extensionSystem  — what before_agent_start appends
+ *   messages         — the provider message list AFTER the context hook
+ *   tools            — registered goal tools (name + description + schema)
+ *
+ * Pure in-process function calls over fixture data: no network, no child
+ * agent, no live model.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import piGoalExtension from "../../extensions/goal.ts";
+import { FIXTURES, userMessage, v2CheckpointMessage, assistantMessage } from "./fixtures.mjs";
+import { serializeGoalFile } from "../../extensions/storage/goal-files.ts";
+import { GOAL_LEDGER_FILE } from "../../extensions/goal-ledger.ts";
+
+const BASE_SYSTEM = "You are a helpful coding agent running inside pi.";
+const CAPTURE_CWD = "/tmp/goal-context-capture";
+
+function createCapture() {
+	const handlers = new Map();
+	const tools = [];
+
+	const mockPi = {
+		registerTool: (def) => tools.push(def),
+		registerCommand: () => {},
+		on: (event, handler) => {
+			handlers.set(event, async (eventArg, ctxArg) => handler(eventArg, ctxArg));
+		},
+		appendEntry: () => {},
+		registerMessageRenderer: () => {},
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		getActiveTools: () => ["read", "bash", "edit", "write", ...tools.map((t) => t.name)],
+		setActiveTools: () => {},
+	};
+
+	const ctx = {
+		cwd: CAPTURE_CWD,
+		hasUI: false,
+		sessionManager: {
+			getBranch: () => [],
+			getCwd: () => CAPTURE_CWD,
+			getSessionId: () => "capture",
+			getRoot: () => CAPTURE_CWD,
+			append: () => {},
+			buildSessionContext: () => ({ messages: [], sessionId: "capture", model: null, thinkingLevel: "medium" }),
+			getSessionFile: () => undefined,
+		},
+		getSystemPrompt: () => BASE_SYSTEM,
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		modelRegistry: { getAvailable: () => [] },
+		ui: {
+			notify: () => {}, setStatus: () => {}, setWidget: () => {},
+			select: async () => undefined, input: async () => undefined, confirm: async () => false,
+		},
+	};
+
+	piGoalExtension(mockPi);
+
+	async function startSession(entries) {
+		const sessionManager = { ...ctx.sessionManager, getBranch: () => entries };
+		await handlers.get("session_start")({ reason: "start" }, { ...ctx, sessionManager });
+	}
+
+	async function runTurn(triggerPrompt) {
+		return (await handlers.get("before_agent_start")(
+			{ systemPrompt: BASE_SYSTEM, prompt: triggerPrompt, systemPromptOptions: {} },
+			ctx,
+		)) ?? {};
+	}
+
+	async function runContext(messages) {
+		const event = { messages };
+		const result = await handlers.get("context")(event, ctx);
+		return result?.messages ?? event.messages;
+	}
+
+	return { tools, startSession, runTurn, runContext };
+}
+
+/** Materialize goal files, focus entry, and ledger events for a scenario. */
+function materializeState(scenario) {
+	fs.rmSync(CAPTURE_CWD, { recursive: true, force: true });
+	fs.mkdirSync(path.join(CAPTURE_CWD, ".pi", "goals", "archived"), { recursive: true });
+
+	const entries = [];
+	const goals = scenario.goal ? [scenario.goal] : [];
+	if (scenario.extraOpenGoals) goals.push(...scenario.extraOpenGoals);
+
+	for (const goal of goals) {
+		const relPath = `.pi/goals/active_goal_${goal.id}.md`;
+		goal.activePath = relPath;
+		fs.writeFileSync(path.join(CAPTURE_CWD, relPath), serializeGoalFile(goal), "utf8");
+		entries.push({ type: "custom", customType: "pi-goal-state", data: { version: 3, goal } });
+	}
+
+	if (goals.length > 0) {
+		const focusedGoalId = scenario.focusNull ? null : scenario.goal.id;
+		entries.unshift({
+			type: "custom",
+			customType: "pi-goal-focus",
+			data: { version: 1, focusedGoalId, reason: "created" },
+		});
+	}
+
+	if (scenario.ledgerEvents?.length > 0) {
+		const lines = scenario.ledgerEvents.map((e) => JSON.stringify(e)).join("\n");
+		fs.writeFileSync(path.join(CAPTURE_CWD, GOAL_LEDGER_FILE), `${lines}\n`, "utf8");
+	}
+	return entries;
+}
+
+/** Deterministic default conversation for active-goal fixtures. */
+function baseConversation(goal) {
+	const messages = [userMessage("Begin working on the goal.")];
+	for (let i = 1; i <= 3; i += 1) {
+		messages.push(v2CheckpointMessage(goal.id, i));
+		messages.push(assistantMessage(`Turn ${i} progress notes.`));
+	}
+	return messages;
+}
+
+/** Capture one fixture's composed request. */
+export async function captureOne(fixtureId) {
+	const build = FIXTURES[fixtureId];
+	if (!build) throw new Error(`unknown fixture: ${fixtureId}`);
+	const scenario = build();
+
+	const capture = createCapture();
+	const entries = materializeState(scenario);
+	await capture.startSession(entries);
+	const turn = await capture.runTurn(scenario.trigger ?? "continue");
+
+	let raw = scenario.messages ?? (scenario.goal ? baseConversation(scenario.goal) : [userMessage("Hello")]);
+	if (scenario.draftPrompt) raw = [...raw, userMessage(scenario.draftPrompt)];
+	const messages = await capture.runContext(raw);
+
+	return {
+		fixture: fixtureId,
+		baseSystem: BASE_SYSTEM,
+		extensionSystem: typeof turn.systemPrompt === "string" && turn.systemPrompt.startsWith(BASE_SYSTEM)
+			? turn.systemPrompt.slice(BASE_SYSTEM.length)
+			: (turn.systemPrompt ?? ""),
+		messages,
+		tools: capture.tools.map((t) => ({
+			name: t.name,
+			description: t.description ?? "",
+			schema: t.parameters ?? t.schema ?? null,
+		})),
+	};
+}
+
+export { BASE_SYSTEM };

--- a/experiments/context/fixtures.mjs
+++ b/experiments/context/fixtures.mjs
@@ -1,0 +1,251 @@
+/**
+ * Deterministic fixtures for the model-context accounting harness (PR D).
+ *
+ * Every fixture produces a complete scenario: goal record(s), ledger events,
+ * the trigger prompt, and the raw pre-hook message list. Fixed timestamps,
+ * fixed ids — no Date.now() enters captured output.
+ */
+
+import { createGoal, safeIdPart } from "../../extensions/goal-record.ts";
+
+const T0 = Date.UTC(2026, 7, 23, 12, 0, 0);
+
+function iso(offsetSeconds) {
+	return new Date(T0 + offsetSeconds * 1000).toISOString();
+}
+
+/** Deterministic goal: fixed id derived from a seed. */
+function stableGoal(seed, config) {
+	const goal = createGoal(config, T0);
+	goal.id = `ctx-${safeIdPart(seed)}`;
+	return goal;
+}
+
+function taskTree(count, { contracted = false } = {}) {
+	const tasks = [];
+	for (let i = 0; i < count; i += 1) {
+		const task = {
+			id: `t${i}`,
+			title: `Task ${i}: implement the sub-feature with a reasonably descriptive title that exercises wrapping`,
+			status: i < count / 2 ? "complete" : "pending",
+		};
+		if (i < count / 2) task.evidence = `verified by test run ${i} with assertions passing`;
+		else if (contracted && i === count / 2) task.verificationContract = "Run the suite and confirm green with a grep check.";
+		if (count >= 10 && i % 10 === 9 && i !== count - 1) {
+			task.subtasks = [
+				{ id: `${task.id}-a`, title: `Subtask A of ${task.id}`, status: "complete", evidence: "done" },
+				{ id: `${task.id}-b`, title: `Subtask B of ${task.id}`, status: "pending" },
+			];
+		}
+		tasks.push(task);
+	}
+	return tasks;
+}
+
+function list(tasks) {
+	return { tasks, blockCompletion: true, proposedAt: iso(60) };
+}
+
+function goalWith(id, overrides) {
+	const goal = stableGoal(id, { objective: overrides.objective ?? "Base objective", autoContinue: true, sisyphus: false });
+	for (const [key, value] of Object.entries(overrides)) {
+		if (key !== "objective") goal[key] = value;
+	}
+	return goal;
+}
+
+export const FIXTURES = {
+	"active-regular-no-tasks": () => ({
+		goal: stableGoal("no-tasks", { objective: "Write the migration guide page.", autoContinue: true, sisyphus: false }),
+		trigger: "continue",
+	}),
+	"active-regular-10-tasks": () => ({
+		goal: goalWith("tasks-10", { objective: "Ship the ten-part refactor.", taskList: list(taskTree(10)) }),
+		trigger: "continue",
+	}),
+	"active-regular-50-tasks": () => ({
+		goal: goalWith("tasks-50", { objective: "Ship the fifty-task program.", taskList: list(taskTree(50)) }),
+		trigger: "continue",
+	}),
+	"current-contracted-task": () => ({
+		goal: goalWith("contracted-task", {
+			objective: "Finish the contracted migration.",
+			taskList: list(taskTree(6, { contracted: true })),
+			currentTaskId: "t3",
+			verificationContract: "npm test passes with zero failures; grep shows no legacy imports.",
+		}),
+		trigger: "continue",
+	}),
+	"nested-tasks": () => ({
+		goal: goalWith("nested-tasks", { objective: "Orchestrate nested work.", taskList: list(taskTree(20)) }),
+		trigger: "continue",
+	}),
+	"half-complete-tree": () => ({
+		goal: goalWith("half-complete", { objective: "Half-done checklist execution.", taskList: list(taskTree(8)) }),
+		trigger: "continue",
+	}),
+	"long-objective": () => ({
+		// Unique numbered clauses: realistic long objective without periodic
+		// substrings (which make occurrence-counting ambiguous).
+		goal: stableGoal("long-objective", { objective: `${Array.from({ length: 120 }, (_, i) => `Requirement paragraph ${i}: satisfy specific acceptance clause ${i}.`).join(" ")} End of requirements.`, autoContinue: true, sisyphus: false }),
+		trigger: "continue",
+	}),
+	"sisyphus-ordered-objective": () => ({
+		goal: stableGoal("sisyphus", { objective: "1. Draft spec\n2. Implement\n3. Validate", autoContinue: true, sisyphus: true }),
+		trigger: "continue",
+	}),
+	"token-budget-zero-percent": () => budgetGoal("budget-zero", 100_000, 0),
+	"token-budget-seventy-five-percent": () => budgetGoal("budget-75pct", 100_000, 75_000),
+	"token-budget-at-limit": () => budgetGoal("budget-limit", 10_000, 10_000),
+	"paused-goal": () => pausedGoal(),
+	"blocked-goal": () => blockedGoal(),
+	"unfocused-multiple-goals": () => {
+		const extraOpenGoals = [
+			stableGoal("unfocused-a", { objective: "First open but unfocused goal awaiting the user.", autoContinue: false, sisyphus: false }),
+			stableGoal("unfocused-b", { objective: "Second open but unfocused goal awaiting the user.", autoContinue: false, sisyphus: false }),
+		];
+		for (const g of extraOpenGoals) g.status = "paused";
+		return { goal: null, focusNull: true, extraOpenGoals, trigger: "what goals exist?" };
+	},
+	"latest-auditor-rejection": () => auditorRejectionFixture(),
+	"post-compaction-turn": () => postCompactionFixture(),
+	"stale-checkpoint": () => staleCheckpointFixture(),
+	"guided-drafting-question": () => draftingFixture("drafting-question", "question"),
+	"guided-proposal": () => draftingFixture("drafting-proposal", "proposal"),
+	"completion-audit": () => auditFixture("completion-audit", "running"),
+	"audit-rejection-and-rework": () => auditFixture("audit-rework", "rejected"),
+	"get-goal-default-and-verbose": () => getGoalFixture(),
+};
+
+// ── scenario helpers ───────────────────────────────────────────────────────
+
+function budgetGoal(seed, budget, used) {
+	const goal = stableGoal(seed, { objective: `Stay within a ${budget}-token budget.`, autoContinue: true, sisyphus: false });
+	goal.tokenBudget = budget;
+	goal.usage.tokensUsed = used;
+	goal.status = used >= budget ? "budget_limited" : "active";
+	return { goal, trigger: "continue" };
+}
+
+function pausedGoal() {
+	const goal = stableGoal("paused", { objective: "Paused mid-implementation by the user.", autoContinue: true, sisyphus: false });
+	goal.status = "paused";
+	goal.stopReason = "user";
+	return { goal, trigger: "status?" };
+}
+
+function blockedGoal() {
+	const goal = stableGoal("blocked", { objective: "Blocked waiting on external credentials.", autoContinue: false, sisyphus: false });
+	goal.status = "blocked";
+	goal.pauseReason = "missing API credentials after three attempts";
+	return { goal, trigger: "status?" };
+}
+
+function auditorRejectionFixture() {
+	const goal = stableGoal("auditor-rejection", { objective: "Deliver audited feature work.", autoContinue: true, sisyphus: false });
+	goal.status = "paused";
+	goal.stopReason = "agent";
+	goal.pauseReason = "auditor rejected completion";
+	const ledgerEvents = [{
+		type: "audit_result",
+		goalId: goal.id,
+		verdict: "disapproved",
+		report: "Completion rejected: the verification contract requires green tests; two suites fail.",
+		at: iso(120),
+	}];
+	return { goal, ledgerEvents, trigger: "continue" };
+}
+
+function postCompactionFixture() {
+	const goal = stableGoal("post-compaction", { objective: "Long-running effort resumed after compaction.", autoContinue: true, sisyphus: false });
+	goal.taskList = list(taskTree(4));
+	return {
+		goal,
+		messages: [
+			userMessage("start work"),
+			assistantMessage("working"),
+			{ type: "compaction", id: "c1", parentId: null, timestamp: iso(90), summary: "Earlier turns summarized.", firstKeptEntryId: "m2", tokensBefore: 9000 },
+		],
+		trigger: `<pi_goal_continuation goal_id="${goal.id}" kind="checkpoint" v="2"/>`,
+	};
+}
+
+function staleCheckpointFixture() {
+	const current = stableGoal("stale-current", { objective: "The currently focused goal.", autoContinue: true, sisyphus: false });
+	return {
+		goal: current,
+		messages: [
+			{
+				role: "custom",
+				customType: "pi-goal-event",
+				content: '<pi_goal_continuation goal_id="ghost-goal" kind="checkpoint">',
+				details: { kind: "checkpoint", goalId: "ghost-goal", objective: "An older cleared goal objective" },
+				display: false,
+			},
+		],
+		trigger: '<pi_goal_continuation goal_id="ghost-goal" kind="checkpoint">',
+	};
+}
+
+function draftingFixture(seed, stage) {
+	return {
+		goal: null,
+		draftPrompt:
+			stage === "question"
+				? `[PI GOAL DRAFTING ${seed}] Clarify material ambiguity with one focused question.`
+				: `[PI GOAL DRAFTING ${seed}] Present the structured proposal via propose_goal_draft.`,
+		trigger: "/goal build the thing",
+	};
+}
+
+function auditFixture(seed, verdict) {
+	const goal = stableGoal(seed, { objective: "Complete the audited deliverable.", autoContinue: true, sisyphus: false });
+	goal.status = "complete";
+	goal.taskList = list(taskTree(2));
+	const ledgerEvents = verdict === "rejected"
+		? [{ type: "audit_result", goalId: goal.id, verdict: "disapproved", report: "Missing evidence for t1.", at: iso(150) }]
+		: [];
+	return { goal, ledgerEvents, trigger: "finish" };
+}
+
+function getGoalFixture() {
+	const goal = stableGoal("get-goal", { objective: "Inspectable objective for get_goal sizing.", autoContinue: true, sisyphus: false });
+	goal.taskList = list(taskTree(5));
+	goal.currentTaskId = "t2";
+	goal.verificationContract = "Show measurable evidence.";
+	return { goal, trigger: "continue" };
+}
+
+// ── message constructors ───────────────────────────────────────────────────
+
+export function userMessage(text) {
+	return { role: "user", content: [{ type: "text", text }] };
+}
+
+export function assistantMessage(text) {
+	return { role: "assistant", content: [{ type: "text", text }], stopReason: "end_turn" };
+}
+
+/** A legacy FULL checkpoint message (~6.4K chars), pre-#30 shape. */
+export function legacyCheckpointMessage(goalId, index) {
+	return {
+		role: "custom",
+		customType: "pi-goal-event",
+		display: false,
+		content: `[GOAL CHECKPOINT goalId=${goalId}]\nContinue working toward the active pi goal.\n${"x".repeat(6400)}`,
+		details: { kind: "checkpoint", goalId, objective: `Objective ${goalId}: ${"y".repeat(2000)}` },
+	};
+}
+
+/** The bounded v2 checkpoint marker. */
+export function v2CheckpointMessage(goalId, seq = 1) {
+	return {
+		role: "custom",
+		customType: "pi-goal-event",
+		display: false,
+		content: `<pi_goal_continuation goal_id="${goalId}" kind="checkpoint" v="2"/>`,
+		details: { version: 2, kind: "checkpoint", goalId, status: "active", revision: 0, checkpointSeq: seq, timestamp: T0 },
+	};
+}
+
+export const FIXTURE_IDS = Object.keys(FIXTURES).sort();

--- a/experiments/context/measure-context.mjs
+++ b/experiments/context/measure-context.mjs
@@ -1,0 +1,96 @@
+/**
+ * Composed-request size breakdown (PR D).
+ *
+ * Measures every component of the model-facing request — including the tool
+ * schemas and historical checkpoint payload that B4 never saw.
+ */
+
+import { countSemanticOccurrences, currentTaskNeedle } from "./semantic-invariants.mjs";
+
+/**
+ * Serialize one captured request to the exact text whose size we report.
+ */
+export function serializeRequest(captured) {
+	const system = `${captured.baseSystem}${captured.extensionSystem ?? ""}`;
+	const messages = (captured.messages ?? [])
+		.map((m) => {
+			if (typeof m.content === "string") return m.content;
+			if (Array.isArray(m.content)) return m.content.map((part) => part.text ?? "").join("");
+			return JSON.stringify(m.content ?? "");
+		})
+		.join("\n");
+	const tools = (captured.tools ?? [])
+		.map((t) => `${t.name}\n${t.description}\n${JSON.stringify(t.schema ?? {})}`)
+		.join("\n");
+	return { system, messages, tools, total: `${system}\n${messages}\n${tools}` };
+}
+
+/**
+ * Compute ContextSizeBreakdown for one captured request.
+ */
+export function measureContext(captured) {
+	const goal = captured.goal;
+	const serialized = serializeRequest(captured);
+
+	let checkpointChars = 0;
+	let historicalCheckpointChars = 0;
+	let messageChars = 0;
+	for (const message of captured.messages ?? []) {
+		const text = typeof message.content === "string"
+			? message.content
+			: Array.isArray(message.content)
+				? message.content.map((p) => p.text ?? "").join("")
+				: "";
+		messageChars += text.length + 8; // role framing overhead estimate
+		if (message.role === "custom" && message.customType === "pi-goal-event") {
+			checkpointChars += text.length;
+			// Historical = any pi-goal-event beyond the LAST one in the list.
+		}
+	}
+	// Historical checkpoints: every event message except the last one.
+	const eventIndexes = [];
+	(captured.messages ?? []).forEach((m, i) => {
+		if (m.role === "custom" && m.customType === "pi-goal-event") eventIndexes.push(i);
+	});
+	for (let k = 0; k < eventIndexes.length - 1; k += 1) {
+		const m = captured.messages[eventIndexes[k]];
+		historicalCheckpointChars += typeof m.content === "string" ? m.content.length : 0;
+	}
+	void checkpointChars;
+
+	const baseSystemChars = captured.baseSystem.length;
+	const extensionSystemChars = (captured.extensionSystem ?? "").length;
+	// Goal state = the extension's injected system block only.
+	const goalStateChars = extensionSystemChars;
+	const toolSchemaChars = serialized.tools.length;
+
+	return {
+		baseSystemChars,
+		extensionSystemChars,
+		goalStateChars,
+		checkpointChars: checkpointTotal(captured),
+		historicalCheckpointChars,
+		toolSchemaChars,
+		messageChars,
+		totalSerializedChars: serialized.total.length,
+		estimatedTokens: Math.ceil(serialized.total.length / 4),
+	};
+}
+
+function checkpointTotal(captured) {
+	let sum = 0;
+	for (const m of captured.messages ?? []) {
+		if (m.role === "custom" && m.customType === "pi-goal-event" && typeof m.content === "string") sum += m.content.length;
+	}
+	return sum;
+}
+
+/** Semantic counts for one captured request. Pass `goal` for exact needles. */
+export function semanticCounts(captured) {
+	const serialized = serializeRequest(captured);
+	return countSemanticOccurrences(serialized.total, {
+		objective: captured.goal?.objective,
+		verificationContract: captured.goal?.verificationContract,
+		currentTaskLine: currentTaskNeedle(captured.goal),
+	});
+}

--- a/experiments/context/run-gate.mjs
+++ b/experiments/context/run-gate.mjs
@@ -1,0 +1,101 @@
+/**
+ * context:gate — CI-safe invariants over the composed-request baseline (PR D).
+ *
+ * Re-measures every fixture IN PROCESS and requires:
+ *   1. deterministic equality with experiments/context/baseline-main.json;
+ *   2. tool schemas present in every breakdown;
+ *   3. every semantic field classified (counts object complete);
+ *   4. provider-visible checkpoint history <= 1 on active-goal fixtures;
+ *   5. every registered fixture ID covered by the baseline.
+ * No network, no child agents, no live model.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+import { captureOne } from "./capture-context.mjs";
+import { FIXTURES } from "./fixtures.mjs";
+import { measureContext, semanticCounts, serializeRequest } from "./measure-context.mjs";
+
+function serializedRequestText(captured) {
+	return serializeRequest(captured).total;
+}
+
+function escapeRegExp(text) {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const failures = [];
+
+const baseline = JSON.parse(readFileSync(path.join(here, "baseline-main.json"), "utf8"));
+const baselineById = new Map(baseline.fixtures.map((r) => [r.fixture, r]));
+
+const expectedFixtureIds = Object.keys(FIXTURES).sort();
+for (const id of expectedFixtureIds) {
+	if (!baselineById.has(id)) failures.push(`fixture missing from baseline: ${id}`);
+}
+for (const id of baselineById.keys()) {
+	if (!FIXTURES[id]) failures.push(`baseline contains unknown fixture: ${id}`);
+}
+
+let checked = 0;
+for (const fixtureId of expectedFixtureIds) {
+	const scenario = FIXTURES[fixtureId]();
+	const captured = await captureOne(fixtureId);
+	const breakdown = measureContext(captured);
+	const semantic = semanticCounts({ ...captured, goal: scenario.goal });
+	checked += 1;
+
+	// 1. deterministic equality
+	const baseRow = baselineById.get(fixtureId);
+	if (!baseRow) continue;
+	if (JSON.stringify(baseRow.breakdown) !== JSON.stringify(breakdown)) {
+		failures.push(`${fixtureId}: breakdown drifted from committed baseline — update baseline-main.json WITH a spec rationale if intentional`);
+	}
+	if (JSON.stringify(baseRow.semantic) !== JSON.stringify(semantic)) {
+		failures.push(`${fixtureId}: semantic counts drifted from committed baseline`);
+	}
+
+	// 2. tool schemas included
+	if (!(breakdown.toolSchemaChars > 0)) failures.push(`${fixtureId}: no tool schema bytes measured`);
+
+	// 3. semantic fields classified
+	for (const key of ["objective", "verificationContract", "currentTask", "lifecyclePolicyThirdBlocker", "independentAuditor", "neverEditObjective"]) {
+		if (!(key in semantic)) failures.push(`${fixtureId}: semantic field ${key} not classified`);
+	}
+
+	// 4. checkpoint history bounded (post-#30 invariant)
+	if (breakdown.historicalCheckpointChars > 0) {
+		failures.push(`${fixtureId}: historical checkpoint payload visible to the provider (${breakdown.historicalCheckpointChars} chars) — must stay filtered`);
+	}
+
+	// Required single-source markers on active-goal fixtures whose turn was
+	// actually dispatched with an active block (a stale-checkpoint trigger
+	// correctly aborts and injects GOAL STALE instead).
+	const hasActiveBlock = /\[PI GOAL ACTIVE goalId=/.test(captured.extensionSystem ?? "");
+	if (scenario.goal?.status === "active" && hasActiveBlock) {
+		if (semantic.goalActiveMarker !== 1) failures.push(`${fixtureId}: [PI GOAL ACTIVE] block count ${semantic.goalActiveMarker} != 1`);
+		// Long objectives are truncated to MAX_OBJECTIVE_BLOCK_CHARS — only the
+		// head can appear. Fixtures use unique (non-periodic) text so a 300-char
+		// head is an unambiguous needle.
+		const fullObjective = scenario.goal.objective ?? "";
+		const objectiveNeedle = fullObjective.slice(0, 300);
+		const objectiveOccurrences = objectiveNeedle
+			? (serializedRequestText(captured).match(new RegExp(escapeRegExp(objectiveNeedle), "g")) ?? []).length
+			: 0;
+		if (objectiveOccurrences !== 1) failures.push(`${fixtureId}: objective appears ${objectiveOccurrences}x in composed request (must be exactly 1)`);
+		if (scenario.goal?.verificationContract && semantic.verificationContract !== 1) {
+			failures.push(`${fixtureId}: verification contract appears ${semantic.verificationContract}x (must be exactly 1)`);
+		}
+	}
+}
+
+console.log(`[context:gate] re-measured ${checked} fixtures against baseline-main.json (${baseline.fixtures.length} rows)`);
+if (failures.length > 0) {
+	console.error("[context:gate] FAIL:");
+	for (const failure of failures) console.error(`  - ${failure}`);
+	process.exit(1);
+}
+console.log("[context:gate] PASS");

--- a/experiments/context/run-measure.mjs
+++ b/experiments/context/run-measure.mjs
@@ -1,0 +1,50 @@
+/**
+ * context:measure — capture and measure every fixture's composed request and
+ * write experiments/context/baseline-main.json (PR D).
+ *
+ * Deterministic: fixed fixture ids/timestamps; the breakdown is byte-stable
+ * across runs on the same code state. No network, no live model.
+ */
+
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+import { captureOne } from "./capture-context.mjs";
+import { FIXTURES } from "./fixtures.mjs";
+import { measureContext, semanticCounts } from "./measure-context.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const rows = [];
+for (const fixtureId of Object.keys(FIXTURES).sort()) {
+	const scenario = FIXTURES[fixtureId]();
+	const captured = await captureOne(fixtureId);
+	const withGoal = { ...captured, goal: scenario.goal };
+	rows.push({
+		fixture: fixtureId,
+		breakdown: measureContext(captured),
+		semantic: semanticCounts(withGoal),
+	});
+}
+
+const baseline = {
+	generatedAtCommit: process.env.CONTEXT_BASELINE_LABEL ?? "main",
+	measuredAt: new Date().toISOString().slice(0, 10),
+	fixtures: rows,
+	totals: {
+		totalSerializedChars: rows.reduce((sum, r) => sum + r.breakdown.totalSerializedChars, 0),
+		estimatedTokens: rows.reduce((sum, r) => sum + r.breakdown.estimatedTokens, 0),
+	},
+};
+
+const outPath = path.join(here, "baseline-main.json");
+writeFileSync(outPath, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+
+console.log(`[context:measure] ${rows.length} fixtures measured -> ${outPath}`);
+for (const row of rows) {
+	const b = row.breakdown;
+	console.log(
+		`  ${row.fixture.padEnd(34)} total=${String(b.totalSerializedChars).padStart(7)} sys=${String(b.extensionSystemChars).padStart(6)} tools=${String(b.toolSchemaChars).padStart(6)} msgs=${String(b.messageChars).padStart(6)} histCp=${b.historicalCheckpointChars}`,
+	);
+}

--- a/experiments/context/semantic-invariants.mjs
+++ b/experiments/context/semantic-invariants.mjs
@@ -1,0 +1,75 @@
+/**
+ * Semantic occurrence counting over the SERIALIZED composed request (PR D).
+ *
+ * Every semantic field the goal system must communicate is counted exactly:
+ * later optimization PRs must keep required markers present while removing
+ * duplicate restatements.
+ */
+
+const MARKERS = {
+	objective: null, // per-fixture: the exact objective text
+	verificationContract: null, // per-fixture
+	currentTask: (fixture) => fixture.currentTaskLine,
+	lifecyclePolicyThirdBlocker: /third consecutive identical blocker|THIRD consecutive identical blocker/g,
+	independentAuditor: /independent (completion )?auditor/g,
+	neverEditObjective: /objective is immutable|never edit it yourself|never edit the objective/g,
+	blockerPolicyUpdateGoal: /update_goal\(\{status: "blocked"\}\)/g,
+	completionPolicyUpdateGoal: /update_goal\(\{status: "complete"\}\)/g,
+	goalActiveMarker: /\[PI GOAL ACTIVE goalId=/g,
+	checkpointMarker: /pi_goal_continuation/g,
+	unfocusedSafety: /\[PI GOAL UNFOCUSED\]/g,
+	pausedMarker: /\[PI GOAL PAUSED goalId=/g,
+	budgetLimitedMarker: /\[PI GOAL BUDGET LIMITED goalId=/g,
+	staleMarker: /\[GOAL STALE goalId=/g,
+	postCompactionMarker: /\[POST-COMPACTION RESYNC goalId=/g,
+};
+
+function countMatches(text, pattern) {
+	if (!pattern) return 0;
+	const matches = text.match(pattern);
+	return matches ? matches.length : 0;
+}
+
+/**
+ * Count semantic fields in a captured request.
+ * `fixtureContext` supplies per-fixture needles: objective, verification
+ * contract, current-task line.
+ */
+export function countSemanticOccurrences(requestText, { objective, verificationContract, currentTaskLine } = {}) {
+	return {
+		objective: objective ? countMatches(requestText, new RegExp(escapeRegExp(objective), "g")) : 0,
+		verificationContract: verificationContract ? countMatches(requestText, new RegExp(escapeRegExp(verificationContract), "g")) : 0,
+		currentTask: currentTaskLine ? countMatches(requestText, new RegExp(escapeRegExp(currentTaskLine), "g")) : 0,
+		lifecyclePolicyThirdBlocker: countMatches(requestText, MARKERS.lifecyclePolicyThirdBlocker),
+		independentAuditor: countMatches(requestText, MARKERS.independentAuditor),
+		neverEditObjective: countMatches(requestText, MARKERS.neverEditObjective),
+		blockerPolicyUpdateGoal: countMatches(requestText, MARKERS.blockerPolicyUpdateGoal),
+		completionPolicyUpdateGoal: countMatches(requestText, MARKERS.completionPolicyUpdateGoal),
+		goalActiveMarker: countMatches(requestText, MARKERS.goalActiveMarker),
+		checkpointMarker: countMatches(requestText, MARKERS.checkpointMarker),
+		unfocusedSafety: countMatches(requestText, MARKERS.unfocusedSafety),
+		pausedMarker: countMatches(requestText, MARKERS.pausedMarker),
+		budgetLimitedMarker: countMatches(requestText, MARKERS.budgetLimitedMarker),
+		staleMarker: countMatches(requestText, MARKERS.staleMarker),
+		postCompactionMarker: countMatches(requestText, MARKERS.postCompactionMarker),
+	};
+}
+
+function escapeRegExp(text) {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Current-task needle as rendered by taskListBlock ("Current: <id> · <title>"). */
+export function currentTaskNeedle(goal) {
+	if (!goal?.currentTaskId || !goal.taskList) return undefined;
+	const find = (tasks) => {
+		for (const t of tasks) {
+			if (t.id === goal.currentTaskId) return t;
+			const nested = t.subtasks && find(t.subtasks);
+			if (nested) return nested;
+		}
+		return undefined;
+	};
+	const task = find(goal.taskList.tasks);
+	return task ? `Current: ${task.id} · ${task.title}` : undefined;
+}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "test:e2e": "node scripts/run-unit-tests.mjs e2e",
     "test:checkpoint-recovery": "node --experimental-strip-types --test tests/session-checkpoint-growth.test.ts tests/session-checkpoint-recovery.test.ts tests/goal-session-health.test.ts",
     "test:settings-race": "node --experimental-strip-types --test tests/goal-settings-race.test.ts",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "context:measure": "node experiments/context/run-measure.mjs",
+    "context:gate": "node experiments/context/run-gate.mjs"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.83.0 <0.85.0",

--- a/specs/2026-08-23-model-context-accounting/CONTEXT-BASELINE.md
+++ b/specs/2026-08-23-model-context-accounting/CONTEXT-BASELINE.md
@@ -1,0 +1,26 @@
+# Context baseline — main @ 2026-08-23 (post PR A/B/C)
+
+Measured by `npm run context:measure`; artifact `experiments/context/baseline-main.json`.
+
+Headline rows (chars):
+
+| fixture | total | ext system | tool schemas | messages | hist checkpoints |
+|---|---|---|---|---|---|
+| active-regular-no-tasks | 8,920 | 1,441 | 7,262 | 202 | 0 |
+| active-regular-10-tasks | 9,655 | 2,176 | 7,262 | 202 | 0 |
+| active-regular-50-tasks | 9,945 | 2,466 | 7,262 | 202 | 0 |
+| long-objective | ~12K | ~4.5K | 7,262 | ~208 | 0 |
+| stale-checkpoint | 7,767 | 386 (GOAL STALE) | 7,262 | 76 | 0 |
+
+Key facts this baseline pins:
+
+1. Active goal tools cost ~7,262 serialized chars per request regardless of
+   prompt content — previously unmeasured by B4.
+2. Historical checkpoint payload is 0 on every fixture (issue #30 fix holds
+   at the composed-request level).
+3. Objective appears exactly once in every active-block request; verification
+   contract exactly once when present.
+
+Later optimization PRs (E/F) must show composed-request reductions against
+this table while keeping these single-source invariants. Update
+`baseline-main.json` only together with a rationale here.

--- a/specs/2026-08-23-model-context-accounting/MILESTONES.md
+++ b/specs/2026-08-23-model-context-accounting/MILESTONES.md
@@ -1,0 +1,21 @@
+# MILESTONES — complete model-context accounting
+
+## 2026-08-23 — Harness built on maint/pr-d-context-measurement
+
+- 22 deterministic fixtures implemented (plan §46 list; ids prefixed `ctx-`).
+- Capture drives the REAL extension handlers (session_start → before_agent_start
+  → context) over materialized goal files + ledger events; no network path.
+- Baseline artifact committed: experiments/context/baseline-main.json.
+- Determinism verified: two consecutive `context:measure` runs produce
+  byte-identical artifacts.
+- Gate (`npm run context:gate`) re-measures in-process and enforces:
+  deterministic equality, tool-schema bytes > 0 per fixture, semantic fields
+  classified, historical checkpoint payload = 0, objective/[PI GOAL ACTIVE]/
+  verification-contract exactly once on active-block fixtures.
+
+Measured headline: active goal tools cost ~7,262 serialized chars per request
+(previously invisible to B4); historical checkpoint payload is 0 everywhere.
+
+Fixtures with empty extension system blocks (completion-audit,
+audit-rejection-and-rework, drafting) reflect real early-return paths in
+before_agent_start; they still exercise message/tool measurement.

--- a/specs/2026-08-23-model-context-accounting/PRODUCT.md
+++ b/specs/2026-08-23-model-context-accounting/PRODUCT.md
@@ -1,0 +1,32 @@
+# PRODUCT — Complete model-context accounting
+
+## Purpose
+
+This PR changes NO shipped behavior. It creates the measurement evidence that
+lets later token-saving PRs (single-source prompts, UI/model payload
+separation) prove they removed real duplicate bytes from the COMPLETE model
+request — not just isolated prompt functions — without weakening outcomes.
+
+The existing B4 benchmark measures `taskListBlock`, `continuationPrompt`, and
+`goalPrompt` separately. It does not measure the composed request after
+`before_agent_start`: extension system-prompt injection, the `context` hook's
+message transformations, active tool schemas, historical custom messages, or
+checkpoint history. This harness measures all of it.
+
+## What ships
+
+- `npm run context:measure` — captures and measures every fixture's composed
+  request and writes `experiments/context/baseline-main.json`.
+- `npm run context:gate` — CI-safe gate: recomputes the baseline in-process,
+  requires deterministic equality with the committed artifact, requires tool
+  schemas in every breakdown, requires checkpoint history ≤1 (post-#30), and
+  requires every fixture ID covered. No network; no child agents.
+
+## Fixtures
+
+Twenty deterministic scenarios covering: taskless/10/50-task goals, current
+contracted task, nested tasks, half-complete trees, long objectives, Sisyphus,
+token budgets at 0%/75%/limit, paused, blocked, multiple open goals, latest
+auditor rejection, post-compaction turn, stale checkpoint, guided drafting,
+guided proposal, completion audit, audit rejection/rework, and get_goal
+default/verbose.

--- a/specs/2026-08-23-model-context-accounting/TECH.md
+++ b/specs/2026-08-23-model-context-accounting/TECH.md
@@ -1,0 +1,45 @@
+# TECH — Complete model-context accounting
+
+## Composed-request capture
+
+`experiments/context/capture-context.mjs` drives the REAL extension through a
+test-only harness (same discipline as tests/integration): registers tools and
+handlers via the pi mock API, runs session_start + before_agent_start for each
+fixture, and captures:
+
+    {
+      baseSystem: string,            // pre-extension system prompt
+      extensionSystem: string,       // injected by before_agent_start
+      messages: AgentMessage[],      // AFTER the context hook transformation
+      tools: ToolDefinition[],       // registered goal tools incl. JSON schemas
+    }
+
+No network call, no child agent, no live provider is possible: the capture is
+pure function calls over fixture data.
+
+## Breakdown (`measure-context.mjs`)
+
+ContextSizeBreakdown:
+  baseSystemChars, extensionSystemChars, checkpointChars,
+  historicalCheckpointChars, goalStateChars, toolSchemaChars, messageChars,
+  totalSerializedChars, estimatedTokens (chars/4 heuristic, labeled as such)
+
+toolSchemaChars serializes every ACTIVE tool's name+description+JSON schema;
+this is the component B4 never saw. historicalCheckpointChars counts
+pi-goal-event messages dropped or rewritten by the context hook.
+
+## Semantic occurrence counts (`semantic-invariants.mjs`)
+
+SemanticOccurrenceCounts over the serialized request: objective,
+verificationContract/goalContract, currentTask, currentTaskContract,
+lifecyclePolicy markers ("third consecutive identical blocker", "independent
+auditor", "never edit"), auditorRejection, blockerPolicy. Every semantic field
+must be classified somewhere in the breakdown (gate assertion).
+
+## Determinism
+
+Fixtures use fixed timestamps and ids; no Date.now() enters captured output.
+The gate re-measures in-process and requires byte equality of the derived
+breakdown against experiments/context/baseline-main.json. Any intentional
+change to prompt composition must update the baseline WITH a spec rationale
+(CONTEXT-BASELINE.md).


### PR DESCRIPTION
Measurement-only PR — changes no shipped behavior.

- `npm run context:measure`: captures the composed request (extension system block, post-hook messages, ACTIVE tool schemas) for 22 deterministic fixtures by driving the real extension handlers in-process. No network, no child agents.
- `npm run context:gate`: CI-safe invariants — deterministic equality with committed baseline-main.json, tool-schema bytes > 0 per fixture, semantic fields classified, historical checkpoint payload = 0 (post-#30), objective/[PI GOAL ACTIVE]/verification-contract exactly once on active-block turns.
- Headline: goal tools cost ~7,262 serialized chars on every request — previously invisible to B4. Historical checkpoints 0 everywhere.

Spec: specs/2026-08-23-model-context-accounting/ (PRODUCT, TECH, CONTEXT-BASELINE, MILESTONES).

Validation: check/lint clean; test:all 862/862; test:selfcheck OK; test:serial 829/829; pack dry-run ok; audit 0 vulns; bench:gate:naf PASS; context:gate PASS; verify-pr-head PASS.