### PR TITLE
fix: recover active goals after provider network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ All notable changes to pi-goal-x are documented here.
   concrete blocker (feeds the blocker fingerprint and ledger record).
 - Tool schemas grew by +136 bytes/request (`attempted_actions` parameter).
 
+## Unreleased
+
+### Fixed
+
+- **Network-error recovery for active goals** — after Pi exhausts its own
+  provider retries with `network_error`, an active auto-continue goal now
+  retries through a bounded 5/10/20/40/80-second backoff ladder. The fallback
+  begins only after Pi settles, cancels cleanly on user interaction or goal
+  lifecycle changes, and leaves the goal active with a clear warning after the
+  capped recovery budget is exhausted.
+
 ## [0.28.0] — 2026-08-23
 
 ### Added

--- a/extensions/goal-events.ts
+++ b/extensions/goal-events.ts
@@ -6,6 +6,7 @@ import {
 	goalEventMessageId,
 	hasAbortedAssistantMessage,
 	hasErrorAssistantMessage,
+	hasNetworkErrorAssistantMessage,
 	isAbortedAssistantMessage,
 	isErrorAssistantMessage,
 	isMeaningfulProgressToolCall,
@@ -92,6 +93,7 @@ export function compactGoalCheckpointContext(
 export function registerGoalEvents(core: GoalCore): void {
 	const { pi } = core;
 	let continuationAfterSettleFor: string | null = null;
+	let networkErrorRecoveryAfterSettleFor: string | null = null;
 
 	pi.on("context", async (event) => {
 		const messages = compactGoalCheckpointContext(event.messages, core.state.goal);
@@ -355,7 +357,10 @@ export function registerGoalEvents(core: GoalCore): void {
 			// evaluating whether the checkpoint is actionable.
 			core.reconcileFocusedGoalFromDisk(ctx);
 			core.runtime.setCheckpoint(incomingGoalId);
-			core.clearContinuationState();
+			// This can be the hidden checkpoint dispatched by the network-error
+			// timer. Clear ordinary continuation bookkeeping but retain the
+			// consecutive recovery count for a later failed retry.
+			core.clearContinuationState(false);
 			if (!core.isActionableContinuationGoal(incomingGoalId)) {
 				try {
 					ctx.abort?.();
@@ -372,6 +377,7 @@ export function registerGoalEvents(core: GoalCore): void {
 			// autoContinue nudge state so the user always gets a fresh chain.
 			core.runtime.setCheckpoint(null);
 			core.clearContinuationState();
+			networkErrorRecoveryAfterSettleFor = null;
 		}
 
 		if (!core.state.goal) {
@@ -471,6 +477,7 @@ export function registerGoalEvents(core: GoalCore): void {
 		const endedGoalId = core.runningGoalId;
 		core.runningGoalId = null;
 		continuationAfterSettleFor = null;
+		networkErrorRecoveryAfterSettleFor = null;
 
 		// Account for any tokens from aborted in-flight assistant messages so
 		// they are not silently lost (but charge them to the original goal).
@@ -481,7 +488,9 @@ export function registerGoalEvents(core: GoalCore): void {
 			core.accountProgress(ctx, { completedTurnTokens: abortedTokens });
 		}
 
-		core.runtime.clearContinuationState();
+		// Keep any prior recovery attempt while Pi finishes its own automatic
+		// retries. A user-driven path resets it through the default argument.
+		core.runtime.clearContinuationState(false);
 		if (!core.state.goal || core.state.goal.status !== "active" || !core.state.goal.autoContinue) return;
 		if (endedGoalId && core.state.goal.id !== endedGoalId) return;
 		if (!core.reconcileFocusedGoalFromDisk(ctx)) return;
@@ -492,11 +501,18 @@ export function registerGoalEvents(core: GoalCore): void {
 		// Provider failures are not completed work: persist and refresh the
 		// display, but never queue a continuation for a run whose messages
 		// include an assistant error (danim47c pattern).
+		if (hasNetworkErrorAssistantMessage(event.messages)) {
+			core.persist(ctx);
+			core.updateUI(ctx);
+			networkErrorRecoveryAfterSettleFor = core.state.goal.id;
+			return;
+		}
 		if (hasErrorAssistantMessage(event.messages)) {
 			core.persist(ctx);
 			core.updateUI(ctx);
 			return;
 		}
+		core.runtime.clearNetworkErrorBackoff();
 		core.persist(ctx);
 		core.updateUI(ctx);
 		// agent_end runs before pi finishes retries, compaction, terminating-tool
@@ -510,14 +526,32 @@ export function registerGoalEvents(core: GoalCore): void {
 	pi.on("agent_settled", async (_event, ctx) => {
 		const goalId = continuationAfterSettleFor;
 		continuationAfterSettleFor = null;
-		if (!goalId || !core.isActionableContinuationGoal(goalId)) return;
-		core.queueContinuation(ctx, true);
+		const networkErrorGoalId = networkErrorRecoveryAfterSettleFor;
+		networkErrorRecoveryAfterSettleFor = null;
+		if (goalId && core.isActionableContinuationGoal(goalId)) {
+			core.queueContinuation(ctx, true);
+			return;
+		}
+		if (!networkErrorGoalId || !core.isActionableContinuationGoal(networkErrorGoalId)) return;
+		const plan = core.runtime.scheduleNetworkErrorRetry(ctx, core.state.goal!);
+		if (plan) {
+			ctx.ui.notify(
+				`Provider network error. Retrying the goal in ${Math.round(plan.delayMs / 1000)}s (recovery ${plan.attempt}/${plan.maxAttempts}).`,
+				"warning",
+			);
+			return;
+		}
+		ctx.ui.notify(
+			"Provider network errors persisted after all recovery attempts. The goal remains active; resume it when the provider is healthy.",
+			"warning",
+		);
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		continuationAfterSettleFor = null;
+		networkErrorRecoveryAfterSettleFor = null;
 		core.accountProgress(ctx);
-		core.clearContinuationTimer();
+		core.clearContinuationState();
 		core.terminalInputUnsubscribe?.();
 		core.terminalInputUnsubscribe = null;
 		if (core.state.goal) core.persist(ctx);

--- a/extensions/goal-format.ts
+++ b/extensions/goal-format.ts
@@ -226,6 +226,16 @@ export function isErrorAssistantMessage(message: unknown): boolean {
 	return raw?.role === "assistant" && raw.stopReason === "error";
 }
 
+/** A provider-declared network failure is safe for the bounded goal backoff. */
+export function isNetworkErrorAssistantMessage(message: unknown): boolean {
+	if (!isErrorAssistantMessage(message)) return false;
+	const raw = asRecord(message);
+	const details = [raw?.rawStopReason, raw?.errorMessage]
+		.filter((value): value is string => typeof value === "string")
+		.join(" ");
+	return /\bnetwork[_\s-]?error\b/i.test(details);
+}
+
 export function isToolUseAssistantMessage(message: unknown): boolean {
 	const raw = asRecord(message);
 	return raw?.role === "assistant" && raw.stopReason === "toolUse";
@@ -237,6 +247,10 @@ export function hasAbortedAssistantMessage(messages: unknown[]): boolean {
 
 export function hasErrorAssistantMessage(messages: unknown[]): boolean {
 	return messages.some(isErrorAssistantMessage);
+}
+
+export function hasNetworkErrorAssistantMessage(messages: unknown[]): boolean {
+	return messages.some(isNetworkErrorAssistantMessage);
 }
 
 export function usageChannelTokens(value: unknown): number {

--- a/extensions/goal-runtime.ts
+++ b/extensions/goal-runtime.ts
@@ -12,6 +12,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { GoalCheckpointDetailsV2, GoalRecord } from "./goal-record.ts";
 import { checkpointTriggerPrompt } from "./prompts/goal-prompts.ts";
 import { POST_STOP_ALLOWED_TOOLS } from "./goal-tool-names.ts";
+import { networkErrorBackoffPlan, type NetworkErrorBackoffPlan } from "./network-error-backoff.ts";
 
 export const CONTINUATION_IDLE_RETRY_MS = 50;
 
@@ -31,6 +32,9 @@ export class GoalRuntime {
 	private continuationQueuedFor: string | null = null;
 	private continuationScheduledFor: string | null = null;
 	private continuationTimer: ReturnType<typeof setTimeout> | null = null;
+	private networkErrorRetryGoalId: string | null = null;
+	private networkErrorRetryAttempt = 0;
+	private networkErrorRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
 	// ── turn-stop guard ──────────────────────────────────────────────────
 	private turnSeq = 0;
@@ -54,9 +58,10 @@ export class GoalRuntime {
 
 	// ── continuation scheduling ──────────────────────────────────────────
 
-	clearContinuationState(): void {
+	clearContinuationState(resetNetworkErrorBackoff = true): void {
 		this.clearContinuationTimer();
 		this.continuationQueuedFor = null;
+		if (resetNetworkErrorBackoff) this.clearNetworkErrorBackoff();
 	}
 
 	/** Clear the pending timer but keep the queued marker (used at session shutdown). */
@@ -98,6 +103,40 @@ export class GoalRuntime {
 	cancelContinuationFor(goalId: string): void {
 		if (this.continuationQueuedFor === goalId) this.continuationQueuedFor = null;
 		if (this.continuationScheduledFor === goalId) this.clearContinuationState();
+		if (this.networkErrorRetryGoalId === goalId) this.clearNetworkErrorBackoff();
+	}
+
+	/**
+	 * Schedule the next bounded recovery after Pi's built-in provider retries
+	 * have failed. The counter stays in memory and is cleared on a successful
+	 * turn or any user-owned cancellation path.
+	 */
+	scheduleNetworkErrorRetry(ctx: ExtensionContext, goal: GoalRecord): NetworkErrorBackoffPlan | null {
+		if (goal.status !== "active" || !goal.autoContinue || this.networkErrorRetryTimer) return null;
+		if (this.networkErrorRetryGoalId !== goal.id) {
+			this.networkErrorRetryGoalId = goal.id;
+			this.networkErrorRetryAttempt = 0;
+		}
+		const plan = networkErrorBackoffPlan(this.networkErrorRetryAttempt + 1);
+		if (!plan) return null;
+		this.networkErrorRetryAttempt = plan.attempt;
+		this.networkErrorRetryTimer = setTimeout(() => {
+			this.networkErrorRetryTimer = null;
+			if (!this.hooks.isActionable(goal.id)) return;
+			const currentGoal = this.hooks.getGoal();
+			if (!currentGoal || currentGoal.id !== goal.id) return;
+			this.queueContinuation(ctx, currentGoal, true);
+		}, plan.delayMs);
+		this.networkErrorRetryTimer.unref?.();
+		return plan;
+	}
+
+	/** Cancel and forget all goal-level network-error recovery state. */
+	clearNetworkErrorBackoff(): void {
+		if (this.networkErrorRetryTimer) clearTimeout(this.networkErrorRetryTimer);
+		this.networkErrorRetryTimer = null;
+		this.networkErrorRetryGoalId = null;
+		this.networkErrorRetryAttempt = 0;
 	}
 
 	/**

--- a/extensions/goal-state.ts
+++ b/extensions/goal-state.ts
@@ -90,7 +90,7 @@ export interface GoalCore {
 	stopAuditAnimation(): void;
 	abortAudit(ctx: ExtensionContext): void;
 	clearContinuationTimer(): void;
-	clearContinuationState(): void;
+	clearContinuationState(resetNetworkErrorBackoff?: boolean): void;
 	clearActiveAccounting(): void;
 	advanceTurnSeq(): void;
 	currentTurnStoppedGoalId(): string | null;
@@ -357,8 +357,8 @@ export function createGoalCore(
 		runtime.clearContinuationTimer();
 	}
 
-	function clearContinuationState(): void {
-		runtime.clearContinuationState();
+	function clearContinuationState(resetNetworkErrorBackoff = true): void {
+		runtime.clearContinuationState(resetNetworkErrorBackoff);
 	}
 
 	function clearActiveAccounting(): void {

--- a/extensions/network-error-backoff.ts
+++ b/extensions/network-error-backoff.ts
@@ -1,0 +1,25 @@
+/**
+ * Bounded, goal-level recovery after Pi has exhausted its provider retries.
+ *
+ * Pi owns the immediate request retries. These longer delays are deliberately
+ * small in number and only apply to terminal `network_error` failures, so an
+ * unavailable provider never becomes an unbounded auto-continue loop.
+ */
+
+export const NETWORK_ERROR_BACKOFF_DELAYS_MS = [5_000, 10_000, 20_000, 40_000, 80_000] as const;
+
+export interface NetworkErrorBackoffPlan {
+	attempt: number;
+	maxAttempts: number;
+	delayMs: number;
+}
+
+/** Return the recovery plan for a one-based attempt, or undefined after the cap. */
+export function networkErrorBackoffPlan(attempt: number): NetworkErrorBackoffPlan | undefined {
+	if (!Number.isInteger(attempt) || attempt < 1 || attempt > NETWORK_ERROR_BACKOFF_DELAYS_MS.length) return undefined;
+	return {
+		attempt,
+		maxAttempts: NETWORK_ERROR_BACKOFF_DELAYS_MS.length,
+		delayMs: NETWORK_ERROR_BACKOFF_DELAYS_MS[attempt - 1]!,
+	};
+}

--- a/specs/2026-08-23-network-error-backoff/MILESTONES.md
+++ b/specs/2026-08-23-network-error-backoff/MILESTONES.md
@@ -1,0 +1,20 @@
+# Milestones — network-error recovery backoff
+
+## 2026-08-23 — Design
+
+- Identified that `agent_end` precedes Pi's built-in retry settlement, so the
+  goal extension must defer its fallback to `agent_settled`.
+- Chose a bounded 5-step exponential ladder (5–80 seconds), preserving the
+  existing protection from runaway provider-error loops.
+
+## 2026-08-23 — Implementation and validation
+
+- Added network-error classification from Pi assistant error metadata and a
+  pure bounded-delay policy.
+- `agent_end` records a network recovery candidate; `agent_settled` schedules
+  it, so a later success in Pi's own retry loop clears the candidate instead.
+- Recovery timers are unref'd and cancelled by every ordinary continuation
+  reset, including user-driven turns, focus/lifecycle changes, and shutdown.
+- Validation passed: `npm run check`, `npm run lint`, `npm test` (837 tests),
+  `npm run test:integration` (31 tests), `npm pack --dry-run`, and
+  `git diff --check`.

--- a/specs/2026-08-23-network-error-backoff/PRODUCT.md
+++ b/specs/2026-08-23-network-error-backoff/PRODUCT.md
@@ -1,0 +1,31 @@
+# Product — network-error recovery backoff
+
+Date: 2026-08-23
+
+## Problem
+
+Pi retries a failed provider request three times. A provider response such as
+`Provider finish_reason: network_error` can still exhaust that retry budget,
+leaving an active auto-continue goal stranded even though the outage may be
+short-lived.
+
+## Behaviour
+
+- After Pi has fully settled with a terminal network error, an active,
+  auto-continue goal retries its checkpoint using a bounded exponential
+  backoff: 5, 10, 20, 40, then 80 seconds.
+- The extension waits for `agent_settled`; a transient Pi retry that succeeds
+  must clear the pending goal-level recovery instead of creating a duplicate
+  turn.
+- A recovery retry is cancelled by user-driven input, pausing/stopping or
+  changing the focused goal, and session shutdown.
+- After the fifth goal-level recovery is exhausted, the goal remains active
+  but no longer retries automatically. The user receives an actionable
+  warning and can resume when the provider is healthy.
+- Non-network provider errors retain the existing non-retry behaviour.
+
+## Non-goals
+
+- Do not create an unbounded retry loop.
+- Do not persist transient retry counters or change a goal's lifecycle status.
+- Do not replace Pi's built-in provider retry policy.

--- a/specs/2026-08-23-network-error-backoff/TECH.md
+++ b/specs/2026-08-23-network-error-backoff/TECH.md
@@ -1,0 +1,21 @@
+# Technical — network-error recovery backoff
+
+Date: 2026-08-23
+
+`GoalRuntime` owns an in-memory, one-timer network-recovery state keyed to the
+focused goal. It derives delay from an exported pure policy helper and, when
+the timer fires, uses the existing checkpoint continuation mechanism.
+
+`goal-events.ts` classifies assistant errors using `stopReason`, `rawStopReason`,
+and `errorMessage`. On a network error it records a pending recovery during
+`agent_end`, but schedules only from `agent_settled`. Any successful
+`agent_end` clears that state, thereby allowing Pi's own retry loop to win
+without extension interference.
+
+The retry state is deliberately ephemeral. `clearContinuationState()` accepts
+an internal opt-out used while the hidden retry checkpoint starts, preserving
+the consecutive-error counter across recovery attempts. All user-visible
+cancellation paths use the default reset behaviour.
+
+Coverage includes error classification, deterministic delay/cap policy, and
+lifecycle-level deferral/cancellation behaviour.

--- a/tests/.test-manifest.json
+++ b/tests/.test-manifest.json
@@ -59,6 +59,7 @@
     ".tests/goal-unfocused-banner.test.ts",
     ".tests/goal-update-objective.test.ts",
     ".tests/goal-widget.test.ts",
+    ".tests/network-error-backoff.test.ts",
     ".tests/no-status-refresh-timer.test.ts",
     ".tests/overflow-regression.test.ts",
     ".tests/session-checkpoint-growth.test.ts",

--- a/tests/goal-stale-continuation-golden.test.ts
+++ b/tests/goal-stale-continuation-golden.test.ts
@@ -40,6 +40,7 @@ interface HandlerMap {
 function createHarness(cwd: string) {
 	const handlers: HandlerMap = {};
 	const sentMessages: Array<{ customType?: string; details?: unknown }> = [];
+	const notifications: Array<{ message: string; level?: string }> = [];
 	let aborts = 0;
 	let toolCalls = 0;
 
@@ -78,7 +79,7 @@ function createHarness(cwd: string) {
 		isIdle: () => false,
 		hasPendingMessages: () => true,
 		abort: () => { aborts++; },
-		ui: { notify: () => {} },
+		ui: { notify: (message: string, level?: string) => { notifications.push({ message, level }); } },
 	} as unknown as ExtensionContext & { abort: () => void };
 
 	piGoalExtension(mockPi as never);
@@ -86,6 +87,7 @@ function createHarness(cwd: string) {
 	return {
 		handlers,
 		sentMessages,
+		notifications,
 		get aborts() { return aborts; },
 		get toolCalls() { return toolCalls; },
 		ctx,
@@ -298,6 +300,56 @@ test("provider-error guard: agent_end with an error message never queues a conti
 		assert.equal(await countCheckpoints(h), 0, "agent_end with an error message must not queue a continuation");
 	} finally {
 		// temp dir cleanup is best-effort.
+	}
+});
+
+test("network-error recovery waits for agent_settled before scheduling its backoff", async () => {
+	const { cwd, goal } = fixtureCwd();
+	const h = createHarness(cwd);
+	try {
+		await startSession(h.handlers, h.ctx, sessionEntriesFor(goal));
+		await h.handlers["before_agent_start"]!({
+			systemPrompt: "base",
+			prompt: "user typed: continue",
+			systemPromptOptions: {},
+		}, h.ctx);
+
+		await h.handlers["agent_end"]!({
+			messages: [{ role: "assistant", stopReason: "error", errorMessage: "Provider finish_reason: network_error" }],
+		}, idleCtx(h.ctx));
+		assert.equal(await countCheckpoints(h), 0, "agent_end must not race Pi's built-in retries");
+
+		await h.handlers["agent_settled"]!({}, idleCtx(h.ctx));
+		assert.equal(await countCheckpoints(h), 0, "the first recovery is delayed by the backoff policy");
+		assert.match(h.notifications.at(-1)?.message ?? "", /Retrying the goal in 5s \(recovery 1\/5\)/);
+	} finally {
+		// The delayed timer is unref'd and needs no test teardown.
+	}
+});
+
+test("a successful Pi retry clears the pending network-error recovery", async () => {
+	const { cwd, goal } = fixtureCwd();
+	const h = createHarness(cwd);
+	try {
+		await startSession(h.handlers, h.ctx, sessionEntriesFor(goal));
+		await h.handlers["before_agent_start"]!({
+			systemPrompt: "base",
+			prompt: "user typed: continue",
+			systemPromptOptions: {},
+		}, h.ctx);
+
+		await h.handlers["agent_end"]!({
+			messages: [{ role: "assistant", stopReason: "error", errorMessage: "Provider finish_reason: network_error" }],
+		}, idleCtx(h.ctx));
+		await h.handlers["agent_end"]!({
+			messages: [{ role: "assistant", stopReason: "end_turn" }],
+		}, idleCtx(h.ctx));
+		await h.handlers["agent_settled"]!({}, idleCtx(h.ctx));
+
+		assert.equal(await countCheckpoints(h), 1, "the successful Pi retry uses the normal continuation path");
+		assert.equal(h.notifications.length, 0, "no goal-level recovery is announced after Pi retries successfully");
+	} finally {
+		// No delayed timer should exist after the successful retry.
 	}
 });
 

--- a/tests/network-error-backoff.test.ts
+++ b/tests/network-error-backoff.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	NETWORK_ERROR_BACKOFF_DELAYS_MS,
+	networkErrorBackoffPlan,
+} from "../extensions/network-error-backoff.ts";
+import {
+	hasNetworkErrorAssistantMessage,
+	isNetworkErrorAssistantMessage,
+} from "../extensions/goal-format.ts";
+
+test("network-error backoff uses a bounded exponential recovery ladder", () => {
+	assert.deepEqual(NETWORK_ERROR_BACKOFF_DELAYS_MS, [5_000, 10_000, 20_000, 40_000, 80_000]);
+	assert.deepEqual(networkErrorBackoffPlan(1), { attempt: 1, maxAttempts: 5, delayMs: 5_000 });
+	assert.deepEqual(networkErrorBackoffPlan(5), { attempt: 5, maxAttempts: 5, delayMs: 80_000 });
+	assert.equal(networkErrorBackoffPlan(0), undefined);
+	assert.equal(networkErrorBackoffPlan(6), undefined);
+});
+
+test("network-error detection accepts provider error text and raw finish reason only", () => {
+	assert.equal(
+		isNetworkErrorAssistantMessage({ role: "assistant", stopReason: "error", errorMessage: "Provider finish_reason: network_error" }),
+		true,
+	);
+	assert.equal(
+		isNetworkErrorAssistantMessage({ role: "assistant", stopReason: "error", rawStopReason: "network-error" }),
+		true,
+	);
+	assert.equal(
+		isNetworkErrorAssistantMessage({ role: "assistant", stopReason: "error", errorMessage: "Provider finish_reason: content_filter" }),
+		false,
+	);
+	assert.equal(
+		isNetworkErrorAssistantMessage({ role: "assistant", stopReason: "stop", errorMessage: "network_error" }),
+		false,
+	);
+	assert.equal(
+		hasNetworkErrorAssistantMessage([
+			{ role: "assistant", stopReason: "error", errorMessage: "other provider error" },
+			{ role: "assistant", stopReason: "error", rawStopReason: "network_error" },
+		]),
+		true,
+	);
+});


### PR DESCRIPTION
## Summary

- add a bounded goal-level recovery ladder for terminal `network_error` provider failures: 5, 10, 20, 40, and 80 seconds
- wait for `agent_settled`, letting Pi's built-in retry loop succeed before scheduling a fallback
- cancel pending recovery on user input, goal lifecycle/focus changes, or shutdown; leave the goal active with a warning once the capped budget is exhausted

## Validation

- `npm run check`
- `npm run lint`
- `npm test` (837 passing)
- `npm run test:integration` (31 passing)
- `npm pack --dry-run`
- `git diff --check`