### PR TITLE
chore(release): 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,16 +27,18 @@ All notable changes to pi-goal-x are documented here.
   concrete blocker (feeds the blocker fingerprint and ledger record).
 - Tool schemas grew by +136 bytes/request (`attempted_actions` parameter).
 
-## Unreleased
+## [0.30.0] — 2026-08-23
 
 ### Fixed
 
-- **Network-error recovery for active goals** — after Pi exhausts its own
+- **Network-error recovery for active goals (#36)** — after Pi exhausts its own
   provider retries with `network_error`, an active auto-continue goal now
   retries through a bounded 5/10/20/40/80-second backoff ladder. The fallback
   begins only after Pi settles, cancels cleanly on user interaction or goal
   lifecycle changes, and leaves the goal active with a clear warning after the
   capped recovery budget is exhausted.
+
+## [0.29.0] — 2026-08-23
 
 ## [0.28.0] — 2026-08-23
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-goal-x",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Goal mode extension for pi: durable long-running objectives, five model tools, structured tasks, independent completion audit, Sisyphus mode, auto-continue, and a status overlay.",
   "license": "MIT",
   "author": "pi-goal-x contributors",


### PR DESCRIPTION
Release PR: network-error recovery for active goals (#36). Version bump + changelog.