### PR TITLE
fix(drafting): survive hosts whose ui.custom cannot render a dialog

### DIFF
--- a/extensions/goal-drafting.ts
+++ b/extensions/goal-drafting.ts
@@ -8,7 +8,7 @@ import { deriveTasksFromObjective } from "./goal-task-derive.ts";
 import { goalDetails, renderGoalResult } from "./goal-format.ts";
 import { buildGoalCreatedReport } from "./goal-policy.ts";
 import { loadGoalSettings } from "./goal-settings.ts";
-import { formatQuestionnaireAnswers, runGoalQuestionnaire, shouldAutoConfirmProposal, showProposalDialog, type GoalQuestionnaireQuestion, type ProposalDecision } from "./goal-questionnaire.ts";
+import { DIALOG_UNAVAILABLE_HINT, formatQuestionnaireAnswers, runGoalQuestionnaire, shouldAutoConfirmProposal, showProposalDialog, type GoalQuestionnaireQuestion, type ProposalDecision } from "./goal-questionnaire.ts";
 import { currentTaskIdIsPending, nowIso, type GoalRecord, type GoalTaskList } from "./goal-record.ts";
 import type { GoalCore } from "./goal-state.ts";
 import { convertFlatTasks, countTasks, mergeTasksWithExisting, type FlatTaskInput } from "./goal-task-tools.ts";
@@ -250,6 +250,7 @@ export function registerDraftingTools(core: GoalCore): void {
 			core.enterGoalModal();
 			try {
 				const result = await runGoalQuestionnaire(ctx, [{ id: "question", question: params.question, options: params.options ?? [], recommended: params.recommended, allowCustom: params.allow_custom }]);
+				if (result.unavailable === true) return { content: [{ type: "text", text: `${DIALOG_UNAVAILABLE_HINT} Ask the question in chat instead.` }], details: goalDetails(core.state.goal) };
 				return { content: [{ type: "text", text: result.cancelled ? "The user cancelled the question. Continue drafting conversationally." : formatQuestionnaireAnswers(result) }], details: goalDetails(core.state.goal) };
 			} finally {
 				core.exitGoalModal();
@@ -284,6 +285,7 @@ export function registerDraftingTools(core: GoalCore): void {
 					const active = activeDraft(core);
 					if (active) active.questionnaireEcho = formatQuestionnaireAnswers(result); // E5
 				}
+				if (result.unavailable === true) return { content: [{ type: "text", text: `${DIALOG_UNAVAILABLE_HINT} Ask the questions in chat instead.` }], details: goalDetails(core.state.goal) };
 				return { content: [{ type: "text", text: result.cancelled ? "The user cancelled the questionnaire. Continue drafting conversationally." : formatQuestionnaireAnswers(result) }], details: goalDetails(core.state.goal) };
 			} finally {
 				core.exitGoalModal();
@@ -329,9 +331,9 @@ export function registerDraftingTools(core: GoalCore): void {
 			const auditorLine = draft.auditorEnabled
 				? "\n\nAuditor for this goal: enabled (independent approval required before completion)."
 				: "\n\nAuditor for this goal: disabled (completion skips the audit).";
-			let confirmation: { decision: ProposalDecision; auditorEnabled: boolean };
+			let confirmation: { decision: ProposalDecision; auditorEnabled: boolean; unavailable: boolean };
 			if (shouldAutoConfirmProposal({ hasUI: ctx.hasUI, autoConfirmEnv: process.env.PI_GOAL_AUTO_CONFIRM })) {
-				confirmation = { decision: "confirm" as const, auditorEnabled: draft.auditorEnabled };
+				confirmation = { decision: "confirm" as const, auditorEnabled: draft.auditorEnabled, unavailable: false };
 			} else {
 				core.enterGoalModal();
 				try {
@@ -355,6 +357,9 @@ export function registerDraftingTools(core: GoalCore): void {
 			if (confirmation.decision === "cancel") {
 				clearGoalDrafting(core, ctx);
 				return { content: [{ type: "text", text: `${summary}\n\nDraft cancelled; no goal was created. Run /goal or /sisyphus to start a new draft.` }], details: goalDetails(core.state.goal) };
+			}
+			if (confirmation.unavailable) {
+				return { content: [{ type: "text", text: `${summary}\n\n${DIALOG_UNAVAILABLE_HINT} The goal was NOT created and drafting remains active; do not propose again until the user confirms in chat or restarts with PI_GOAL_AUTO_CONFIRM=1.` }], details: goalDetails(core.state.goal) };
 			}
 			if (confirmation.decision !== "confirm") {
 				// Continue refining: preserve the user's auditor choice for the

--- a/extensions/goal-questionnaire.ts
+++ b/extensions/goal-questionnaire.ts
@@ -304,6 +304,51 @@ export function isHeadlessQuestionSufficientForDraft(args: { topic: string; ques
 	return !vagueTopic;
 }
 
+const CUSTOM_ANSWER_LABEL = "Write your own answer...";
+
+/**
+ * Run the questionnaire with the dialog primitives every host implements.
+ *
+ * `ui.custom` renders a terminal component, so it exists only in pi's TUI.
+ * `confirm`, `select` and `input` are part of the same UI contract and are
+ * what a non-terminal host (a browser front end, for one) can actually
+ * present, so the questionnaire degrades onto them instead of disappearing.
+ * The auditor toggle has no place in these primitives, so the caller's
+ * default carries through untouched.
+ */
+async function runQuestionnaireWithBasicDialogs(
+	ctx: ExtensionContext,
+	questions: GoalQuestionnaireQuestion[],
+	auditorToggleInit?: { defaultEnabled: boolean },
+): Promise<GoalQuestionnaireResult> {
+	const answers: GoalQuestionnaireAnswer[] = [];
+	for (const question of questions) {
+		// Context is the substance of a proposal, not decoration, so it has to
+		// travel with the question the host displays.
+		const prompt = question.context === undefined || question.context === "" ? question.question : `${question.question}\n\n${question.context}`;
+		const options = question.allowCustom === false ? question.options : [...question.options, CUSTOM_ANSWER_LABEL];
+		let answer: string | undefined;
+		let wasCustom = false;
+		if (options.length === 0) {
+			answer = await ctx.ui.input(prompt, undefined);
+			wasCustom = true;
+		} else {
+			const picked = await ctx.ui.select(prompt, options);
+			if (picked === CUSTOM_ANSWER_LABEL) {
+				answer = await ctx.ui.input(question.question, undefined);
+				wasCustom = true;
+			} else {
+				answer = picked;
+			}
+		}
+		// A dismissed dialog is a cancelled questionnaire: partial answers would
+		// be presented as if the user had finished.
+		if (answer === undefined || answer === "") return { questions, answers: [], cancelled: true, auditorEnabled: auditorToggleInit?.defaultEnabled };
+		answers.push({ id: question.id, question: question.question, answer, wasCustom });
+	}
+	return { questions, answers, cancelled: false, auditorEnabled: auditorToggleInit?.defaultEnabled };
+}
+
 export const DIALOG_UNAVAILABLE_HINT = "This host cannot display goal-drafting dialogs (ui.custom is unavailable outside pi's terminal UI). Set PI_GOAL_AUTO_CONFIRM=1 to confirm proposals without a dialog, or run the draft from the pi TUI.";
 
 export function proposalDialogFailureMessage(error: unknown): string {
@@ -960,7 +1005,18 @@ function advanceAfterAnswer() {
 	// browser, for one) install a real UI context - so `hasUI` is true - while
 	// `ui.custom` remains the SDK's headless default and resolves to undefined.
 	// Reading `.cancelled` off that crashed every drafting tool on those hosts.
-	return result ?? { questions: [], answers: [], cancelled: true, unavailable: true };
+	if (result !== undefined) return result;
+	// `ctx.hasUI` only reports that a UI context is installed, not that it can
+	// render a TUI component, so a host with a non-terminal UI lands here with
+	// `hasUI === true` and an undefined result. Falling back keeps drafting
+	// usable there; hosts with no dialogs at all report `unavailable` so the
+	// caller can explain itself instead of claiming the user cancelled.
+	if (!hostSupportsBasicDialogs(ctx)) return { questions: [], answers: [], cancelled: true, unavailable: true };
+	return await runQuestionnaireWithBasicDialogs(ctx, questions, auditorToggleInit);
+}
+
+function hostSupportsBasicDialogs(ctx: ExtensionContext): boolean {
+	return typeof ctx.ui.select === "function" && typeof ctx.ui.input === "function";
 }
 
 /**

--- a/extensions/goal-questionnaire.ts
+++ b/extensions/goal-questionnaire.ts
@@ -25,6 +25,13 @@ export interface GoalQuestionnaireResult {
 	answers: GoalQuestionnaireAnswer[];
 	cancelled: boolean;
 	auditorEnabled?: boolean;
+	/**
+	 * The host could not present the dialog at all, so `cancelled` reflects an
+	 * absent UI rather than a decision the user made. Hosts that expose a
+	 * non-terminal UI keep `ctx.hasUI` true while `ctx.ui.custom` stays the
+	 * SDK's headless default, which resolves to `undefined`.
+	 */
+	unavailable?: boolean;
 }
 
 export type ProposalDecision = "confirm" | "continue" | "cancel";
@@ -297,6 +304,8 @@ export function isHeadlessQuestionSufficientForDraft(args: { topic: string; ques
 	return !vagueTopic;
 }
 
+export const DIALOG_UNAVAILABLE_HINT = "This host cannot display goal-drafting dialogs (ui.custom is unavailable outside pi's terminal UI). Set PI_GOAL_AUTO_CONFIRM=1 to confirm proposals without a dialog, or run the draft from the pi TUI.";
+
 export function proposalDialogFailureMessage(error: unknown): string {
 	const detail = error instanceof Error ? error.message : String(error);
 	return `Goal draft confirmation failed: ${detail}. The goal was NOT created; drafting remains active.`;
@@ -316,7 +325,7 @@ export async function runGoalQuestionnaire(ctx: ExtensionContext, rawQuestions: 
 	const isMulti = questions.length > 1;
 	const totalTabs = questions.length + 1;
 
-	return await ctx.ui.custom<GoalQuestionnaireResult>((tui, theme, _kb, done) => {
+	const result = await ctx.ui.custom<GoalQuestionnaireResult>((tui, theme, _kb, done) => {
 		// Suppress hardware cursor during dialog to reduce TUI auto-scroll
 		// (the TUI render loop runs at ~60fps and writes ANSI cursor positioning
 		// sequences every cycle, which can cause terminal viewport snapping).
@@ -946,6 +955,12 @@ function advanceAfterAnswer() {
 			},
 		};
 	});
+	// `ctx.hasUI` only reports that a UI context is installed, not that it can
+	// render a TUI component. Hosts embedding pi behind a non-terminal UI (a
+	// browser, for one) install a real UI context - so `hasUI` is true - while
+	// `ui.custom` remains the SDK's headless default and resolves to undefined.
+	// Reading `.cancelled` off that crashed every drafting tool on those hosts.
+	return result ?? { questions: [], answers: [], cancelled: true, unavailable: true };
 }
 
 /**
@@ -957,7 +972,7 @@ export async function showProposalDialog(
 	confirmationText: string,
 	focus: GoalDraftingFocus,
 	defaultAuditorEnabled?: boolean,
-): Promise<{ decision: ProposalDecision; auditorEnabled: boolean }> {
+): Promise<{ decision: ProposalDecision; auditorEnabled: boolean; unavailable: boolean }> {
 	const headerTitle = focus === "sisyphus" ? "Confirm Sisyphus Goal Draft" : "Confirm Goal Draft";
 	const result = await runGoalQuestionnaire(ctx, [{
 		id: "confirm",
@@ -971,5 +986,5 @@ export async function showProposalDialog(
 		cancelled: result.cancelled,
 		answer: result.answers[0]?.answer,
 	});
-	return { decision, auditorEnabled: result.auditorEnabled ?? true };
+	return { decision, auditorEnabled: result.auditorEnabled ?? true, unavailable: result.unavailable === true };
 }

--- a/tests/goal-questionnaire.test.ts
+++ b/tests/goal-questionnaire.test.ts
@@ -879,6 +879,50 @@ test("runGoalQuestionnaire reports an unavailable dialog instead of dereferencin
 	assert.deepEqual(result, { questions: [], answers: [], cancelled: true, unavailable: true });
 });
 
+// A host with a non-terminal UI implements the same confirm/select/input
+// contract; only `custom` is terminal-only. Drafting degrades onto those.
+
+function browserLikeUiContext(script: { picks?: (string | undefined)[]; typed?: string }) {
+	const picks = [...(script.picks ?? [])];
+	const prompts: string[] = [];
+	const ctx = {
+		hasUI: true,
+		cwd: "/test",
+		ui: {
+			custom: async () => undefined,
+			select: async (title: string, options: string[]) => { prompts.push(title); return picks.length > 0 ? picks.shift() : options[0]; },
+			input: async (title: string) => { prompts.push(title); return script.typed; },
+		},
+	} as unknown as Parameters<typeof runGoalQuestionnaire>[0];
+	return { ctx, prompts };
+}
+
+test("drafting degrades onto select/input where only ui.custom is missing", async () => {
+	const { ctx, prompts } = browserLikeUiContext({ picks: ["B"] });
+	const result = await runGoalQuestionnaire(ctx, [{ id: "scope", question: "Scope?", context: "Pick one", options: ["A", "B"] }]);
+	assert.equal(result.cancelled, false);
+	assert.equal(result.unavailable, undefined);
+	assert.deepEqual(result.answers, [{ id: "scope", question: "Scope?", answer: "B", wasCustom: false }]);
+	// Context is part of the question the host shows, not decoration dropped on
+	// the way: a proposal is unreadable without it.
+	assert.match(prompts[0] ?? "", /Scope\?[\s\S]*Pick one/);
+});
+
+test("the proposal dialog is answerable through plain select on such a host", async () => {
+	const { ctx, prompts } = browserLikeUiContext({ picks: ["Confirm — create this goal now"] });
+	assert.deepEqual(await showProposalDialog(ctx, "OBJECTIVE\n\nTasks:\n1. one", "goal", true), { decision: "confirm", auditorEnabled: true, unavailable: false });
+	assert.match(prompts[0] ?? "", /Confirm Goal Draft[\s\S]*OBJECTIVE[\s\S]*1\. one/);
+});
+
+test("a free-text question falls back to input, and a dismissed dialog cancels", async () => {
+	const typed = await runGoalQuestionnaire(browserLikeUiContext({ typed: "my own words" }).ctx, [{ id: "notes", question: "Notes?", options: [] }]);
+	assert.deepEqual(typed.answers, [{ id: "notes", question: "Notes?", answer: "my own words", wasCustom: true }]);
+	const dismissed = await runGoalQuestionnaire(browserLikeUiContext({ picks: [undefined] }).ctx, [{ id: "scope", question: "Scope?", options: ["A"] }]);
+	assert.equal(dismissed.cancelled, true);
+	// Partial answers must not be presented as a finished questionnaire.
+	assert.deepEqual(dismissed.answers, []);
+});
+
 test("showProposalDialog survives a host whose ui.custom resolves to undefined", async () => {
 	const decision = await showProposalDialog(nonTerminalUiContext(), "objective", "goal", true);
 	assert.deepEqual(decision, { decision: "continue", auditorEnabled: true, unavailable: true });

--- a/tests/goal-questionnaire.test.ts
+++ b/tests/goal-questionnaire.test.ts
@@ -15,8 +15,10 @@ import {
 	normalizeQuestionnaireQuestions,
 	proposalDialogFailureMessage,
 	proposalDecisionFromQuestionnaireResult,
+	showProposalDialog,
 	runGoalQuestionnaire,
 	shouldAutoConfirmProposal,
+	DIALOG_UNAVAILABLE_HINT,
 	type GoalQuestionnaireResult,
 } from "../extensions/goal-questionnaire.ts";
 
@@ -860,4 +862,35 @@ test("custom answer flows to the summary as (wrote) and Enter submits it", () =>
 	const view = component.render(100).map(strip).join("\n");
 	assert.ok(view.includes("Ready to submit"), "submit summary shown");
 	assert.ok(view.includes("(wrote) my custom answer"), "custom answer recorded as (wrote) in the summary");
+});
+
+// ── Hosts with a UI that cannot render TUI components ───────────────────
+// A host embedding pi behind a non-terminal UI installs a real UI context, so
+// `ctx.hasUI` is true, while `ui.custom` stays the SDK's headless default
+// (`async () => undefined`). Every drafting tool used to crash there with
+// "Cannot read properties of undefined (reading 'cancelled')".
+
+function nonTerminalUiContext() {
+	return { hasUI: true, cwd: "/test", ui: { custom: async () => undefined } } as unknown as Parameters<typeof runGoalQuestionnaire>[0];
+}
+
+test("runGoalQuestionnaire reports an unavailable dialog instead of dereferencing undefined", async () => {
+	const result = await runGoalQuestionnaire(nonTerminalUiContext(), [{ id: "q", question: "Scope?", options: ["A", "B"] }]);
+	assert.deepEqual(result, { questions: [], answers: [], cancelled: true, unavailable: true });
+});
+
+test("showProposalDialog survives a host whose ui.custom resolves to undefined", async () => {
+	const decision = await showProposalDialog(nonTerminalUiContext(), "objective", "goal", true);
+	assert.deepEqual(decision, { decision: "continue", auditorEnabled: true, unavailable: true });
+});
+
+test("a dialog the host never rendered is not reported as a user decision", async () => {
+	const cancelledByUser = proposalDecisionFromQuestionnaireResult({ cancelled: true, answer: undefined });
+	assert.equal(cancelledByUser, "continue");
+	// Same decision, different cause: only `unavailable` distinguishes "the user
+	// pressed escape" from "no dialog was ever shown", which is what lets the
+	// drafting tools explain themselves instead of claiming a cancellation.
+	const result = await runGoalQuestionnaire(nonTerminalUiContext(), [{ id: "q", question: "Scope?", options: [] }]);
+	assert.equal(result.unavailable, true);
+	assert.match(DIALOG_UNAVAILABLE_HINT, /PI_GOAL_AUTO_CONFIRM=1/);
 });


### PR DESCRIPTION
Fixes #45. Related: #47.

Hosts can provide a UI context without being able to render terminal components. This caused all three guided-drafting tools to dereference an undefined dialog result. The original contributor commits preserve unavailable-dialog outcomes and fall back to native select/input dialogs while retaining proposal context and cancellation behavior.

Maintainer review: accepted with hardening in #50. That companion retains both original author commits and adds direct RPC routing, safe handling of incompatible web-host factory arguments, unambiguous option/recommendation labels, editable auditor selection, and explicit failure handling. GitHub denies maintainer pushes to this fork over both HTTPS and SSH despite reporting maintainerCanModify=true, so those amendments are on the maintainer release branch.

The combined candidate for 0.31.1 passes 961 tests, TypeScript, lint, context/provider checks and GitHub CI. SDK 0.83.0 and 0.84.4 each pass 915 serial unit tests, 11 real-SDK session scenarios and six provider-payload checks. #50 will be integrated before publication; there is no npm release of the intermediate merge.
