### PR TITLE
chore(release): 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to pi-goal-x are documented here.
 
+## [0.29.0] — 2026-08-23
+
+### Added
+
+- **Complete model-context accounting (PR D)** — `npm run context:measure` /
+  `context:gate`: composed-request measurement over 22 deterministic fixtures
+  including active tool schemas; committed deterministic baseline.
+- **Single-source active-goal prompt (PR E)** — current task rendered once,
+  lifecycle rules stated once, concise `get_goal` default with optional
+  verbose mode, `PI_GOAL_PROMPT_PROFILE=legacy-v1` emergency fallback.
+  Composed requests reduced on every task fixture.
+- **UI/model payload separation (PR F)** — audit events display-only;
+  auditor progress derived from session events (progress tool removed);
+  auditor prompt single-source; post-compaction delta.
+- **Opt-in read-only blocker Oracle (PR G, #26)** — one stronger-model
+  consultation per distinct blocker before blocking. Default off; explicit
+  provider/model required; read-only session; follow-up gating; durable
+  ledger events.
+
+### Changed
+
+- `update_goal({status:"blocked"})` now requires a `reason` describing the
+  concrete blocker (feeds the blocker fingerprint and ledger record).
+- Tool schemas grew by +136 bytes/request (`attempted_actions` parameter).
+
 ## [0.28.0] — 2026-08-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-goal-x",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Goal mode extension for pi: durable long-running objectives, five model tools, structured tasks, independent completion audit, Sisyphus mode, auto-continue, and a status overlay.",
   "license": "MIT",
   "author": "pi-goal-x contributors",
@@ -61,7 +61,8 @@
     "test:settings-race": "node --experimental-strip-types --test tests/goal-settings-race.test.ts",
     "lint": "eslint .",
     "context:measure": "node experiments/context/run-measure.mjs",
-    "context:gate": "node experiments/context/run-gate.mjs"
+    "context:gate": "node experiments/context/run-gate.mjs",
+    "test:oracle": "node --experimental-strip-types --test tests/goal-oracle.test.ts"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.83.0 <0.85.0",


### PR DESCRIPTION
Release PR: model-context accounting (D), single-source prompts (E), UI/model separation (F), blocker Oracle (G, #26). Version bump + changelog.