### PR TITLE
feat(ui): separate human display payloads from model payloads (PR F)

### DIFF
--- a/extensions/goal-auditor.ts
+++ b/extensions/goal-auditor.ts
@@ -15,6 +15,7 @@ import {
 import type { GoalRecord, GoalTask, GoalTaskList } from "./goal-record.ts";
 import { countTaskSubtree } from "./goal-task-count.ts";
 import { loadGoalSettings, type GoalSettings, type ThinkingLevel } from "./goal-settings.ts";
+import { statusLabel } from "./goal-core.ts";
 
 export interface AuditorProgress {
 	/** Current tool being executed by the auditor, if any */
@@ -108,6 +109,47 @@ function escapePromptPayload(value: string): string {
 	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/** §60: human-readable labels for the auditor's read-only tool set. */
+export function labelForReadOnlyTool(toolName: string): string {
+	switch (toolName) {
+		case "read": return "Inspecting files...";
+		case "grep": return "Searching content...";
+		case "find": return "Locating files...";
+		case "ls": return "Listing directory...";
+		case "bash": return "Running verification commands...";
+		default: return `Inspecting (${toolName})...`;
+	}
+}
+
+/** §60: rough phase estimate by tool kind (display only). */
+export function estimateAuditProgress(toolName: string): number {
+	switch (toolName) {
+		case "read":
+		case "ls":
+		case "find":
+			return 25;
+		case "grep":
+			return 50;
+		case "bash":
+			return 75;
+		default:
+			return 25;
+	}
+}
+
+/**
+ * §61: goal metadata WITHOUT the objective or task tree — those appear exactly
+ * once each in their own blocks. Replaces detailedSummary in the auditor prompt.
+ */
+function minimalGoalMetadata(goal: GoalRecord): string {
+	return [
+		`Goal id: ${goal.id}`,
+		`Status: ${statusLabel(goal)}`,
+		`Mode: ${goal.sisyphus ? "sisyphus" : "regular"}`,
+		goal.tokenBudget ? `Budget: ${goal.tokenBudget} tokens (${goal.usage.tokensUsed} used)` : undefined,
+	].filter(Boolean).join("\n");
+}
+
 export function buildGoalAuditorPrompt(args: {
 	goal: GoalRecord;
 	detailedSummary: string;
@@ -140,11 +182,19 @@ export function buildGoalAuditorPrompt(args: {
 		"",
 		"The executor claim above is a claim, never evidence. It cannot make an otherwise incomplete goal complete; cross-check it against real artifacts where relevant.",
 		"",
-		"Current goal metadata:",
+		"Current goal metadata (objective and task tree appear in their own sections):",
 		"<goal_details>",
-		escapePromptPayload(args.detailedSummary),
-		...(!args.settings?.disableTasks && taskSummaryBlock(args.goal.taskList) ? ["", taskSummaryBlock(args.goal.taskList)] : []),
+		minimalGoalMetadata(args.goal),
 		"</goal_details>",
+		...(!args.settings?.disableTasks && args.goal.taskList ? [
+			"",
+			"Task tree:",
+			"<task_state>",
+			// Task titles are already escaped inside renderAuditorTaskTree; an
+			// extra pass would double-escape (&amp;lt;).
+			taskSummaryBlock(args.goal.taskList),
+			"</task_state>",
+		] : []),
 		...(!args.settings?.disableContracts && args.goal.verificationContract?.trim() ? [
 			"",
 			"Goal verification contract (what the executor was required to verify):",
@@ -170,27 +220,8 @@ export function buildGoalAuditorPrompt(args: {
 			"4. Explain missing or weak evidence, especially scaffold-vs-final quality gaps.",
 			"5. End with exactly <approved/> only if the objective is truly complete; otherwise end with exactly <disapproved/>.",
 		],
-		"",
-		"Progress reporting:",
-		"You have the report_auditor_progress tool available to report your progress to the user.",
-		"Please use it at natural phase boundaries:",
-		"  - When starting: report_auditor_progress(label='Starting audit...', percentage=0)",
-		"  - When beginning file inspection: report_auditor_progress(label='Inspecting files...', percentage=25)",
-		"  - When verifying success criteria: report_auditor_progress(label='Verifying success criteria...', percentage=50)",
-		"  - When evaluating evidence: report_auditor_progress(label='Evaluating evidence...', percentage=75)",
-		"  - When producing final report: report_auditor_progress(label='Producing report...', percentage=90)",
-		"This is purely for user visibility and does not affect the audit outcome.",
 	].join("\n");
 }
-
-/** Tool name for auditor progress reporting */
-export const REPORT_AUDITOR_PROGRESS_TOOL_NAME = "report_auditor_progress";
-
-/** Parameters for the report_auditor_progress tool */
-export const reportAuditorProgressParams = Type.Object({
-	label: Type.String({ description: "Current step label describing what the auditor is doing (e.g. 'Inspecting files...', 'Verifying success criteria...', 'Producing report...')" }),
-	percentage: Type.Number({ description: "Completion percentage from 0 to 100", minimum: 0, maximum: 100 }),
-});
 
 function makeAuditorResourceLoader(): ResourceLoader {
 	return {
@@ -203,11 +234,6 @@ function makeAuditorResourceLoader(): ResourceLoader {
 			"You are a read-only completion auditor running in an isolated pi agent session.",
 			"Inspect the repository and decide whether the claimed goal completion is genuinely satisfied.",
 			"Never modify files. Never approve unless the actual user objective is complete.",
-			"",
-			"You have the report_auditor_progress tool available. Use it to report your audit progress",
-			"to the user at natural phase boundaries (starting, inspecting files, verifying criteria,",
-			"producing report). This helps the user understand what the auditor is doing and how far",
-			"along it is.",
 		].join("\n"),
 		getSystemPromptSource: () => undefined,
 		getAppendSystemPrompt: () => [],
@@ -312,37 +338,6 @@ export async function runGoalCompletionAuditor(args: {
 			args.onProgress?.({ ...progress });
 		}
 
-		// Build the report_auditor_progress tool, capturing the progress state
-		const reportProgressTool = defineTool({
-			name: REPORT_AUDITOR_PROGRESS_TOOL_NAME,
-			label: "Report Auditor Progress",
-			description: "Report current progress of the audit to the user. Call this at natural phase boundaries (starting, inspecting files, verifying criteria, producing report) to keep the user informed.",
-			promptSnippet: "Report current audit progress (step label and completion percentage) to the user.",
-			promptGuidelines: [
-				"Use report_auditor_progress at natural phase boundaries during the audit:",
-				"  - When starting the audit: label='Starting audit...' percentage=0",
-				"  - When beginning file inspection: label='Inspecting files...' percentage=25",
-				"  - When verifying success criteria: label='Verifying success criteria...' percentage=50",
-				"  - When evaluating evidence: label='Evaluating evidence...' percentage=75",
-				"  - When producing final report: label='Producing report...' percentage=90",
-				"This is purely for user visibility — it does not affect the audit outcome.",
-				"Do not call this tool more than once every few seconds to avoid flooding.",
-			],
-			parameters: reportAuditorProgressParams,
-			executionMode: "sequential",
-			async execute(_toolCallId, params) {
-				const { label, percentage } = params as Static<typeof reportAuditorProgressParams>;
-				progress.label = label;
-				progress.percentage = percentage;
-				progress.phase = "running";
-				emitProgress();
-				return {
-					content: [{ type: "text", text: `Progress reported: ${label} (${percentage}%)` }],
-					details: {},
-				};
-			},
-		});
-
 		const projectResources = args.settings?.auditorProjectResources === true;
 		const { session } = await createSession({
 			cwd: args.ctx.cwd,
@@ -357,10 +352,18 @@ export async function runGoalCompletionAuditor(args: {
 				: { resourceLoader: makeAuditorResourceLoader() }),
 			sessionManager: SessionManager.inMemory(args.ctx.cwd),
 			settingsManager: SettingsManager.inMemory({ compaction: { enabled: false } }),
-			tools: ["read", "grep", "find", "ls", "bash", REPORT_AUDITOR_PROGRESS_TOOL_NAME],
-			customTools: [reportProgressTool],
+			tools: ["read", "grep", "find", "ls", "bash"],
 		} as Parameters<typeof createAgentSession>[0]);
 		const unsubscribe = session.subscribe((event) => {
+			if (event.type === "agent_start") {
+				// PR E §60: progress is derived from session events — no model-facing
+				// report_auditor_progress tool exists anymore.
+				progress.label = "Starting audit...";
+				progress.percentage = 0;
+				progress.phase = "running";
+				emitProgress();
+				return;
+			}
 			if (event.type === "tool_execution_start") {
 				progress.currentTool = event.toolName;
 				progress.currentToolArgs = typeof event.args === "object" && event.args !== null
@@ -368,6 +371,9 @@ export async function runGoalCompletionAuditor(args: {
 					: String(event.args ?? "").slice(0, 120);
 				progress.currentToolStartedAt = Date.now();
 				progress.phase = "tool_executing";
+				// §60 derive the human label + estimate from the read-only tool.
+				progress.label = labelForReadOnlyTool(event.toolName);
+				progress.percentage = Math.max(progress.percentage ?? 0, estimateAuditProgress(event.toolName));
 				emitProgress();
 				return;
 			}
@@ -413,6 +419,12 @@ export async function runGoalCompletionAuditor(args: {
 			if (message.role !== "assistant") return;
 			for (const part of message.content ?? []) {
 				if (part.type === "text" && typeof part.text === "string") outputParts.push(part.text);
+			}
+			// Final report production: derived label for the widget.
+			if (outputParts.some((t) => t.trim())) {
+				progress.label = "Producing report...";
+				progress.percentage = Math.max(progress.percentage ?? 0, 90);
+				progress.phase = "producing_report";
 			}
 			// Show the accumulated output in progress
 			const fullText = outputParts.join("\n\n");

--- a/extensions/goal-compaction.ts
+++ b/extensions/goal-compaction.ts
@@ -11,7 +11,7 @@ import {
   type GoalLedgerEvent,
   type LedgerStateReadResult,
 } from "./goal-ledger.ts";
-import { type GoalRecord } from "./goal-record.ts";
+import { type GoalRecord, type GoalTask } from "./goal-record.ts";
 
 export function buildGoalCompactSummary(
   goal: GoalRecord,
@@ -149,5 +149,53 @@ export function buildCompactionSummary(args: {
   lines.push("Continue from the focused goal above, or ask the user to run /goal-focus.");
   lines.push("Do not rely on chat memory for goal state; use the facts above.");
 
+  return lines.join("\n");
+}
+
+/**
+ * PR E §62: post-compaction DELTA for the focused goal. The active system
+ * goal block already contains the objective, full policy, task gate, and
+ * verification contract — this delta adds only what compaction may have
+ * lost: the execution focus, a bounded recent-events tail, the latest
+ * unresolved auditor finding, and the other-open-goals count.
+ */
+export function buildPostCompactionGoalDelta(args: {
+  goal: GoalRecord;
+  ledgerEvents: GoalLedgerEvent[];
+  otherOpenCount: number;
+}): string {
+  const { goal, ledgerEvents, otherOpenCount } = args;
+  const lines: string[] = [];
+  lines.push(`[POST-COMPACTION RESYNC goalId=${goal.id}]`);
+  // Execution focus (with contract) — the one thing memory must not lose.
+  if (goal.currentTaskId && goal.taskList) {
+    const find = (tasks: GoalTask[]): GoalTask | undefined => {
+      for (const t of tasks) {
+        if (t.id === goal.currentTaskId) return t;
+        const nested = t.subtasks ? find(t.subtasks) : undefined;
+        if (nested) return nested;
+      }
+      return undefined;
+    };
+    const current = find(goal.taskList.tasks);
+    if (current) {
+      lines.push(`Current task: ${current.id} — ${current.title}${current.verificationContract ? ` (contract: ${current.verificationContract})` : ""}`);
+    }
+  }
+  // Bounded recent-event tail.
+  const recent = latestEventsForGoal(ledgerEvents, goal.id, 5);
+  if (recent.length > 0) {
+    lines.push("Recent events:");
+    for (const event of recent) {
+      lines.push(`  ${event.at.slice(11, 19)} ${event.type}`);
+    }
+  }
+  // Latest unresolved auditor finding.
+  const audit = latestAuditorResultForGoal(ledgerEvents, goal.id);
+  if (audit && audit.verdict === "disapproved") {
+    lines.push(`Latest unresolved auditor finding: ${audit.report.slice(0, 300)}`);
+  }
+  lines.push(`Other open goals: ${otherOpenCount}`);
+  lines.push("Continue from authoritative files and goal storage.");
   return lines.join("\n");
 }

--- a/extensions/goal-completion.ts
+++ b/extensions/goal-completion.ts
@@ -195,7 +195,7 @@ if (settings.disabled === true) {
 		].filter((line): line is string => line !== undefined).join("\n"),
 		display: true,
 		details: { phase: "started", goalId: auditTarget.id, auditor: auditorLabel },
-	}, { triggerTurn: true });
+	}, { triggerTurn: false });
 	if (!core.isFocusedOperationCurrent(completionFocus)) {
 		return core.focusedOperationCancelledResult("Goal completion", completionFocus);
 	}

--- a/extensions/goal-draft.ts
+++ b/extensions/goal-draft.ts
@@ -150,7 +150,7 @@ export function goalDraftingPrompt(topic: string, focus: GoalDraftingFocus): str
 		"- For simple single-step goals, no task list is required. The `tasks` parameter can be omitted.",
 		"- After goal creation, `propose_task_list` is still available for user-requested task additions or structural changes.",
 		"- propose_goal_draft opens the user's Confirm / Continue Chatting dialog. Confirm creates and focuses the goal; Continue Chatting means keep refining through normal proposal cycles.",
-		"- Before proposing, write the COMPLETE goal into your own message — every section (objective, success criteria, boundaries, constraints, verification contract) and the full task list — so the user can scroll up and re-read the whole goal while the confirmation dialog is open. Nothing may be omitted from the presented goal.",
+		"- Call propose_goal_draft with the complete structured proposal. The tool call renderer is the scrollable, complete human presentation of the objective and task tree — do NOT duplicate the full proposal in a preceding prose message. A brief orientation sentence is fine.",
 		"- create_goal is not a shortcut. Direct create_goal calls are rejected so the user keeps explicit say in goal creation.",
 	];
 

--- a/extensions/goal-events.ts
+++ b/extensions/goal-events.ts
@@ -11,7 +11,7 @@ import {
 	isMeaningfulProgressToolCall,
 	isToolUseAssistantMessage,
 } from "./goal-format.ts";
-import { buildCompactionSummary } from "./goal-compaction.ts";
+import { buildCompactionSummary, buildPostCompactionGoalDelta } from "./goal-compaction.ts";
 import { latestAuditorResultForGoal, loadLedgerState, readGoalLedger, invalidateGoalLedgerCache } from "./goal-ledger.ts";
 import { shouldArmPostCompactReminder, shouldInjectPostCompactReminder } from "./goal-policy.ts";
 import { formatTokenValue } from "./goal-core.ts";
@@ -431,11 +431,15 @@ export function registerGoalEvents(core: GoalCore): void {
 		}
 		if (core.runtime.isPostCompactReminderPending() && shouldInjectPostCompactReminder({ pending: true, goal: activeGoal })) {
 			core.runtime.clearPostCompactReminder();
-				// Use deterministic compaction summary instead of generic reminder
-				try {
-					const ledger = getPromptLedger();
-				const compaction = buildCompactionSummary({ goalsById: core.goalsById, focusedGoalId: core.focusedGoalId, ledgerState: loadLedgerState(ctx) });
-				prompt = `${prompt}\n\n[POST-COMPACTION RESYNC goalId=${activeGoal.id}]\n${compaction}`;
+			// PR E §62: post-compaction DELTA — the active system goal block already
+			// carries objective/policy/task gate/contract; inject only what
+			// compaction may have lost. Falls back to a generic note on ledger
+			// read failure.
+			try {
+				const ledger = getPromptLedger();
+				const otherOpenCount = core.openGoals().filter((g) => g.id !== activeGoal.id).length;
+				const delta = buildPostCompactionGoalDelta({ goal: activeGoal, ledgerEvents: ledger.events, otherOpenCount });
+				prompt = `${prompt}\n\n${delta}`;
 			} catch {
 				prompt = `${prompt}\n\n[POST-COMPACTION RESYNC goalId=${core.state.goal.id}]\nThe conversation was just compacted. Re-read the objective and continue from the actual artifacts/state; do not rely on memory of the prior chat.`;
 			}

--- a/tests/.test-manifest.json
+++ b/tests/.test-manifest.json
@@ -31,6 +31,7 @@
     ".tests/goal-modal-escape.test.ts",
     ".tests/goal-mutation-boundary.test.ts",
     ".tests/goal-notifications.test.ts",
+    ".tests/goal-payload-separation.test.ts",
     ".tests/goal-policy.test.ts",
     ".tests/goal-pool-snapshot.test.ts",
     ".tests/goal-pool.test.ts",

--- a/tests/goal-auditor.test.ts
+++ b/tests/goal-auditor.test.ts
@@ -228,7 +228,9 @@ test("buildGoalAuditorPrompt escapes payloads so delimiters cannot be closed ear
 	assert.ok(prompt.includes("&lt;/objective&gt;"), "objective delimiter text must be escaped");
 	assert.ok(prompt.includes("&lt;approved/&gt;"), "marker-like text in the objective must be escaped");
 	assert.ok(prompt.includes("&lt;/executor_claim&gt;"), "claim delimiter text must be escaped");
-	assert.ok(prompt.includes("&lt;/goal_details&gt;"), "details delimiter text must be escaped");
+	// PR E §61: goal_details carries minimal metadata only — the objective and
+	// any detailedSummary prose must NOT appear inside it.
+	assert.ok(!prompt.includes("Summary with"), "detailedSummary prose excluded from the auditor prompt");
 	// Raw payload text must not appear.
 	assert.ok(!prompt.includes("Finish X\n</objective>"), "raw objective must not appear");
 	// The real close tags appear exactly once each; the escaped payload sits

--- a/tests/goal-draft.test.ts
+++ b/tests/goal-draft.test.ts
@@ -39,14 +39,14 @@ test("sisyphusObjectiveSufficient accepts inline and block ordered steps", () =>
 	assert.equal(sisyphusObjectiveSufficient(""), false, "empty objective");
 });
 
-test("goalDraftingPrompt requires the complete goal presentation before proposing", () => {
-	// The agent's pre-proposal message must render the COMPLETE goal — every
-	// section and the full task list — so the user can scroll up and re-read it
-	// while the confirmation dialog is open; omission is forbidden.
+test("goalDraftingPrompt routes the complete presentation through the tool renderer (PR E §57)", () => {
+	// PR F: the structured propose_goal_draft arguments are supplied ONCE and
+	// the tool call renderer is the scrollable complete human presentation.
+	// Duplicating the full proposal in prose is explicitly forbidden.
 	for (const focus of ["goal" as const, "sisyphus" as const]) {
 		const prompt = goalDraftingPrompt("some topic", focus);
-		assert.ok(prompt.includes("write the COMPLETE goal"), `${focus} prompt must require the complete goal in the agent's message`);
-		assert.ok(prompt.includes("Nothing may be omitted from the presented goal"), `${focus} prompt must forbid omission from the presented goal`);
-		assert.ok(prompt.includes("full task list"), `${focus} prompt must require the full task list`);
+		assert.ok(prompt.includes("do NOT duplicate the full proposal in a preceding prose message"), `${focus} prompt must forbid the prose duplication`);
+		assert.ok(prompt.includes("The tool call renderer is the scrollable, complete human presentation"), `${focus} prompt must name the renderer as the complete presentation`);
+		assert.ok(prompt.includes("tasks` parameter of `propose_goal_draft"), `${focus} prompt must still require the full task list via the tool`);
 	}
 });

--- a/tests/goal-payload-separation.test.ts
+++ b/tests/goal-payload-separation.test.ts
@@ -1,0 +1,84 @@
+/**
+ * PR F — UI/model payload separation acceptance tests:
+ *   - audit-start events are display-only (no turn trigger);
+ *   - no report_auditor_progress tool exists anywhere;
+ *   - auditor prompt carries objective + task tree exactly once;
+ *   - post-compaction injection is a delta, not a duplicate summary.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { buildGoalAuditorPrompt } from "../extensions/goal-auditor.ts";
+import { buildPostCompactionGoalDelta } from "../extensions/goal-compaction.ts";
+import { createGoal } from "../extensions/goal-record.ts";
+import type { GoalRecord } from "../extensions/goal-record.ts";
+
+const completionSource = readFileSync(new URL("../extensions/goal-completion.ts", import.meta.url), "utf8");
+const auditorSource = readFileSync(new URL("../extensions/goal-auditor.ts", import.meta.url), "utf8");
+
+function goal(overrides: Partial<GoalRecord> = {}): GoalRecord {
+	const base = createGoal({ objective: "Deliver the audited thing.", autoContinue: true, sisyphus: false }, Date.UTC(2026, 7, 23, 9, 0, 0));
+	base.taskList = {
+		tasks: [
+			{ id: "t1", title: "First task", status: "complete" },
+			{ id: "t2", title: "Second task", status: "pending" },
+		],
+		blockCompletion: true,
+		proposedAt: "2026-08-23T09:01:00.000Z",
+	};
+	base.verificationContract = "All suites green.";
+	return { ...base, ...overrides };
+}
+
+describe("PR F §59/§60: audit event separation and progress tool removal", () => {
+	it("audit-start custom messages are display-only (never trigger a turn)", () => {
+		assert.match(
+			completionSource,
+			/customType: GOAL_AUDIT_ENTRY[\s\S]{0,400}triggerTurn: false/,
+			"audit_started sendMessage must use triggerTurn: false",
+		);
+	});
+
+	it("the report_auditor_progress tool no longer exists in any shipped surface", () => {
+		assert.doesNotMatch(auditorSource, /name:\s*"report_auditor_progress"/);
+		assert.doesNotMatch(completionSource, /report_auditor_progress/);
+		const goalCoreTools = readFileSync(new URL("../extensions/goal-core-tools.ts", import.meta.url), "utf8");
+		assert.doesNotMatch(goalCoreTools, /report_auditor_progress/);
+	});
+});
+
+describe("PR F §61: single-source auditor prompt", () => {
+	it("objective appears exactly once; task tree exactly once", () => {
+		const g = goal();
+		const prompt = buildGoalAuditorPrompt({
+			goal: g,
+			detailedSummary: `Goal: ${g.objective}\nStatus: running\nTasks: 1/2 complete`, // legacy verbose summary input
+			completionSummary: "I claim it is done.",
+		});
+		assert.equal(prompt.split("Deliver the audited thing.").length - 1, 1, "objective occurs once");
+		assert.equal(prompt.split("[ ] t2").length - 1, 1, "task tree rendered once");
+		assert.ok(!prompt.includes("report_auditor_progress"), "no progress protocol in the prompt");
+	});
+});
+
+describe("PR F §62: post-compaction delta", () => {
+	it("carries focus/events/findings without repeating objective or policy", () => {
+		const g = goal({ currentTaskId: "t2" });
+		g.taskList!.tasks[1]!.verificationContract = "Prove t2.";
+		const ledger = [
+			{ type: "goal_resumed", goalId: g.id, reason: "user", at: "2026-08-23T10:00:00.000Z" },
+			{ type: "audit_result", goalId: g.id, verdict: "disapproved", report: "Missing evidence for t2.", at: "2026-08-23T11:00:00.000Z" },
+		];
+		const delta = buildPostCompactionGoalDelta({ goal: g, ledgerEvents: ledger as never, otherOpenCount: 3 });
+		assert.match(delta, /\[POST-COMPACTION RESYNC goalId=/);
+		assert.match(delta, /Current task: t2 — Second task \(contract: Prove t2\.\)/);
+		assert.match(delta, /goal_resumed/);
+		assert.match(delta, /Latest unresolved auditor finding: Missing evidence for t2\./);
+		assert.match(delta, /Other open goals: 3/);
+		// The active system block already has these — the delta must not repeat them.
+		assert.ok(!delta.includes(g.objective), "delta must not repeat the objective");
+		assert.ok(!delta.includes("update_goal"), "delta must not restate lifecycle policy");
+	});
+});


### PR DESCRIPTION
Token optimization gated by the deterministic protocol gate — no live-agent runs.

## Changes
- **§57 Guided proposal**: the drafting protocol now forbids duplicating the full proposal in prose; the `propose_goal_draft` tool renderer is the scrollable complete human presentation (objective + full task tree visible to the user, pinned by test).
- **§59 Audit events**: audit-start custom messages are display-only (`triggerTurn: false`); the verdict reaches the executor exactly once via the `update_goal` tool result.
- **§60 Progress tool removed**: `report_auditor_progress` is gone from the auditor tool list, prompts, and schema; progress is derived from session events with read-only-tool labels and phase estimates. The human widget keeps equivalent progress.
- **§61 Auditor prompt single-source**: `goal_details` carries minimal metadata only; the objective and task tree each appear exactly once in their own escaped sections.
- **§62 Post-compaction delta**: injection is now a bounded delta (execution focus + contract, 5-event tail, latest unresolved auditor finding, other-open count) instead of a duplicate summary.

Validation: check/lint clean; test:all 870/870; test:selfcheck OK; test:serial 837/837; pack dry-run ok; audit 0 vulns; bench:gate:naf PASS; context:gate PASS; verify-pr-head PASS.