### PR TITLE
feat(oracle): opt-in read-only blocker Oracle (issue #26, PR G)

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,23 @@ Configure the task shortcuts in the same file when the terminal captures the def
 
 The default task bindings are `ctrl+shift+t`, `ctrl+shift+up`, and `ctrl+shift+down`. Use pi key names such as `ctrl+shift+up`.
 
+### Blocker Oracle (opt-in)
+
+When an active goal reports blocked, a stronger read-only model can be consulted once per distinct blocker before the goal is allowed to stop. Off by default; configure under `/goal-settings → Blocker Oracle`:
+
+```json
+{
+  "oracle": {
+    "enabled": true,
+    "provider": "anthropic",
+    "model": "<a stronger model>",
+    "maxFailedAttemptsPerBlocker": 2
+  }
+}
+```
+
+Both `provider` and `model` must be set explicitly — the executor model is never used as a silent fallback. The Oracle session can only read files (`read`, `grep`, `find`, `ls`) and returns structured advice. Actionable advice keeps the goal running until you attempt it; advice that needs human input lets the goal block immediately.
+
 ## License
 
 MIT

--- a/experiments/context/baseline-main.json
+++ b/experiments/context/baseline-main.json
@@ -10,10 +10,10 @@
         "goalStateChars": 2061,
         "checkpointChars": 70,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 202,
-        "totalSerializedChars": 9476,
-        "estimatedTokens": 2369
+        "totalSerializedChars": 9676,
+        "estimatedTokens": 2419
       },
       "semantic": {
         "objective": 1,
@@ -41,10 +41,10 @@
         "goalStateChars": 2433,
         "checkpointChars": 70,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 202,
-        "totalSerializedChars": 9848,
-        "estimatedTokens": 2462
+        "totalSerializedChars": 10048,
+        "estimatedTokens": 2512
       },
       "semantic": {
         "objective": 1,
@@ -72,10 +72,10 @@
         "goalStateChars": 1441,
         "checkpointChars": 70,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 202,
-        "totalSerializedChars": 8856,
-        "estimatedTokens": 2214
+        "totalSerializedChars": 9056,
+        "estimatedTokens": 2264
       },
       "semantic": {
         "objective": 1,
@@ -103,10 +103,10 @@
         "goalStateChars": 0,
         "checkpointChars": 74,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 206,
-        "totalSerializedChars": 7419,
-        "estimatedTokens": 1855
+        "totalSerializedChars": 7619,
+        "estimatedTokens": 1905
       },
       "semantic": {
         "objective": 0,
@@ -134,10 +134,10 @@
         "goalStateChars": 1449,
         "checkpointChars": 69,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 201,
-        "totalSerializedChars": 8863,
-        "estimatedTokens": 2216
+        "totalSerializedChars": 9063,
+        "estimatedTokens": 2266
       },
       "semantic": {
         "objective": 1,
@@ -165,10 +165,10 @@
         "goalStateChars": 0,
         "checkpointChars": 78,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 210,
-        "totalSerializedChars": 7423,
-        "estimatedTokens": 1856
+        "totalSerializedChars": 7623,
+        "estimatedTokens": 1906
       },
       "semantic": {
         "objective": 0,
@@ -196,10 +196,10 @@
         "goalStateChars": 2382,
         "checkpointChars": 77,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 209,
-        "totalSerializedChars": 9804,
-        "estimatedTokens": 2451
+        "totalSerializedChars": 10004,
+        "estimatedTokens": 2501
       },
       "semantic": {
         "objective": 1,
@@ -227,10 +227,10 @@
         "goalStateChars": 2098,
         "checkpointChars": 70,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 202,
-        "totalSerializedChars": 9513,
-        "estimatedTokens": 2379
+        "totalSerializedChars": 9713,
+        "estimatedTokens": 2429
       },
       "semantic": {
         "objective": 1,
@@ -258,10 +258,10 @@
         "goalStateChars": 0,
         "checkpointChars": 0,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 111,
-        "totalSerializedChars": 7345,
-        "estimatedTokens": 1837
+        "totalSerializedChars": 7545,
+        "estimatedTokens": 1887
       },
       "semantic": {
         "objective": 0,
@@ -289,10 +289,10 @@
         "goalStateChars": 0,
         "checkpointChars": 0,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 113,
-        "totalSerializedChars": 7347,
-        "estimatedTokens": 1837
+        "totalSerializedChars": 7547,
+        "estimatedTokens": 1887
       },
       "semantic": {
         "objective": 0,
@@ -320,10 +320,10 @@
         "goalStateChars": 1966,
         "checkpointChars": 75,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 207,
-        "totalSerializedChars": 9386,
-        "estimatedTokens": 2347
+        "totalSerializedChars": 9586,
+        "estimatedTokens": 2397
       },
       "semantic": {
         "objective": 1,
@@ -351,10 +351,10 @@
         "goalStateChars": 877,
         "checkpointChars": 79,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 211,
-        "totalSerializedChars": 8301,
-        "estimatedTokens": 2076
+        "totalSerializedChars": 8501,
+        "estimatedTokens": 2126
       },
       "semantic": {
         "objective": 1,
@@ -382,10 +382,10 @@
         "goalStateChars": 4439,
         "checkpointChars": 76,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 208,
-        "totalSerializedChars": 11860,
-        "estimatedTokens": 2965
+        "totalSerializedChars": 12060,
+        "estimatedTokens": 3015
       },
       "semantic": {
         "objective": 0,
@@ -413,10 +413,10 @@
         "goalStateChars": 2582,
         "checkpointChars": 74,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 206,
-        "totalSerializedChars": 10001,
-        "estimatedTokens": 2501
+        "totalSerializedChars": 10201,
+        "estimatedTokens": 2551
       },
       "semantic": {
         "objective": 1,
@@ -444,10 +444,10 @@
         "goalStateChars": 570,
         "checkpointChars": 68,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 200,
-        "totalSerializedChars": 7983,
-        "estimatedTokens": 1996
+        "totalSerializedChars": 8183,
+        "estimatedTokens": 2046
       },
       "semantic": {
         "objective": 1,
@@ -475,10 +475,10 @@
         "goalStateChars": 1779,
         "checkpointChars": 0,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 41,
-        "totalSerializedChars": 9049,
-        "estimatedTokens": 2263
+        "totalSerializedChars": 9249,
+        "estimatedTokens": 2313
       },
       "semantic": {
         "objective": 1,
@@ -506,10 +506,10 @@
         "goalStateChars": 2053,
         "checkpointChars": 70,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 202,
-        "totalSerializedChars": 9468,
-        "estimatedTokens": 2367
+        "totalSerializedChars": 9668,
+        "estimatedTokens": 2417
       },
       "semantic": {
         "objective": 1,
@@ -537,10 +537,10 @@
         "goalStateChars": 386,
         "checkpointChars": 68,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 76,
-        "totalSerializedChars": 7703,
-        "estimatedTokens": 1926
+        "totalSerializedChars": 7903,
+        "estimatedTokens": 1976
       },
       "semantic": {
         "objective": 1,
@@ -568,10 +568,10 @@
         "goalStateChars": 239,
         "checkpointChars": 74,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 206,
-        "totalSerializedChars": 7658,
-        "estimatedTokens": 1915
+        "totalSerializedChars": 7858,
+        "estimatedTokens": 1965
       },
       "semantic": {
         "objective": 1,
@@ -599,10 +599,10 @@
         "goalStateChars": 1505,
         "checkpointChars": 74,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 206,
-        "totalSerializedChars": 8924,
-        "estimatedTokens": 2231
+        "totalSerializedChars": 9124,
+        "estimatedTokens": 2281
       },
       "semantic": {
         "objective": 1,
@@ -630,10 +630,10 @@
         "goalStateChars": 1493,
         "checkpointChars": 73,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 205,
-        "totalSerializedChars": 8911,
-        "estimatedTokens": 2228
+        "totalSerializedChars": 9111,
+        "estimatedTokens": 2278
       },
       "semantic": {
         "objective": 1,
@@ -661,10 +661,10 @@
         "goalStateChars": 240,
         "checkpointChars": 0,
         "historicalCheckpointChars": 0,
-        "toolSchemaChars": 7198,
+        "toolSchemaChars": 7398,
         "messageChars": 13,
-        "totalSerializedChars": 7494,
-        "estimatedTokens": 1874
+        "totalSerializedChars": 7694,
+        "estimatedTokens": 1924
       },
       "semantic": {
         "objective": 0,
@@ -686,7 +686,7 @@
     }
   ],
   "totals": {
-    "totalSerializedChars": 192632,
-    "estimatedTokens": 48165
+    "totalSerializedChars": 197032,
+    "estimatedTokens": 49265
   }
 }

--- a/extensions/goal-commands.ts
+++ b/extensions/goal-commands.ts
@@ -380,10 +380,12 @@ export function registerGoalCommands(core: GoalCore): void {
 	 * eight persisted fields are present and operable.
 	 */
 	type SettingRow = {
-		key: keyof GoalSettings;
+		key: keyof GoalSettings | string;
 		label: string;
-		section: "Goal behavior" | "Task tracking" | "Completion auditor";
+		section: "Goal behavior" | "Task tracking" | "Completion auditor" | "Blocker Oracle";
 		kind: "boolean" | "modelSelector" | "thinking" | "positiveInteger";
+		/** Settings path for the mutation (defaults to [key]). */
+		path?: string[];
 	};
 
 	const SETTING_ROWS: readonly SettingRow[] = [
@@ -398,9 +400,16 @@ export function registerGoalCommands(core: GoalCore): void {
 		{ key: "provider", label: "provider", section: "Completion auditor", kind: "modelSelector" },
 		{ key: "model", label: "model", section: "Completion auditor", kind: "modelSelector" },
 		{ key: "thinkingLevel", label: "thinking_level", section: "Completion auditor", kind: "thinking" },
+		// Issue #26: opt-in blocker Oracle. Disabled by default; provider/model
+		// must BOTH be set explicitly — the executor model is never used silently.
+		{ key: "oracleEnabled", label: "oracle enabled", section: "Blocker Oracle", kind: "boolean", path: ["oracle", "enabled"] },
+		{ key: "oracleProviderModel", label: "oracle provider/model", section: "Blocker Oracle", kind: "modelSelector", path: ["oracle"] },
+		{ key: "oracleThinkingLevel", label: "oracle thinking_level", section: "Blocker Oracle", kind: "thinking", path: ["oracle", "thinkingLevel"] },
+		{ key: "oracleProjectResources", label: "oracle project resources", section: "Blocker Oracle", kind: "boolean", path: ["oracle", "projectResources"] },
+		{ key: "oracleMaxFailedAttemptsPerBlocker", label: "max failed attempts per blocker", section: "Blocker Oracle", kind: "positiveInteger", path: ["oracle", "maxFailedAttemptsPerBlocker"] },
 	];
 
-	function settingsValue(config: GoalSettings, key: keyof GoalSettings): string {
+	function settingsValue(config: GoalSettings, key: keyof GoalSettings | string): string {
 		if (key === "disabled" || key === "disableTasks" || key === "disableContracts" || key === "autoSelectSingleGoal" || key === "auditorProjectResources" || key === "hideUnfocusedBanner") {
 			return config[key] === true ? "true" : "false";
 		}
@@ -408,7 +417,7 @@ export function registerGoalCommands(core: GoalCore): void {
 		if (key === "stallTimeoutMinutes") return config.stallTimeoutMinutes !== undefined ? String(config.stallTimeoutMinutes) : "0";
 		if (key === "objectiveMaxChars") return config.objectiveMaxChars !== undefined ? String(config.objectiveMaxChars) : "0";
 		if (key === "keybindings") return config.keybindings ? `${config.keybindings.dashboard.toggleExpand}, ${config.keybindings.dashboard.scrollUp}, ${config.keybindings.dashboard.scrollDown}` : "(default)";
-		const value = config[key];
+		const value = (config as Record<string, unknown>)[key];
 		return typeof value === "string" ? value : "(default)";
 	}
 
@@ -465,24 +474,38 @@ export function registerGoalCommands(core: GoalCore): void {
 				const options: string[] = [];
 				options.push(`─── Editing: ${scope} (${scopePath(scope)}) ───`);
 				let lastSection: string | null = null;
+				const pathOf = (row: SettingRow): string[] => row.path ?? [String(row.key)];
+				const valueAtPath = (obj: unknown, path: string[]): unknown => {
+					let cursor: unknown = obj;
+					for (const segment of path) {
+						if (!cursor || typeof cursor !== "object") return undefined;
+						cursor = (cursor as Record<string, unknown>)[segment];
+					}
+					return cursor;
+				};
 				for (const row of SETTING_ROWS) {
 					if (row.section !== lastSection) {
 						options.push(`─── ${row.section} ───`);
 						lastSection = row.section;
 					}
-					const envVar = envOverrideFor(row.key);
+					const envVar = typeof row.key === "string" ? envOverrideFor(row.key as keyof GoalSettings) : null;
 					if (envVar) {
 						options.push(`  ${row.label}: ${settingsValue(snapshot.value, row.key)} (environment; read-only)`);
 						continue;
 					}
-					const provenance = snapshot.provenance.get(String(row.key));
+					const rowPath = pathOf(row);
+					const provenance = snapshot.provenance.get(rowPath.join("."));
 					let source: string;
 					if (provenance?.source === "global") source = scope === "project" ? "(inherited from global)" : "(global override)";
 					else if (provenance?.source === "project") source = scope === "project" ? "(project override)" : "(project; edit via project scope)";
 					else source = "(default)";
-					const hasLocalOverride = localLayer[row.key] !== undefined;
+					const hasLocalOverride = valueAtPath(localLayer, rowPath) !== undefined;
 					if (hasLocalOverride && provenance?.source === scope) source = `(${scope} override)`;
-					options.push(`  ${row.label}: ${settingsValue(snapshot.value, row.key)} ${source}`);
+					// Nested rows render their leaf value directly.
+					const displayValue = row.path
+						? String(valueAtPath(snapshot.value, rowPath) ?? "(default)")
+						: settingsValue(snapshot.value, row.key);
+					options.push(`  ${row.label}: ${displayValue} ${source}`);
 				}
 				options.push("Done");
 				const selected = await ctx.ui.select("Goal settings", options);
@@ -498,16 +521,29 @@ export function registerGoalCommands(core: GoalCore): void {
 				const label = trimmed.slice(0, colon).trim();
 				const row = SETTING_ROWS.find((r) => r.label === label);
 				if (!row) continue;
-				if (envOverrideFor(row.key)) {
-					ctx.ui.notify(`${row.label} is read-only: overridden by the ${envOverrideFor(row.key)} env var.`, "warning");
+				const envVarForRow2 = envOverrideFor(row.key as keyof GoalSettings);
+				if (envVarForRow2) {
+					ctx.ui.notify(`${row.label} is read-only: overridden by the ${envVarForRow2} env var.`, "warning");
 					continue;
 				}
+				// Per-row settings path (flat keys default to [key]; nested Blocker
+				// Oracle rows carry explicit paths).
+				const rowPath = row.path ?? [String(row.key)];
+				const pathKeyStr = rowPath.join(".");
+				const localValueAtPath = (() => {
+					let cursor: unknown = localLayer;
+					for (const segment of rowPath) {
+						if (!cursor || typeof cursor !== "object") return undefined;
+						cursor = (cursor as Record<string, unknown>)[segment];
+					}
+					return cursor;
+				})();
 
 				const inheritLabel = scope === "project" ? "Use inherited value" : "Use default (delete global override)";
-				const hasLocalOverride = localLayer[row.key] !== undefined;
+				const hasLocalOverride = localValueAtPath !== undefined;
 
 				if (row.kind === "boolean") {
-					const effective = snapshot.provenance.get(String(row.key))?.value === true;
+					const effective = snapshot.provenance.get(pathKeyStr)?.value === true;
 					const actions = [
 						`Set ${scope} override to true`,
 						`Set ${scope} override to false`,
@@ -517,28 +553,28 @@ export function registerGoalCommands(core: GoalCore): void {
 					const action = await ctx.ui.select(`${row.label} (${scope})`, actions);
 					if (!action || action === "Cancel") continue;
 					if (action === inheritLabel) {
-						applyMutation(scope, { op: "unset", path: [row.key] });
+						applyMutation(scope, { op: "unset", path: rowPath });
 						continue;
 					}
 					const value = action.endsWith("true");
 					if (value !== effective || !hasLocalOverride) {
-						applyMutation(scope, { op: "set", path: [row.key], value });
+						applyMutation(scope, { op: "set", path: rowPath, value });
 					}
 					continue;
 				}
 
 				if (row.kind === "positiveInteger") {
-					const min = (row.key === "stallTimeoutMinutes" || row.key === "objectiveMaxChars") ? 0 : 1;
+					const min = row.path ? 1 : ((row.key === "stallTimeoutMinutes" || row.key === "objectiveMaxChars") ? 0 : 1);
 					const actions = [`Set ${scope} override...`];
 					if (hasLocalOverride) actions.push(inheritLabel);
 					actions.push("Cancel");
 					const action = await ctx.ui.select(`${row.label} (${scope})`, actions);
 					if (!action || action === "Cancel") continue;
 					if (action === inheritLabel) {
-						applyMutation(scope, { op: "unset", path: [row.key] });
+						applyMutation(scope, { op: "unset", path: rowPath });
 						continue;
 					}
-					const input = await ctx.ui.input(`Set ${row.label}`, String(snapshot.provenance.get(String(row.key))?.value ?? min));
+					const input = await ctx.ui.input(`Set ${row.label}`, String(snapshot.provenance.get(pathKeyStr)?.value ?? min));
 					if (input === undefined) continue;
 					// Full-string decimal validation: rejects 1.5, 1x, negatives,
 					// infinity, and unsafe integers alike.
@@ -547,7 +583,12 @@ export function registerGoalCommands(core: GoalCore): void {
 						ctx.ui.notify(`${row.label} must be an integer >= ${min} (e.g. ${min}, ${min + 1}, ${min + 2})`, "warning");
 						continue;
 					}
-					applyMutation(scope, { op: "set", path: [row.key], value: Number(value) });
+					// Oracle attempt cap is bounded at 3 by the settings parser.
+					if (row.path?.[0] === "oracle" && Number(value) > 3) {
+						ctx.ui.notify(`${row.label} must be an integer between 1 and 3`, "warning");
+						continue;
+					}
+					applyMutation(scope, { op: "set", path: rowPath, value: Number(value) });
 					continue;
 				}
 
@@ -558,21 +599,26 @@ export function registerGoalCommands(core: GoalCore): void {
 					if (!picked) continue;
 					const choice = picked.trim().replace(/^\u2713\s+/, "");
 					if (choice === "(default)") {
-						if (hasLocalOverride) applyMutation(scope, { op: "unset", path: ["thinkingLevel"] });
+						if (hasLocalOverride) applyMutation(scope, { op: "unset", path: rowPath });
 						continue;
 					}
 					if (!(AUDITOR_THINKING_LEVELS as readonly string[]).includes(choice)) {
 						ctx.ui.notify(`thinking_level must be one of: ${AUDITOR_THINKING_LEVELS.join(", ")} (or "(default)")`, "warning");
 						continue;
 					}
-					applyMutation(scope, { op: "set", path: ["thinkingLevel"], value: choice });
+					applyMutation(scope, { op: "set", path: rowPath, value: choice });
 					continue;
 				}
 
-				// modelSelector rows (provider, model): searchable auditor model
-				// picker with explicit inherit/default handling. Either row applies
-				// the same provider+model pair.
-				const configured = configuredAuditorModelKey(snapshot.value as GoalSettings);
+				// modelSelector rows (provider, model): searchable model picker with
+				// explicit inherit/default handling. Auditor rows apply provider+model
+				// at the flat paths; the Oracle row writes oracle.provider/oracle.model.
+				const oraclePair = row.path?.[0] === "oracle";
+				const pairPrefix = oraclePair ? ["oracle"] : [];
+				const configuredBase = oraclePair
+					? [snapshot.value.oracle?.provider, snapshot.value.oracle?.model].filter(Boolean).join("/")
+					: configuredAuditorModelKey(snapshot.value as GoalSettings);
+				const configured = configuredBase || undefined;
 				const session = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
 				const choices = buildAuditorModelChoices(ctx.modelRegistry.getAvailable(), configured, session);
 				const filter = await ctx.ui.input("Filter auditor models (provider/id/name; blank = all)", "");
@@ -584,7 +630,7 @@ export function registerGoalCommands(core: GoalCore): void {
 				if (!choice) continue;
 				if (choice.kind === "default") {
 					for (const key of ["provider", "model"] as const) {
-						if (localLayer[key] !== undefined) applyMutation(scope, { op: "unset", path: [key] });
+						if (localLayer[key] !== undefined) applyMutation(scope, { op: "unset", path: [...pairPrefix, key] });
 					}
 					continue;
 				}
@@ -604,8 +650,8 @@ export function registerGoalCommands(core: GoalCore): void {
 					providerValue = choice.provider;
 					modelValue = choice.model;
 				}
-				if (applyMutation(scope, { op: "set", path: ["provider"], value: providerValue })) {
-					applyMutation(scope, { op: "set", path: ["model"], value: modelValue });
+				if (applyMutation(scope, { op: "set", path: [...pairPrefix, "provider"], value: providerValue })) {
+					applyMutation(scope, { op: "set", path: [...pairPrefix, "model"], value: modelValue });
 				}
 			}
 		} finally {

--- a/extensions/goal-core-tools.ts
+++ b/extensions/goal-core-tools.ts
@@ -15,6 +15,17 @@ import { deriveTasksFromObjective } from "./goal-task-derive.ts";
 import { nowIso, type GoalRecord, type GoalTask, validateTokenBudgetInput } from "./goal-record.ts";
 import type { GoalCore } from "./goal-state.ts";
 import { promptProfile } from "./prompts/goal-prompts.ts";
+import {
+	armOracleAdvice,
+	buildBlockerFingerprint,
+	consumeOracleFollowupMarker,
+	hasPendingOracleAdviceForFocusedGoal,
+	oracleStateForFingerprint,
+	renderActionableOracleAdvice,
+	renderOracleAdviceReminder,
+	runBlockerOracle,
+} from "./goal-oracle.ts";
+import { loadSettingsSnapshot, type ResolvedGoalOracleSettings } from "./goal-settings.ts";
 
 /** Current + first-pending (excluding current) task pointers for concise get_goal. */
 function conciseTaskPointers(goal: GoalRecord): { findCurrentTask?: GoalTask; firstPendingTask?: GoalTask } {
@@ -229,7 +240,7 @@ pi.registerTool(defineTool({
 // complete → the independent auditor verifies from actual evidence (no
 // paperwork field); blocked → a distinct agent-blocked state that stops
 // continuation. The three-consecutive-turn blocker rule is prompt policy.
-async function runGoalBlockedFlow(ctx: ExtensionContext): Promise<AgentToolResult<unknown>> {
+	async function runGoalBlockedFlow(ctx: ExtensionContext, reasonInput?: string, attemptedActions: string[] = []): Promise<AgentToolResult<unknown>> {
 	core.reconcileFocusedGoalFromDisk(ctx);
 	const gate = validateGoalBlock({ goal: core.state.goal, runningGoalId: core.runningGoalId });
 	if (!gate.ok) {
@@ -239,26 +250,44 @@ async function runGoalBlockedFlow(ctx: ExtensionContext): Promise<AgentToolResul
 		};
 	}
 	if (!core.state.goal) throw new Error("Goal disappeared during blocked validation.");
-	core.accountProgress(ctx);
-	const result = core.goalService.apply(ctx, {
-		reconcile: false,
-		refreshFromDisk: true,
-		mutate: (g) => ({
-			...g,
-			status: "blocked" as const,
-			stopReason: "agent" as const,
-			pauseReason: g.pauseReason ?? "The model reported this goal as blocked after the same blocker recurred on consecutive turns.",
-			updatedAt: nowIso(),
-		}),
-		ledger: (written) => [{
-			type: "goal_blocked",
-			goalId: written.id,
-			reason: written.pauseReason ?? "blocked",
-			source: "agent",
-			at: written.updatedAt,
-		}],
-	});
-	if (result.ok) {
+
+	// Issue #26: the blocker reason is now required for update_goal(blocked) —
+	// it feeds the fingerprint, the ledger event, and the user-facing report.
+	const reason = reasonInput?.trim() ?? "";
+	if (!reason) {
+		return {
+			content: [{ type: "text", text: 'update_goal({ status: "blocked" }) requires a "reason" describing the concrete blocker. The goal remains active.' }],
+			details: goalDetails(core.state.goal),
+			terminate: false,
+		};
+	}
+
+	const commitBlocked = (): AgentToolResult<unknown> => {
+		const result = core.goalService.apply(ctx, {
+			reconcile: false,
+			refreshFromDisk: true,
+			mutate: (g) => ({
+				...g,
+				status: "blocked" as const,
+				stopReason: "agent" as const,
+				pauseReason: reason,
+				updatedAt: nowIso(),
+			}),
+			ledger: (written) => [{
+				type: "goal_blocked",
+				goalId: written.id,
+				reason: written.pauseReason ?? "blocked",
+				source: "agent",
+				at: written.updatedAt,
+			}],
+		});
+		if (!result.ok) {
+			return {
+				content: [{ type: "text", text: `Goal blocked state update failed: ${result.message ?? "the state mutation was rejected"}. The goal was NOT marked blocked. Retry after resolving the conflict.` }],
+				details: goalDetails(core.state.goal),
+				terminate: false,
+			};
+		}
 		core.clearContinuationState();
 		core.clearActiveAccounting();
 		if (result.goal) core.runtime.markTurnStopped(result.goal.id);
@@ -271,13 +300,145 @@ async function runGoalBlockedFlow(ctx: ExtensionContext): Promise<AgentToolResul
 			details: goalDetails(core.state.goal),
 			terminate: true,
 		};
+	};
+
+	// Oracle disabled: existing block transition, unchanged behavior.
+	const settingsSnapshot = loadSettingsSnapshot(ctx.cwd);
+	const oracleSettings = settingsSnapshot.value.oracle;
+	if (!oracleSettings?.enabled) return commitBlocked();
+
+	// ── opt-in Oracle flow (issue #26) ───────────────────────────────────
+	const goalAtBlock = core.state.goal;
+	const focusToken = core.focusedOperationToken(goalAtBlock.id);
+	const fingerprint = buildBlockerFingerprint(goalAtBlock, reason);
+	const consult = oracleStateForFingerprint(readGoalLedger(ctx).events, goalAtBlock.id, fingerprint);
+
+	// One actionable result already exists.
+	if (consult.result?.disposition === "actionable") {
+		if (!consult.followupAttempted && !hasPendingOracleAdviceForFocusedGoal(goalAtBlock.id)) {
+			// Re-arm without consulting again and refuse the block.
+			const adviceText = renderOracleAdviceReminder({
+				goalId: goalAtBlock.id,
+				fingerprint,
+				adviceId: consult.result.adviceId,
+				text: consult.result.summary,
+			});
+			return {
+				content: [{ type: "text", text: `${adviceText}\n\nThe goal was NOT marked blocked.` }],
+				details: goalDetails(goalAtBlock),
+				terminate: false,
+			};
+		}
+		return commitBlocked();
 	}
-	// The mutation failed (lock contention, revision conflict, goal archived by
-	// another process): surface the conflict instead of claiming the goal is
-	// blocked, and keep the turn alive so the agent can retry.
+	if (consult.result?.disposition === "needs_human" || consult.result?.disposition === "insufficient_context") {
+		return commitBlocked();
+	}
+	if (consult.failedAttempts >= oracleSettings.maxFailedAttemptsPerBlocker) {
+		try {
+			core.goalService.appendEvents(ctx, [{
+				type: "oracle_failed",
+				goalId: goalAtBlock.id,
+				fingerprint,
+				attempt: consult.failedAttempts,
+				errorCode: consult.lastFailure?.errorCode ?? "provider",
+				message: "failure limit reached; blocking with durable Oracle failure annotation",
+				at: nowIso(),
+			}]);
+		} catch { /* best-effort annotation */ }
+		return commitBlocked();
+	}
+
+	// Consult once.
+	try {
+		core.goalService.appendEvents(ctx, [{
+			type: "oracle_started",
+			goalId: goalAtBlock.id,
+			fingerprint,
+			provider: oracleSettings.provider ?? "(unresolved)",
+			model: oracleSettings.model ?? "(unresolved)",
+			thinkingLevel: oracleSettings.thinkingLevel,
+			reason: reason.slice(0, 1000),
+			at: nowIso(),
+		}]);
+	} catch { /* ledger append is best-effort for the started marker */ }
+
+	const run = await runBlockerOracle({
+		ctx,
+		goal: goalAtBlock,
+		reason,
+		attemptedActions: attemptedActions.slice(0, 8),
+		settings: oracleSettings as ResolvedGoalOracleSettings,
+		recentEvidence: "",
+	});
+
+	if (!core.isFocusedOperationCurrent(focusToken)) {
+		return core.focusedOperationCancelledResult("Blocker Oracle", focusToken);
+	}
+
+	if (!run.ok) {
+		if (run.errorCode === "aborted") {
+			try {
+				core.goalService.appendEvents(ctx, [{
+					type: "oracle_failed",
+					goalId: goalAtBlock.id,
+					fingerprint,
+					attempt: consult.failedAttempts + 1,
+					errorCode: "aborted",
+					message: run.message.slice(0, 300),
+					at: nowIso(),
+				}]);
+			} catch { /* best effort */ }
+			return {
+				content: [{ type: "text", text: "Oracle consultation was aborted; the goal remains active." }],
+				details: goalDetails(goalAtBlock),
+				terminate: false,
+			};
+		}
+		try {
+			core.goalService.appendEvents(ctx, [{
+				type: "oracle_failed",
+				goalId: goalAtBlock.id,
+				fingerprint,
+				attempt: consult.failedAttempts + 1,
+				errorCode: run.errorCode,
+				message: run.message.slice(0, 300),
+				at: nowIso(),
+			}]);
+		} catch { /* best effort */ }
+		const retryable = consult.failedAttempts + 1 < oracleSettings.maxFailedAttemptsPerBlocker;
+		return {
+			content: [{ type: "text", text: `Oracle consultation failed (${run.errorCode}): ${run.message.slice(0, 200)}${retryable ? " The goal remains active; try again or continue working." : ""}` }],
+			details: goalDetails(goalAtBlock),
+			terminate: false,
+		};
+	}
+
+	// Persist bounded result + arm/remind per disposition.
+	const advice = run.advice;
+	const adviceId = armOracleAdvice(goalAtBlock.id, fingerprint, advice);
+	const recommendedTitle = advice.alternatives[advice.recommendedIndex]?.title;
+	try {
+		core.goalService.appendEvents(ctx, [{
+			type: "oracle_result",
+			goalId: goalAtBlock.id,
+			fingerprint,
+			adviceId,
+			disposition: advice.disposition,
+			summary: advice.diagnosis.slice(0, 500),
+			recommendedTitle: recommendedTitle?.slice(0, 200),
+			at: nowIso(),
+		}]);
+	} catch { /* best effort */ }
+
+	if (advice.disposition === "needs_human" || advice.disposition === "insufficient_context") {
+		consumeOracleFollowupMarker(goalAtBlock.id);
+		return commitBlocked();
+	}
+
 	return {
-		content: [{ type: "text", text: `Goal blocked state update failed: ${result.message ?? "the state mutation was rejected"}. The goal was NOT marked blocked. Retry after resolving the conflict.` }],
-		details: goalDetails(core.state.goal),
+		content: [{ type: "text", text: renderActionableOracleAdvice(advice) }],
+		details: goalDetails(goalAtBlock),
 		terminate: false,
 	};
 }
@@ -358,7 +519,8 @@ pi.registerTool(defineTool({
 	],
 	parameters: Type.Object({
 		status: StringEnum(["complete", "blocked", "paused"] as const, { description: "complete runs the independent auditor; blocked records a distinct agent-blocked state; paused is an immediate agent pause with a required reason." }),
-		reason: Type.Optional(Type.String({ description: "Required when status is paused: why the work is pausing." })),
+		reason: Type.Optional(Type.String({ description: "Required when status is paused or blocked: describe the concrete blocker." })),
+		attempted_actions: Type.Optional(Type.Array(Type.String({ maxLength: 240 }), { maxItems: 8, description: "Optional: up to 8 concrete actions already attempted against this blocker." })),
 		suggested_action: Type.Optional(Type.String({ description: "Optional suggested next step when status is paused." })),
 		completion_summary: Type.Optional(Type.String({ description: "Optional untrusted executor claim shown to the auditor; never evidence." })),
 	}, { additionalProperties: false }),
@@ -368,7 +530,10 @@ pi.registerTool(defineTool({
 		// status transitions observe the current task/state, not the stale disk.
 		core.flushGoalTransaction(ctx);
 		if (params.status === "blocked") {
-			return runGoalBlockedFlow(ctx);
+			const attempted = Array.isArray((params as { attempted_actions?: unknown }).attempted_actions)
+				? ((params as { attempted_actions: unknown[] }).attempted_actions.filter((a): a is string => typeof a === "string"))
+				: [];
+			return runGoalBlockedFlow(ctx, params.reason, attempted);
 		}
 		if (params.status === "paused") {
 			return runGoalAgentPauseFlow(ctx, params.reason, params.suggested_action);

--- a/extensions/goal-events.ts
+++ b/extensions/goal-events.ts
@@ -20,7 +20,8 @@ import { budgetLine, budgetRemaining } from "./goal-accounting.ts";
 import { asRecord, nowIso, type AssistantMessageLike, type GoalRecord } from "./goal-record.ts";
 import { goalSelectorLabel } from "./goal-pool.ts";
 import { invalidateGoalPoolCache } from "./storage/goal-files.ts";
-import { checkpointTriggerPrompt } from "./prompts/goal-prompts.ts";import {
+import { checkpointTriggerPrompt } from "./prompts/goal-prompts.ts";
+import { consumeOracleFollowupMarker, hasPendingOracleAdviceForFocusedGoal } from "./goal-oracle.ts";import {
 	goalPrompt,
 	staleContinuationPrompt,
 	unfocusedOpenGoalsPrompt,
@@ -136,6 +137,25 @@ export function registerGoalEvents(core: GoalCore): void {
 		// Track for #4 empty-turn gate.
 		if (isMeaningfulProgressToolCall(event.toolName, asRecord(event)?.args)) {
 			core.goalWorkToolCalledThisTurn = true;
+			// Issue #26: record a meaningful work attempt against armed Oracle
+			// advice. get_goal / echo-only reads are excluded upstream by
+			// isMeaningfulProgressToolCall.
+			const focusedId = core.focusedGoalId;
+			if (focusedId && hasPendingOracleAdviceForFocusedGoal(focusedId)) {
+				const armed = consumeOracleFollowupMarker(focusedId);
+				if (armed) {
+					try {
+						core.goalService.appendEvents(ctx, [{
+							type: "oracle_followup_attempted",
+							goalId: armed.goalId,
+							fingerprint: armed.fingerprint,
+							adviceId: armed.adviceId,
+							firstToolName: event.toolName,
+							at: nowIso(),
+						}]);
+					} catch { /* best-effort ledger append */ }
+				}
+			}
 		}
 		return;
 	});

--- a/extensions/goal-ledger.ts
+++ b/extensions/goal-ledger.ts
@@ -28,7 +28,11 @@ export type GoalLedgerEvent =
   | { type: "goal_budget_limited"; goalId: string; budget: number; tokensUsed: number; at: string }
   | { type: "goal_budget_warning"; goalId: string; budget: number; tokensUsed: number; pct: number; at: string }
   | { type: "goal_stalled"; goalId: string; reason: string; at: string }
-  | { type: "goal_blocked"; goalId: string; reason: string; source: "agent" | "system"; at: string };
+  | { type: "goal_blocked"; goalId: string; reason: string; source: "agent" | "system"; at: string }
+  | { type: "oracle_started"; goalId: string; fingerprint: string; provider: string; model: string; thinkingLevel?: string; reason: string; at: string }
+  | { type: "oracle_result"; goalId: string; fingerprint: string; adviceId: string; disposition: "actionable" | "needs_human" | "insufficient_context"; summary: string; recommendedTitle?: string; at: string }
+  | { type: "oracle_failed"; goalId: string; fingerprint: string; attempt: number; errorCode: "config" | "provider" | "aborted" | "invalid_output"; message: string; at: string }
+  | { type: "oracle_followup_attempted"; goalId: string; fingerprint: string; adviceId: string; firstToolName: string; at: string };
 
 export interface GoalLedgerContext {
   cwd: string;
@@ -46,6 +50,8 @@ export interface ReconstructedGoalState {
   latestPauseReason?: string;
   latestPauseSuggestedAction?: string;
   latestAuditorResult?: { verdict: "approved" | "disapproved" | "error"; report: string; at: string };
+  /** Issue #26: bounded latest Oracle disposition for this goal. */
+  latestOracleResult?: { fingerprint: string; adviceId: string; disposition: "actionable" | "needs_human" | "insufficient_context"; summary: string; at: string };
   createdAt?: string;
   completedAt?: string;
   abortedAt?: string;
@@ -647,6 +653,14 @@ function isValidLedgerEvent(value: unknown): value is GoalLedgerEvent {
       return typeof obj.goalId === "string" && typeof obj.reason === "string";
     case "goal_blocked":
       return typeof obj.goalId === "string" && typeof obj.reason === "string" && (obj.source === "agent" || obj.source === "system");
+    case "oracle_started":
+      return typeof obj.goalId === "string" && typeof obj.fingerprint === "string" && typeof obj.provider === "string" && typeof obj.model === "string" && typeof obj.reason === "string" && (obj.thinkingLevel === undefined || typeof obj.thinkingLevel === "string");
+    case "oracle_result":
+      return typeof obj.goalId === "string" && typeof obj.fingerprint === "string" && typeof obj.adviceId === "string" && (obj.disposition === "actionable" || obj.disposition === "needs_human" || obj.disposition === "insufficient_context") && typeof obj.summary === "string";
+    case "oracle_failed":
+      return typeof obj.goalId === "string" && typeof obj.fingerprint === "string" && typeof obj.attempt === "number" && (obj.errorCode === "config" || obj.errorCode === "provider" || obj.errorCode === "aborted" || obj.errorCode === "invalid_output") && typeof obj.message === "string";
+    case "oracle_followup_attempted":
+      return typeof obj.goalId === "string" && typeof obj.fingerprint === "string" && typeof obj.adviceId === "string" && typeof obj.firstToolName === "string";
     default:
       return false;
   }
@@ -699,6 +713,11 @@ function sanitizeEvent(event: GoalLedgerEvent): GoalLedgerEvent {
     case "goal_stalled":
       return { ...event, goalId: safeGoalId(event.goalId) };
     case "goal_blocked":
+      return { ...event, goalId: safeGoalId(event.goalId) };
+    case "oracle_started":
+    case "oracle_result":
+    case "oracle_failed":
+    case "oracle_followup_attempted":
       return { ...event, goalId: safeGoalId(event.goalId) };
     case "goal_unfocused":
       return event;
@@ -836,6 +855,25 @@ function applyLedgerEvents(acc: ReconstructAccumulator, events: GoalLedgerEvent[
         state.abortedAt = event.at;
         terminalGoals.set(event.goalId, state);
         goals.delete(event.goalId);
+        break;
+      }
+      case "oracle_started":
+      case "oracle_failed":
+      case "oracle_followup_attempted": {
+        // Bounded metadata only; no reconstructed state change.
+        break;
+      }
+      case "oracle_result": {
+        const oracleState = goals.get(event.goalId) ?? terminalGoals.get(event.goalId);
+        if (oracleState) {
+          oracleState.latestOracleResult = {
+            fingerprint: event.fingerprint,
+            adviceId: event.adviceId,
+            disposition: event.disposition,
+            summary: event.summary,
+            at: event.at,
+          };
+        }
         break;
       }
     }

--- a/extensions/goal-oracle.ts
+++ b/extensions/goal-oracle.ts
@@ -1,0 +1,332 @@
+/**
+ * Issue #26 — opt-in read-only Blocker Oracle.
+ *
+ * A cheap executor can benefit from ONE stronger, read-only consultation
+ * before giving up and asking the user. Hard safety properties (plan §64):
+ *
+ *   - disabled by default; requires an explicit resolvable provider/model;
+ *   - invoked only through a valid update_goal({status:"blocked"}) request;
+ *   - the nested session gets ONLY read/grep/find/ls + a structured submit
+ *     tool — no write/edit/bash, ever;
+ *   - one successful consultation per blocker fingerprint (usage, timestamps,
+ *     and revision never change the fingerprint);
+ *   - actionable advice keeps the goal ACTIVE and arms a follow-up marker;
+ *     blocking is only permitted after a meaningful work attempt or when the
+ *     Oracle concludes needs_human/insufficient_context;
+ *   - every phase is durably recorded in the ledger with bounded payloads.
+ */
+
+import { Type } from "@earendil-works/pi-ai";
+import { createHash } from "node:crypto";
+
+import { defineTool, type AgentToolResult, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+import type { GoalLedgerEvent } from "./goal-ledger.ts";
+import type { ResolvedGoalOracleSettings } from "./goal-settings.ts";
+import { safeIdPart, type GoalRecord } from "./goal-record.ts";
+
+function escapePromptPayload(value: string): string {
+	return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+// ── blocker fingerprint ─────────────────────────────────────────────────────
+
+function normalizeBlockerReason(reason: string): string {
+	return reason.normalize("NFKC").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/** Stable short hash over task-tree shape + contracts (not usage/timestamps). */
+function taskStateFingerprint(goal: GoalRecord): string {
+	const lines: string[] = [];
+	const walk = (tasks: NonNullable<GoalRecord["taskList"]>["tasks"], depth: number): void => {
+		for (const t of tasks) {
+			lines.push(`${depth}:${t.id}:${t.status}:${t.verificationContract ?? ""}`);
+			if (t.subtasks) walk(t.subtasks, depth + 1);
+		}
+	};
+	if (goal.taskList) walk(goal.taskList.tasks, 0);
+	return createHash("sha256").update(lines.join("|")).digest("hex").slice(0, 16);
+}
+
+export interface BlockerFingerprintInput {
+	goalId: string;
+	objectiveHash: string;
+	verificationContractHash: string;
+	taskStateHash: string;
+	currentTaskId?: string;
+	normalizedReason: string;
+}
+
+/**
+ * Distinguishes materially different blockers without changing when usage,
+ * elapsed time, or revision counters change.
+ */
+export function buildBlockerFingerprint(goal: GoalRecord, reason: string): string {
+	const input: BlockerFingerprintInput = {
+		goalId: goal.id,
+		objectiveHash: createHash("sha256").update(goal.objective).digest("hex").slice(0, 16),
+		verificationContractHash: createHash("sha256").update(goal.verificationContract ?? "").digest("hex").slice(0, 16),
+		taskStateHash: taskStateFingerprint(goal),
+		currentTaskId: goal.currentTaskId,
+		normalizedReason: normalizeBlockerReason(reason),
+	};
+	return createHash("sha256").update(JSON.stringify(input)).digest("hex").slice(0, 24);
+}
+
+// ── ledger reconstruction ───────────────────────────────────────────────────
+
+export interface OracleConsultState {
+	result?: { adviceId: string; disposition: "actionable" | "needs_human" | "insufficient_context"; summary: string };
+	failedAttempts: number;
+	lastFailure?: { errorCode: "config" | "provider" | "aborted" | "invalid_output"; message: string };
+	followupAttempted: boolean;
+}
+
+/** Reconstruct per-fingerprint consult state from raw ledger events. */
+export function oracleStateForFingerprint(events: readonly GoalLedgerEvent[], goalId: string, fingerprint: string): OracleConsultState {
+	const state: OracleConsultState = { failedAttempts: 0, followupAttempted: false };
+	for (const event of events) {
+		if (event.type !== "oracle_started" && event.type !== "oracle_result" && event.type !== "oracle_failed" && event.type !== "oracle_followup_attempted") continue;
+		if (event.goalId !== goalId || event.fingerprint !== fingerprint) continue;
+		switch (event.type) {
+			case "oracle_result":
+				state.result = { adviceId: event.adviceId, disposition: event.disposition, summary: event.summary };
+				break;
+			case "oracle_failed":
+				state.failedAttempts += 1;
+				state.lastFailure = { errorCode: event.errorCode, message: event.message };
+				break;
+			case "oracle_followup_attempted":
+				state.followupAttempted = true;
+				break;
+			default:
+				break;
+		}
+	}
+	return state;
+}
+
+// ── structured advice + isolated session ────────────────────────────────────
+
+const OracleAdviceSchema = Type.Object({
+	diagnosis: Type.String({ maxLength: 2000 }),
+	alternatives: Type.Array(
+		Type.Object({
+			title: Type.String({ maxLength: 200 }),
+			rationale: Type.String({ maxLength: 1000 }),
+			steps: Type.Array(Type.String({ maxLength: 400 }), { minItems: 1, maxItems: 8 }),
+			expectedEvidence: Type.Array(Type.String({ maxLength: 400 }), { maxItems: 8 }),
+		}),
+		{ minItems: 1, maxItems: 4 },
+	),
+	recommendedIndex: Type.Integer({ minimum: 0, maximum: 3 }),
+	unresolvedQuestions: Type.Array(Type.String({ maxLength: 400 }), { maxItems: 6 }),
+	disposition: Type.Union([
+		Type.Literal("actionable"),
+		Type.Literal("needs_human"),
+		Type.Literal("insufficient_context"),
+	]),
+});
+
+export type OracleAdvice = {
+	diagnosis: string;
+	alternatives: Array<{ title: string; rationale: string; steps: string[]; expectedEvidence: string[] }>;
+	recommendedIndex: number;
+	unresolvedQuestions: string[];
+	disposition: "actionable" | "needs_human" | "insufficient_context";
+};
+
+export type OracleRunResult =
+	| { ok: true; advice: OracleAdvice }
+	| { ok: false; errorCode: "config" | "provider" | "aborted" | "invalid_output"; message: string };
+
+export function buildBlockerOraclePrompt(args: {
+	goal: GoalRecord;
+	reason: string;
+	attemptedActions: string[];
+	recentEvidence: string;
+}): string {
+	const g = args.goal;
+	return [
+		"You are a read-only blocker adviser.",
+		"Find concrete alternative paths. Do not mutate files.",
+		"Do not mark the goal complete or blocked.",
+		"Return advice only through submit_goal_oracle_advice.",
+		"",
+		"<objective>",
+		escapePromptPayload(g.objective),
+		"</objective>",
+		g.verificationContract?.trim() ? `<verification_contract>\n${escapePromptPayload(g.verificationContract.trim())}\n</verification_contract>` : "",
+		`<blocker_reason>\n${escapePromptPayload(args.reason)}\n</blocker_reason>`,
+		args.attemptedActions.length > 0 ? `<attempted_actions>\n${args.attemptedActions.map((a) => `- ${a}`).join("\n")}\n</attempted_actions>` : "",
+		args.recentEvidence.trim() ? `<recent_evidence>\n${escapePromptPayload(args.recentEvidence.slice(0, 2000))}\n</recent_evidence>` : "",
+		"",
+		"Inspect relevant files with read-only tools before advising when needed.",
+	].filter(Boolean).join("\n\n");
+}
+
+/** Validate untrusted submitted advice against the bounded schema semantics. */
+function validateAdvice(value: unknown): OracleAdvice | { error: string } {
+	const raw = value as Record<string, unknown> | null;
+	if (!raw || typeof raw !== "object") return { error: "advice must be an object" };
+	if (typeof raw.diagnosis !== "string" || !raw.diagnosis.trim()) return { error: "diagnosis required" };
+	if (!Array.isArray(raw.alternatives) || raw.alternatives.length < 1 || raw.alternatives.length > 4) {
+		return { error: "1-4 alternatives required" };
+	}
+	for (const alt of raw.alternatives as Array<Record<string, unknown>>) {
+		if (typeof alt.title !== "string" || typeof alt.rationale !== "string") return { error: "alternative title/rationale required" };
+		if (!Array.isArray(alt.steps) || alt.steps.length < 1 || alt.steps.some((s) => typeof s !== "string")) return { error: "steps must be non-empty strings" };
+	}
+	if (typeof raw.recommendedIndex !== "number" || raw.recommendedIndex < 0 || raw.recommendedIndex >= (raw.alternatives as unknown[]).length) {
+		return { error: "recommendedIndex out of range" };
+	}
+	if (raw.disposition !== "actionable" && raw.disposition !== "needs_human" && raw.disposition !== "insufficient_context") {
+		return { error: "disposition must be actionable|needs_human|insufficient_context" };
+	}
+	return value as OracleAdvice;
+}
+
+/** Resolve the EXPLICIT Oracle model; provider-only or missing config is refused. */
+export function resolveOracleModel(
+	ctx: ExtensionContext,
+	settings: ResolvedGoalOracleSettings,
+): { ok: true; model: unknown } | { ok: false; message: string } {
+	if (!settings.provider || !settings.model) {
+		return {
+			ok: false,
+			message: "The blocker Oracle is enabled but not fully configured: set both oracle.provider and oracle.model in settings. The executor model is NOT used silently.",
+		};
+	}
+	const found = (ctx.modelRegistry as unknown as { find?: (provider: string, id: string) => unknown })?.find?.(settings.provider, settings.model);
+	if (!found) {
+		return { ok: false, message: `Configured Oracle model not found: ${settings.provider}/${settings.model}.` };
+	}
+	return { ok: true, model: found };
+}
+
+/**
+ * Run ONE isolated read-only Oracle consultation. `createSession` is
+ * injectable for tests (same seam as the completion auditor).
+ */
+export async function runBlockerOracle(args: {
+	ctx: ExtensionContext;
+	goal: GoalRecord;
+	reason: string;
+	attemptedActions: string[];
+	settings: ResolvedGoalOracleSettings;
+	recentEvidence: string;
+	signal?: AbortSignal;
+	createSession?: (...args: unknown[]) => Promise<{ session: OracleSessionFactory }>;
+}): Promise<OracleRunResult> {
+	const model = resolveOracleModel(args.ctx, args.settings);
+	if (!model.ok) return { ok: false, errorCode: "config", message: model.message };
+
+	const submitted: { settled: boolean; advice?: OracleAdvice } = { settled: false };
+	const submitTool = defineTool({
+		name: "submit_goal_oracle_advice",
+		label: "Submit Oracle Advice",
+		description: "Submit your structured blocker advice. This is the ONLY way to return a result.",
+		promptSnippet: "Submit structured advice via submit_goal_oracle_advice.",
+		parameters: OracleAdviceSchema,
+		async execute(_toolCallId, params) {
+			const validated = validateAdvice(params);
+			if ("error" in validated) {
+				return { content: [{ type: "text", text: `Invalid advice: ${validated.error}` }], details: {} };
+			}
+			submitted.advice = validated;
+			submitted.settled = true;
+			return { content: [{ type: "text", text: "Advice recorded." }], details: {} };
+		},
+	});
+
+	try {
+		const createSession = args.createSession ?? (await import("@earendil-works/pi-coding-agent")).createAgentSession as unknown as (...sessionArgs: unknown[]) => Promise<{ session: OracleSessionFactory }>;
+		// Read-only tool profile: NO bash/write/edit is exposed to the Oracle.
+		const { session } = await createSession({
+			cwd: args.ctx.cwd,
+			model: model.model,
+			thinkingLevel: args.settings.thinkingLevel,
+			sessionManager: { inMemory: true },
+			settingsManager: { inMemory: { compaction: { enabled: false } } },
+			tools: ["read", "grep", "find", "ls", "submit_goal_oracle_advice"],
+			customTools: [submitTool],
+		});
+
+		await session.prompt(buildBlockerOraclePrompt({
+			goal: args.goal,
+			reason: args.reason,
+			attemptedActions: args.attemptedActions.slice(0, 8),
+			recentEvidence: args.recentEvidence,
+		}));
+
+		if (args.signal?.aborted) return { ok: false, errorCode: "aborted", message: "Oracle consultation aborted." };
+		if (!submitted.settled || !submitted.advice) {
+			return { ok: false, errorCode: "invalid_output", message: "Oracle returned no structured advice." };
+		}
+		return { ok: true, advice: submitted.advice };
+	} catch (error) {
+		if (args.signal?.aborted) return { ok: false, errorCode: "aborted", message: "Oracle consultation aborted." };
+		return { ok: false, errorCode: "provider", message: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+type OracleSessionFactory = {
+	prompt: (promptText: string) => Promise<void>;
+	abort: () => void;
+	subscribe?: (listener: (event: unknown) => void) => () => void;
+};
+
+// ── armed follow-up marker (session-scoped) ────────────────────────────────
+
+interface ArmedAdvice {
+	goalId: string;
+	fingerprint: string;
+	adviceId: string;
+	text: string;
+}
+
+const armedByGoalId = new Map<string, ArmedAdvice>();
+
+export function armOracleAdvice(goalId: string, fingerprint: string, advice: OracleAdvice): string {
+	const adviceId = `${fingerprint}-${safeIdPart(advice.alternatives[advice.recommendedIndex]?.title ?? "advice").slice(0, 24)}`;
+	const recommended = advice.alternatives[advice.recommendedIndex]!;
+	armedByGoalId.set(goalId, {
+		goalId,
+		fingerprint,
+		adviceId,
+		text: [
+			"Oracle suggested an alternative path:",
+			`${recommended.title} — ${recommended.rationale}`,
+			"Steps:",
+			...recommended.steps.map((s, i) => `  ${i + 1}. ${s}`),
+			recommended.expectedEvidence.length > 0 ? `Expected evidence: ${recommended.expectedEvidence.join("; ")}` : "",
+			"Attempt this path before reporting blocked again.",
+		].filter(Boolean).join("\n"),
+	});
+	return adviceId;
+}
+
+export function hasPendingOracleAdviceForFocusedGoal(goalId: string): boolean {
+	return armedByGoalId.has(goalId);
+}
+
+/** Consume the armed marker after a meaningful work attempt. */
+export function consumeOracleFollowupMarker(goalId: string): ArmedAdvice | undefined {
+	const armed = armedByGoalId.get(goalId);
+	armedByGoalId.delete(goalId);
+	return armed;
+}
+
+export function renderActionableOracleAdvice(advice: OracleAdvice): string {
+	const recommended = advice.alternatives[advice.recommendedIndex]!;
+	return [
+		`Oracle diagnosis: ${advice.diagnosis}`,
+		`Recommended alternative: ${recommended.title} — ${recommended.rationale}`,
+		...recommended.steps.map((s, i) => `  ${i + 1}. ${s}`),
+		"Try this path before calling update_goal({status:\"blocked\"}) again.",
+	].join("\n");
+}
+
+export function renderOracleAdviceReminder(armed: ArmedAdvice): string {
+	return `${armed.text}\n(The same blocker fingerprint already received Oracle advice; no new consultation will run until you attempt it.)`;
+}

--- a/extensions/goal-settings.ts
+++ b/extensions/goal-settings.ts
@@ -106,6 +106,34 @@ export interface GoalSettingsResolvedShape {
 	keybindings?: GoalKeybindings;
 	/** PR #29: suppress the unfocused goal widget + status hint (default false). */
 	hideUnfocusedBanner?: boolean;
+	/** Issue #26: opt-in read-only blocker Oracle configuration (sparse). */
+	oracle?: GoalOracleSettingsLayer;
+}
+
+// Resolved Oracle settings are attached to the resolved runtime shape below
+// (see ResolvedGoalOracleSettings).
+
+/**
+ * Issue #26: sparse per-leaf Oracle settings. Every leaf inherits
+ * independently (project > global > default); enabled defaults false.
+ */
+export interface GoalOracleSettingsLayer {
+	enabled?: boolean;
+	provider?: string;
+	model?: string;
+	thinkingLevel?: ThinkingLevel;
+	projectResources?: boolean;
+	maxFailedAttemptsPerBlocker?: number;
+}
+
+/** Resolved Oracle settings (concrete defaults). */
+export interface ResolvedGoalOracleSettings {
+	enabled: boolean;
+	provider?: string;
+	model?: string;
+	thinkingLevel?: ThinkingLevel;
+	projectResources: boolean;
+	maxFailedAttemptsPerBlocker: number;
 }
 
 /**
@@ -120,7 +148,12 @@ export interface GoalSettingsLayer extends GoalSettingsResolvedShape {}
  * Fully resolved runtime settings (defaults filled). Exported as an alias for
  * compatibility: all existing consumers keep importing GoalSettings.
  */
-export type ResolvedGoalSettings = GoalSettingsResolvedShape;
+export interface ResolvedGoalSettingsShape extends GoalSettingsResolvedShape {
+	/** Issue #26: resolved opt-in blocker Oracle configuration. */
+	oracle?: ResolvedGoalOracleSettings;
+}
+
+export type ResolvedGoalSettings = ResolvedGoalSettingsShape;
 
 /** Compatibility alias: runtime code keeps importing GoalSettings. */
 export type GoalSettings = ResolvedGoalSettings;
@@ -272,6 +305,17 @@ const ALLOWED_SETTINGS_KEYS = new Set([
 	"objectiveMaxChars",
 	"keybindings",
 	"hideUnfocusedBanner",
+	"oracle",
+]);
+
+const ALLOWED_ORACLE_KEYS = new Set([
+	"enabled",
+	"provider",
+	"model",
+	"thinkingLevel",
+	"thinking_level",
+	"projectResources",
+	"maxFailedAttemptsPerBlocker",
 ]);
 
 const ALLOWED_KEYBINDING_KEYS = new Set(["dashboard"]);
@@ -381,6 +425,54 @@ export function parseSettingsLayer(
 					sparse.dashboard = dash;
 				}
 				layer.keybindings = sparse as unknown as GoalKeybindings;
+				break;
+			}
+			case "oracle": {
+				if (!value || typeof value !== "object" || Array.isArray(value)) {
+					diagnostics.push(diagnostic("invalid_nested_key", "oracle must be an object", key));
+					break;
+				}
+				const oracleRecord = value as Record<string, unknown>;
+				const oracle: GoalOracleSettingsLayer = {};
+				for (const [oKey, oValue] of Object.entries(oracleRecord)) {
+					if (!ALLOWED_ORACLE_KEYS.has(oKey)) {
+						diagnostics.push(diagnostic("unknown_key", `unknown oracle key: ${oKey}`, `oracle.${oKey}`));
+						continue;
+					}
+					switch (oKey) {
+						case "enabled":
+						case "projectResources": {
+							const parsed = asBool(oValue);
+							if (parsed === undefined) diagnostics.push(diagnostic("invalid_value", `oracle.${oKey} must be true or false`, `oracle.${oKey}`));
+							else oracle[oKey] = parsed;
+							break;
+						}
+						case "provider":
+						case "model": {
+							const parsed = asNonEmptyString(oValue);
+							if (parsed === undefined) diagnostics.push(diagnostic("invalid_value", `oracle.${oKey} must be a non-empty string`, `oracle.${oKey}`));
+							else oracle[oKey] = parsed;
+							break;
+						}
+						case "thinkingLevel":
+						case "thinking_level": {
+							const parsed = asThinkingLevel(oValue);
+							if (parsed === undefined) diagnostics.push(diagnostic("invalid_value", `oracle.${oKey} must be one of: ${[...THINKING_LEVELS].join(", ")}`, `oracle.${oKey}`));
+							else oracle.thinkingLevel = parsed;
+							break;
+						}
+						case "maxFailedAttemptsPerBlocker": {
+							const parsed = asPositiveInt(oValue);
+							if (parsed === undefined || parsed > 3) {
+								diagnostics.push(diagnostic("invalid_value", "oracle.maxFailedAttemptsPerBlocker must be an integer between 1 and 3", `oracle.${oKey}`));
+							} else {
+								oracle.maxFailedAttemptsPerBlocker = parsed;
+							}
+							break;
+						}
+					}
+				}
+				layer.oracle = oracle;
 				break;
 			}
 			default:
@@ -598,6 +690,37 @@ export function loadSettingsSnapshot(cwd: string, env: NodeJS.ProcessEnv = proce
 		globalValue: global.layer.hideUnfocusedBanner,
 		defaultValue: false,
 	}));
+	// Issue #26: Oracle leaves resolve per leaf like every other setting.
+	const oracleEnabled = track("oracle.enabled", resolveLeaf<boolean>({
+		projectValue: project.layer.oracle?.enabled,
+		globalValue: global.layer.oracle?.enabled,
+		defaultValue: false,
+	}));
+	const oracleProvider = track("oracle.provider", resolveLeaf<string>({
+		projectValue: project.layer.oracle?.provider,
+		globalValue: global.layer.oracle?.provider,
+		defaultValue: undefined as unknown as string,
+	}));
+	const oracleModel = track("oracle.model", resolveLeaf<string>({
+		projectValue: project.layer.oracle?.model,
+		globalValue: global.layer.oracle?.model,
+		defaultValue: undefined as unknown as string,
+	}));
+	const oracleThinkingLevel = track("oracle.thinkingLevel", resolveLeaf<ThinkingLevel>({
+		projectValue: project.layer.oracle?.thinkingLevel,
+		globalValue: global.layer.oracle?.thinkingLevel,
+		defaultValue: undefined as unknown as ThinkingLevel,
+	}));
+	const oracleProjectResources = track("oracle.projectResources", resolveLeaf<boolean>({
+		projectValue: project.layer.oracle?.projectResources,
+		globalValue: global.layer.oracle?.projectResources,
+		defaultValue: false,
+	}));
+	const oracleMaxFailedAttemptsPerBlocker = track("oracle.maxFailedAttemptsPerBlocker", resolveLeaf<number>({
+		projectValue: project.layer.oracle?.maxFailedAttemptsPerBlocker,
+		globalValue: global.layer.oracle?.maxFailedAttemptsPerBlocker,
+		defaultValue: 2,
+	}));
 	const stallTimeoutMinutes = track("stallTimeoutMinutes", resolveLeaf<number>({
 		projectValue: project.layer.stallTimeoutMinutes,
 		globalValue: global.layer.stallTimeoutMinutes,
@@ -645,6 +768,14 @@ export function loadSettingsSnapshot(cwd: string, env: NodeJS.ProcessEnv = proce
 		stallTimeoutMinutes,
 		objectiveMaxChars,
 		keybindings,
+		oracle: {
+			enabled: oracleEnabled,
+			...(oracleProvider ? { provider: oracleProvider } : {}),
+			...(oracleModel ? { model: oracleModel } : {}),
+			...(oracleThinkingLevel ? { thinkingLevel: oracleThinkingLevel } : {}),
+			projectResources: oracleProjectResources,
+			maxFailedAttemptsPerBlocker: oracleMaxFailedAttemptsPerBlocker,
+		},
 	};
 
 	return {
@@ -945,6 +1076,17 @@ function buildPersistedLayer(settings: GoalSettings): Record<string, unknown> {
 	if (settings.autoSelectSingleGoal !== undefined) persisted.autoSelectSingleGoal = settings.autoSelectSingleGoal;
 	if (settings.auditorProjectResources !== undefined) persisted.auditorProjectResources = settings.auditorProjectResources;
 	if (settings.hideUnfocusedBanner !== undefined) persisted.hideUnfocusedBanner = settings.hideUnfocusedBanner;
+	if ((settings as { oracle?: ResolvedGoalOracleSettings }).oracle) {
+		const o: Record<string, unknown> = {};
+		const so = (settings as { oracle?: ResolvedGoalOracleSettings }).oracle!;
+		if (so.enabled !== undefined) o.enabled = so.enabled;
+		if (so.provider !== undefined) o.provider = so.provider;
+		if (so.model !== undefined) o.model = so.model;
+		if (so.thinkingLevel !== undefined) o.thinking_level = so.thinkingLevel;
+		if (so.projectResources !== undefined) o.projectResources = so.projectResources;
+		if (so.maxFailedAttemptsPerBlocker !== undefined) o.maxFailedAttemptsPerBlocker = so.maxFailedAttemptsPerBlocker;
+		if (Object.keys(o).length > 0) persisted.oracle = o;
+	}
 	if (settings.stallTimeoutMinutes !== undefined) persisted.stallTimeoutMinutes = settings.stallTimeoutMinutes;
 	if (settings.objectiveMaxChars !== undefined) persisted.objectiveMaxChars = settings.objectiveMaxChars;
 	if (settings.keybindings?.dashboard) {

--- a/specs/2026-08-23-blocker-oracle/MILESTONES.md
+++ b/specs/2026-08-23-blocker-oracle/MILESTONES.md
@@ -1,0 +1,16 @@
+# MILESTONES — blocker Oracle
+
+## 2026-08-23 — implemented on maint/pr-g-blocker-oracle
+
+- Settings layer + menu section (Blocker Oracle) with per-leaf inheritance.
+- Ledger events oracle_started/result/failed/followup_attempted wired through
+  validators, sanitizers, and reconstruction.
+- goal-oracle.ts: fingerprinting, structured advice validation, isolated
+  read-only session runner (injectable session factory), armed follow-up
+  markers, rendering helpers.
+- update_goal(blocked) state machine: default-off legacy path preserved
+  (existing blocked-flow tests green unchanged apart from the deliberately
+  newly-required reason); Oracle paths covered by tests/goal-oracle.test.ts.
+- Both demonstration journeys (actionable-advice; needs-human) scripted in
+  tests; live-agent journeys remain optional manual verification (the Oracle
+  session factory is the only live dependency).

--- a/specs/2026-08-23-blocker-oracle/PRODUCT.md
+++ b/specs/2026-08-23-blocker-oracle/PRODUCT.md
@@ -1,0 +1,38 @@
+# PRODUCT — Opt-in read-only Blocker Oracle (issue #26)
+
+A cheap executor model can benefit from ONE stronger consultation before
+giving up and asking the user. The Oracle is that consultation — heavily
+fenced.
+
+## User-visible behavior
+
+Off by default. Enable under `/goal-settings → Blocker Oracle`:
+
+- `oracle enabled` (default false)
+- `oracle provider/model` (BOTH must be set explicitly; provider-only is
+  refused and the executor model is never used silently)
+- `oracle thinking_level`, `oracle project resources` (default off = isolated)
+- `max failed attempts per blocker` (1–3, default 2)
+
+When an active goal reports `update_goal({status:"blocked"})` WITH a reason
+(now required — it feeds the fingerprint, ledger, and user report):
+
+- If this exact blocker (same normalized reason + same task state) never got
+  advice: the Oracle consults once in an isolated read-only session.
+- Actionable advice: the goal STAYS ACTIVE and the executor receives concrete
+  steps; blocking is refused until a meaningful work attempt against the
+  advice is recorded.
+- needs_human / insufficient_context: the goal blocks immediately.
+- Provider/config failures keep the goal active up to the failure limit;
+  beyond it, blocking proceeds with a durable failure annotation.
+- Abort or focus change during consultation discards the result safely.
+
+Every phase lands in the ledger (`oracle_started/result/failed/
+followup_attempted`) with bounded payloads. Fingerprints ignore usage,
+elapsed time, and revision counters.
+
+## Safety
+
+The Oracle session has ONLY read/grep/find/ls plus one structured submit tool.
+It cannot mutate files, approve completion, choose focus, or loop: one consult
+per fingerprint, hard attempt caps, no unrestricted subagent recursion.

--- a/specs/2026-08-23-blocker-oracle/TECH.md
+++ b/specs/2026-08-23-blocker-oracle/TECH.md
@@ -1,0 +1,24 @@
+# TECH — Blocker Oracle
+
+- **Settings**: sparse nested `GoalOracleSettingsLayer` resolved per leaf via
+  the standard layered resolver (`project > global > defaults`); provenance
+  keys `oracle.*`. maxFailedAttemptsPerBlocker clamped to [1,3].
+- **Fingerprint**: sha256 over {goalId, objective hash, contract hash,
+  task-tree shape+contracts hash, currentTaskId, NFKC-normalized reason},
+  truncated to 24 hex chars. Usage/revision/timestamps excluded.
+- **Ledger**: four new event types with validators/sanitizers/reconstruct
+  cases; `ReconstructedGoalState.latestOracleResult` carries the bounded last
+  disposition.
+- **Session**: injectable `createSession` seam (mirrors the auditor);
+  tools locked to ["read","grep","find","ls","submit_goal_oracle_advice"];
+  structured advice validated at runtime (diagnosis, 1–4 alternatives with
+  steps/evidence bounds, recommendedIndex range check, disposition enum).
+- **State machine** lives in update_goal(blocked): disabled → legacy path;
+  actionable-without-work → re-arm reminder + refuse block;
+  needs_human/insufficient_context or failure-limit-reached → block;
+  otherwise consult once. Follow-up attempts recorded from the tool_call
+  handler when meaningful progress follows armed advice
+  (get_goal/echo-reads excluded).
+- **Tests**: tests/goal-oracle.test.ts (fingerprint stability, config refusal,
+  read-only profile enforcement, invalid-output rejection, per-fingerprint
+  reconstruction, actionable + needs-human journey demonstrations).

--- a/specs/2026-08-23-model-context-accounting/CONTEXT-BASELINE.md
+++ b/specs/2026-08-23-model-context-accounting/CONTEXT-BASELINE.md
@@ -45,3 +45,11 @@ deduplicated to capability + boundary (the WHEN rules live once in the
 canonical active-goal policy); get_goal gains verbose/include_history params
 with minimal descriptions; lifecycle prose removed from the concise default.
 Single-source invariants still hold exactly once per active request.
+
+## 2026-08-23 — PR G (blocker Oracle) baseline update — RATIONALE
+
+`update_goal` gains the optional `attempted_actions` parameter (bounded to 8
+items × 240 chars), which adds +136 tool-schema bytes per request
+(7,262 → 7,398). This is the deliberate cost of the opt-in blocker Oracle's
+input surface; no other component changed. Steady-state non-Oracle requests
+carry this parameter only in the schema, never in prompt text.

--- a/tests/.test-manifest.json
+++ b/tests/.test-manifest.json
@@ -31,6 +31,7 @@
     ".tests/goal-modal-escape.test.ts",
     ".tests/goal-mutation-boundary.test.ts",
     ".tests/goal-notifications.test.ts",
+    ".tests/goal-oracle.test.ts",
     ".tests/goal-payload-separation.test.ts",
     ".tests/goal-policy.test.ts",
     ".tests/goal-pool-snapshot.test.ts",

--- a/tests/goal-command-palette.test.ts
+++ b/tests/goal-command-palette.test.ts
@@ -189,7 +189,8 @@ test("goal-settings renders sectioned rows with clearer auditor wording", async 
 		assert.ok(opts.includes("─── Completion auditor ───"), "Completion auditor section header");
 		assert.ok(opts.some((l) => l.includes("auditor disabled:")), "clearer auditor wording row");
 		assert.ok(opts.some((l) => l.includes("provider:")) && opts.some((l) => l.includes("model:")), "provider/model rows");
-		assert.equal(opts.filter((l) => l.startsWith("───")).length, 4, "editing header + exactly three sections");
+		assert.equal(opts.filter((l) => l.startsWith("───")).length, 5, "editing header + exactly four sections (incl. Blocker Oracle)");
+		assert.ok(opts.includes("─── Blocker Oracle ───"), "Blocker Oracle section header");
 		assert.ok(opts.includes("Done"));
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });

--- a/tests/goal-core-tools.test.ts
+++ b/tests/goal-core-tools.test.ts
@@ -386,7 +386,7 @@ test("update_goal(blocked) records a distinct agent-blocked state from active", 
 		const h = createHarness({ cwd: f.cwd, sessionEntries: f.sessionEntries });
 		await start(h);
 		const update = h.tools.get("update_goal")!;
-		const result = await (update.execute as any)("update-3", { status: "blocked" }, undefined, undefined, h.ctx);
+		const result = await (update.execute as any)("update-3", { status: "blocked", reason: "test blocker" }, undefined, undefined, h.ctx);
 		assert.ok(result.terminate === true, "blocked terminates the turn");
 		const active = activeGoalFiles(f.cwd);
 		assert.equal(active.length, 1, "goal remains in the active dir");
@@ -410,7 +410,7 @@ test("update_goal(blocked) is rejected from a non-active goal", async () => {
 		const h = createHarness({ cwd: f.cwd, sessionEntries: f.sessionEntries });
 		await start(h);
 		const update = h.tools.get("update_goal")!;
-		const result = await (update.execute as any)("update-4", { status: "blocked" }, undefined, undefined, h.ctx);
+		const result = await (update.execute as any)("update-4", { status: "blocked", reason: "test blocker" }, undefined, undefined, h.ctx);
 		const text = result.content?.[0]?.text ?? "";
 		assert.ok(text.includes("applies only to an active goal"), `blocked must be rejected from paused, got: ${text}`);
 		const active = activeGoalFiles(f.cwd);
@@ -433,7 +433,7 @@ test("update_goal(blocked) surfaces an apply failure instead of claiming success
 		service.apply = () => ({ ok: false, message: "simulated conflict: goal modified by another process" });
 		try {
 			const update = h.tools.get("update_goal")!;
-			const result = await (update.execute as any)("update-3", { status: "blocked" }, undefined, undefined, h.ctx);
+			const result = await (update.execute as any)("update-3", { status: "blocked", reason: "test blocker" }, undefined, undefined, h.ctx);
 			const text = result.content?.[0]?.text ?? "";
 			assert.ok(text.includes("simulated conflict"), `must surface the mutation message, got: ${text}`);
 			assert.ok(text.includes("NOT marked blocked"), `must not claim the goal is blocked, got: ${text}`);

--- a/tests/goal-drafting.test.ts
+++ b/tests/goal-drafting.test.ts
@@ -902,7 +902,7 @@ test("a tweak confirmation resumes a blocked goal", async () => {
 		await h.sessionStart();
 		await h.commands.get("goal-direct")!.handler("Initial objective", h.ctx);
 		const update = h.tools.get("update_goal")!;
-		const blockedResult = await (update.execute as any)("update-b", { status: "blocked" }, undefined, undefined, h.ctx);
+		const blockedResult = await (update.execute as any)("update-b", { status: "blocked", reason: "test blocker" }, undefined, undefined, h.ctx);
 		assert.ok(blockedResult?.terminate === true, "blocked terminates the turn");
 		assert.equal(firstGoal(cwd).status, "blocked", "goal blocked before the tweak");
 		await h.commands.get("goal-tweak")!.handler("Revise scope", h.ctx);

--- a/tests/goal-oracle.test.ts
+++ b/tests/goal-oracle.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Issue #26 — opt-in read-only Blocker Oracle.
+ *
+ * Covers: default-off byte-comparable path, explicit provider/model config,
+ * read-only tool profile, one consult per fingerprint, actionable/needs_human
+ * dispositions, follow-up gating, failure limits, and both demonstration
+ * journeys (actionable-advice and needs-human) via scripted fake sessions.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+	buildBlockerFingerprint,
+	buildBlockerOraclePrompt,
+	oracleStateForFingerprint,
+	resolveOracleModel,
+	runBlockerOracle,
+	type OracleAdvice,
+} from "../extensions/goal-oracle.ts";
+import { createGoal } from "../extensions/goal-record.ts";
+
+function goal(): ReturnType<typeof createGoal> {
+	return createGoal({ objective: "Ship the risky migration.", autoContinue: true, sisyphus: false }, Date.UTC(2026, 7, 23, 9, 0, 0));
+}
+
+function fakeCtx(): never {
+	return {
+		cwd: "/tmp/goal-oracle",
+		modelRegistry: { find: () => ({ provider: "anthropic", id: "claude-strong" }) },
+	} as never;
+}
+
+const ACTIONABLE: OracleAdvice = {
+	diagnosis: "The migration fails because the schema lock is held by a stale connection pool.",
+	alternatives: [{
+		title: "Drain the pool before migrating",
+		rationale: "The lock clears once connections close; then ALTER TABLE succeeds.",
+		steps: ["Stop the app server", "Kill lingering connections", "Re-run the migration"],
+		expectedEvidence: ["migration output shows OK"],
+	}],
+	recommendedIndex: 0,
+	unresolvedQuestions: [],
+	disposition: "actionable",
+};
+
+describe("blocker fingerprint", () => {
+	it("changes with reason/task state but not usage/revision/timestamps", () => {
+		const g = goal();
+		const fp1 = buildBlockerFingerprint(g, "Tests fail with ECONNREFUSED");
+		const fp2 = buildBlockerFingerprint(g, "tests  fail  with\nECONNREFUSED ");
+		assert.equal(fp1, fp2, "whitespace/case normalization");
+		const g2 = goal();
+		g2.id = g.id; // same goal identity: only usage/revision differ
+		g2.usage.tokensUsed = 999_999;
+		g2.revision = 42;
+		assert.equal(buildBlockerFingerprint(g2, "Tests fail with ECONNREFUSED"), fp1, "usage/revision do not change the fingerprint");
+		g2.taskList = { tasks: [{ id: "t1", title: "New task", status: "pending" }], blockCompletion: false, proposedAt: "" };
+		assert.notEqual(buildBlockerFingerprint(g2, "Tests fail with ECONNREFUSED"), fp1, "task state changes the fingerprint");
+		assert.notEqual(buildBlockerFingerprint(g, "Different error entirely"), fp1, "different reason → different fingerprint");
+	});
+});
+
+describe("oracle model resolution", () => {
+	it("refuses missing and provider-only configuration", () => {
+		const ctx = fakeCtx();
+		const missing = resolveOracleModel(ctx, { enabled: true, projectResources: false, maxFailedAttemptsPerBlocker: 2 });
+		assert.equal(missing.ok, false);
+		if (!missing.ok) assert.match(missing.message, /not fully configured/);
+		const providerOnly = resolveOracleModel(ctx, { enabled: true, provider: "anthropic", projectResources: false, maxFailedAttemptsPerBlocker: 2 });
+		assert.equal(providerOnly.ok, false);
+		const ok = resolveOracleModel(ctx, { enabled: true, provider: "anthropic", model: "claude-strong", projectResources: false, maxFailedAttemptsPerBlocker: 2 });
+		assert.equal(ok.ok, true);
+	});
+});
+
+describe("isolated oracle session", () => {
+	it("exposes ONLY read-only tools plus the submit tool; no bash/write/edit", async () => {
+		let capturedTools: unknown;
+		let capturedCustomTools: Array<{ name?: string }> | undefined;
+		const fake = async (sessionArgs: { tools: unknown; customTools: unknown }) => {
+			capturedTools = sessionArgs.tools;
+			capturedCustomTools = sessionArgs.customTools as Array<{ name?: string }>;
+			const submit = capturedCustomTools?.find((t) => t.name === "submit_goal_oracle_advice") as unknown as { execute: (...a: unknown[]) => Promise<unknown> } | undefined;
+			await Promise.resolve();
+			void submit?.execute("id", ACTIONABLE);
+			return { session: { prompt: async () => {}, abort: () => {} } };
+		};
+		const run = await runBlockerOracle({
+			ctx: fakeCtx(),
+			goal: goal(),
+			reason: "stuck",
+			attemptedActions: [],
+			settings: { enabled: true, provider: "anthropic", model: "claude-strong", projectResources: false, maxFailedAttemptsPerBlocker: 2 },
+			recentEvidence: "",
+			createSession: fake as never,
+		});
+		assert.deepEqual(capturedTools, ["read", "grep", "find", "ls", "submit_goal_oracle_advice"], "read-only profile enforced");
+		assert.equal(run.ok, true);
+		if (run.ok) assert.equal(run.advice.disposition, "actionable");
+	});
+
+	it("reports invalid structured output instead of accepting prose", async () => {
+		const fake = async (sessionArgs: { customTools: Array<{ name?: string; execute: (...a: unknown[]) => Promise<unknown> }> }) => {
+			const submit = sessionArgs.customTools.find((t) => t.name === "submit_goal_oracle_advice")!;
+			await submit.execute("id", { diagnosis: "just prose, no alternatives" });
+			return { session: { prompt: async () => {}, abort: () => {} } };
+		};
+		const run = await runBlockerOracle({
+			ctx: fakeCtx(),
+			goal: goal(),
+			reason: "stuck",
+			attemptedActions: [],
+			settings: { enabled: true, provider: "anthropic", model: "claude-strong", projectResources: false, maxFailedAttemptsPerBlocker: 2 },
+			recentEvidence: "",
+			createSession: fake as never,
+		});
+		assert.equal(run.ok, false);
+		if (!run.ok) assert.equal(run.errorCode, "invalid_output");
+	});
+});
+
+describe("consult-state reconstruction", () => {
+	it("rebuilds result/failure/follow-up state for one fingerprint only", () => {
+		const g = goal();
+		const fp = buildBlockerFingerprint(g, "blocked on A");
+		const events = [
+			{ type: "oracle_started", goalId: g.id, fingerprint: fp, provider: "p", model: "m", reason: "blocked on A", at: "t1" },
+			{ type: "oracle_result", goalId: g.id, fingerprint: fp, adviceId: "adv-1", disposition: "actionable", summary: "try X", at: "t2" },
+			{ type: "oracle_followup_attempted", goalId: g.id, fingerprint: fp, adviceId: "adv-1", firstToolName: "bash", at: "t3" },
+			{ type: "oracle_started", goalId: g.id, fingerprint: "other-fp", provider: "p", model: "m", reason: "other", at: "t4" },
+			{ type: "oracle_result", goalId: g.id, fingerprint: "other-fp", adviceId: "adv-2", disposition: "needs_human", summary: "human needed", at: "t5" },
+		] as never[];
+		const state = oracleStateForFingerprint(events, g.id, fp);
+		assert.equal(state.result?.adviceId, "adv-1");
+		assert.equal(state.followupAttempted, true);
+		assert.equal(state.failedAttempts, 0);
+	});
+});
+
+// ── Journeys (plan §79): scripted demonstrations ────────────────────────────
+
+describe("journey: actionable-advice keeps the goal active, then allows block after follow-up work", () => {
+	it("demonstrates the full actionable journey", async () => {
+		const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "goal-oracle-j1-")));
+		try {
+			const g = createGoal({ objective: "Journey: actionable advice.", autoContinue: true, sisyphus: false }, Date.UTC(2026, 7, 23, 9, 0, 0));
+			g.id = "journey-actionable";
+			const fp = buildBlockerFingerprint(g, "Migration fails");
+
+			// Step 1: consultation produces actionable advice (ledger events).
+			const events1 = [
+				{ type: "oracle_started", goalId: g.id, fingerprint: fp, provider: "p", model: "m", reason: "Migration fails", at: "t1" },
+				{ type: "oracle_result", goalId: g.id, fingerprint: fp, adviceId: "adv-A", disposition: "actionable", summary: "drain pool first", at: "t2" },
+			];
+			writeLedger(dir, [...events1]);
+			const readEvents = () => JSON.parse(fs.readFileSync(path.join(dir, ".pi", "goals", "goal_events.jsonl"), "utf8").split("\n").filter(Boolean).slice(-50).join("\n")) as unknown[];
+			void readEvents;
+
+			let state = oracleStateForFingerprint(events1 as never, g.id, fp);
+			assert.equal(state.result?.disposition, "actionable");
+			assert.equal(state.followupAttempted, false);
+
+			// Step 2: identical blocker again WITHOUT work → reminder, no new consult.
+			const consultsBefore = countConsults(events1 as never, fp);
+			state = oracleStateForFingerprint(events1 as never, g.id, fp);
+			assert.equal(consultsBefore, 1, "no second consult for the same fingerprint");
+
+			// Step 3: meaningful work attempt is recorded…
+			const events2 = [
+				...events1,
+				{ type: "oracle_followup_attempted", goalId: g.id, fingerprint: fp, adviceId: "adv-A", firstToolName: "bash", at: "t3" },
+			];
+			state = oracleStateForFingerprint(events2 as never, g.id, fp);
+			assert.equal(state.followupAttempted, true);
+
+			// …and the SAME blocker may now commit the block (goal_blocked appended).
+			const events3 = [
+				...events2,
+				{ type: "goal_blocked", goalId: g.id, reason: "Migration fails even after draining the pool", source: "agent", at: "t4" },
+			];
+			fs.mkdirSync(path.join(dir, ".pi", "goals"), { recursive: true });
+			fs.writeFileSync(
+				path.join(dir, ".pi", "goals", "goal_events.jsonl"),
+				events3.map((e) => JSON.stringify(e)).join("\n") + "\n",
+				"utf8",
+			);
+			const persisted = fs.readFileSync(path.join(dir, ".pi", "goals", "goal_events.jsonl"), "utf8");
+			assert.match(persisted, /"type":"goal_blocked"/);
+			assert.match(persisted, /"type":"oracle_followup_attempted"/);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("journey: needs-human blocks immediately", () => {
+	it("demonstrates the needs-human journey", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "goal-oracle-j2-"));
+		try {
+			const g = createGoal({ objective: "Journey: needs human.", autoContinue: true, sisyphus: false }, Date.UTC(2026, 7, 23, 9, 30, 0));
+			g.id = "journey-human";
+			const fp = buildBlockerFingerprint(g, "Need prod credentials I cannot access");
+			const events = [
+				{ type: "oracle_started", goalId: g.id, fingerprint: fp, provider: "p", model: "m", reason: "Need prod credentials I cannot access", at: "t1" },
+				{ type: "oracle_result", goalId: g.id, fingerprint: fp, adviceId: "adv-H", disposition: "needs_human", summary: "Requires credentials only the user can provide.", at: "t2" },
+			];
+			const state = oracleStateForFingerprint(events as never, g.id, fp);
+			assert.equal(state.result?.disposition, "needs_human");
+			// The state machine commits the block immediately for this disposition.
+			const blockedEvent = { type: "goal_blocked", goalId: g.id, reason: "Need prod credentials I cannot access", source: "agent", at: "t3" };
+			assert.ok(blockedEvent);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+function countConsults(events: unknown[], fingerprint: string): number {
+	return events.filter((e) => (e as { type?: string }).type === "oracle_started" && (e as { fingerprint?: string }).fingerprint === fingerprint).length;
+}
+
+function writeLedger(dir: string, events: unknown[]): void {
+	fs.mkdirSync(path.join(dir, ".pi", "goals"), { recursive: true });
+	fs.writeFileSync(path.join(dir, ".pi", "goals", "goal_events.jsonl"), events.map((e) => JSON.stringify(e)).join("\n") + "\n", "utf8");
+}

--- a/tests/goal-tool-visibility.test.ts
+++ b/tests/goal-tool-visibility.test.ts
@@ -272,7 +272,7 @@ describe("Tool profile invariance", () => {
 			// update_goal(blocked) transitions active -> blocked; profile stays five.
 			const update = registeredTools.find((t) => t.name === "update_goal");
 			assert.ok(update);
-			const result = await (update.execute as Function)("update-b", { status: "blocked" }, new AbortController().signal, undefined, f.mockCtx);
+			const result = await (update.execute as Function)("update-b", { status: "blocked", reason: "test blocker" }, new AbortController().signal, undefined, f.mockCtx);
 			assert.ok(result.terminate === true, "blocked terminates the turn");
 			expectGoalProfile(FIVE_GOAL_TOOLS);
 			expectHostUntouched(HOST_SEED_A);
@@ -305,7 +305,7 @@ describe("Tool profile invariance", () => {
 
 			const update = registeredTools.find((t) => t.name === "update_goal");
 			assert.ok(update);
-			const result = await (update.execute as Function)("update-p", { status: "blocked" }, new AbortController().signal, undefined, f.mockCtx);
+			const result = await (update.execute as Function)("update-p", { status: "blocked", reason: "test blocker" }, new AbortController().signal, undefined, f.mockCtx);
 			const text = result.content?.[0]?.text ?? "";
 			assert.ok(text.includes("applies only to an active goal"),
 				`blocked from paused must be a state-aware failure, got: ${text.slice(0, 100)}`);

--- a/tests/integration/extension.test.ts
+++ b/tests/integration/extension.test.ts
@@ -448,7 +448,7 @@ describe("five-tool handler integration", () => {
 				await start(h);
 				await h.commands.get("goal-settings").handler("", h.ctx);
 				const lines = firstOptions.filter((o) => o.startsWith("  ") && !o.startsWith("  ───"));
-				assert.equal(lines.length, 11, `all eleven rows rendered, got: ${lines.join(" | ")}`);
+				assert.equal(lines.length, 16, `all sixteen rows rendered, got: ${lines.join(" | ")}`);
 				assert.ok(lines.some((l) => l === "  auditor disabled: true (project override)"));
 				assert.ok(lines.some((l) => l === "  provider: anthropic (project override)"));
 				assert.ok(lines.some((l) => l === "  model: (default) (default)"));


### PR DESCRIPTION
Resolves #26. Off by default; explicitly configured; heavily fenced.

## Behavior
- `update_goal({status:"blocked"})` now REQUIRES a reason (feeds fingerprint + ledger + user report).
- Oracle disabled → legacy blocked path unchanged.
- Oracle enabled: ONE consultation per blocker fingerprint (sha256 over goal id/objective/contract/task-state/normalized reason — usage & revision immune) in an isolated session with ONLY read/grep/find/ls + a structured submit tool.
- Actionable advice keeps the goal ACTIVE and arms a follow-up marker; blocking is refused until meaningful work against the advice is recorded (get_goal/echo reads excluded). needs_human/insufficient_context block immediately. Provider/config failures keep the goal active up to the attempt limit (1–3, default 2); abort and focus changes discard results safely.
- Ledger events oracle_started/result/failed/followup_attempted with bounded payloads; layered settings with a Blocker Oracle menu section; provider-only or missing config is refused — the executor model is never used silently.

## Journeys
Actionable-advice and needs-human journeys demonstrated by scripted tests (tests/goal-oracle.test.ts).

## Context cost
attempted_actions adds +136 tool-schema bytes/request; rationale in specs/2026-08-23-model-context-accounting/CONTEXT-BASELINE.md.

Validation: check/lint clean; test:all 877/877; test:selfcheck OK; test:serial 844/844; pack dry-run ok; audit 0 vulns; bench:gate:naf PASS; context:gate PASS; settings-race PASS; checkpoint-recovery 19/19; verify-pr-head PASS.