### PR TITLE
Enable unattended npm publishing through GitHub OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,158 @@
+name: Publish npm
+run-name: Publish ${{ inputs.tag || github.ref_name }}${{ inputs.dry_run && ' (dry run)' || '' }}
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing stable release tag (vX.Y.Z) on main history
+        required: true
+        type: string
+      dry_run:
+        description: Validate and pack without publishing
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'tmonk/pi-goal-x'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    steps:
+      - name: Validate requested tag
+        shell: bash
+        run: |
+          [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || exit 1
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check release metadata and main ancestry
+        shell: bash
+        run: |
+          git merge-base --is-ancestor HEAD origin/main
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+          import assert from 'node:assert/strict';
+          const pkg = JSON.parse(fs.readFileSync('package.json'));
+          const lock = JSON.parse(fs.readFileSync('package-lock.json'));
+          assert.equal(pkg.name, 'pi-goal-x');
+          assert.equal(`v${pkg.version}`, process.env.RELEASE_TAG);
+          assert.equal(lock.version, pkg.version);
+          assert.equal(lock.packages[''].version, pkg.version);
+          NODE
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - name: Use verified OIDC-capable npm
+        run: npm install --global npm@11.19.0
+      - run: npm ci
+      - run: npm run check
+      - run: npm run lint
+      - run: npm run test:all
+      - run: npm run test:selfcheck
+      - run: npm run context:gate
+      - run: npm run context:provider-check
+      - run: npm audit --omit=dev
+      - run: npm run bench:gate:naf
+      - name: Pack once and smoke-test recovery CLI
+        run: |
+          mkdir -p "$RUNNER_TEMP/release"
+          npm pack --json --pack-destination "$RUNNER_TEMP/release" > "$RUNNER_TEMP/release/pack.json"
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+          import path from 'node:path';
+          const [pkg] = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/release/pack.json`));
+          fs.appendFileSync(process.env.GITHUB_ENV, `TARBALL=${path.join(process.env.RUNNER_TEMP, 'release', pkg.filename)}\n`);
+          NODE
+          mkdir -p "$RUNNER_TEMP/package-smoke"
+          tar -xzf "$RUNNER_TEMP/release/pi-goal-x-${RELEASE_TAG#v}.tgz" -C "$RUNNER_TEMP/package-smoke"
+          node "$RUNNER_TEMP/package-smoke/package/scripts/recover-session-checkpoints.mjs" --help
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-${{ env.RELEASE_TAG }}
+          path: ${{ runner.temp }}/release/
+          if-no-files-found: error
+      - name: Rehearse publication
+        if: env.DRY_RUN == 'true'
+        run: npm publish "$TARBALL" --dry-run --access public --tag latest
+      - name: Publish exact tarball with OIDC and verify registry
+        if: env.DRY_RUN != 'true'
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+          import assert from 'node:assert/strict';
+          import { execFileSync } from 'node:child_process';
+          const [pkg] = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/release/pack.json`));
+          const url = `https://registry.npmjs.org/${pkg.name}/${pkg.version}`;
+          const response = await fetch(url);
+          const isNewVersion = response.status === 404;
+          if (isNewVersion) {
+            const latestResponse = await fetch(`https://registry.npmjs.org/${pkg.name}/latest`);
+            if (!latestResponse.ok) throw new Error(`Cannot read latest: ${latestResponse.status}`);
+            const latest = (await latestResponse.json()).version;
+            const nextParts = pkg.version.split('.').map(Number);
+            const oldParts = latest.split('.').map(Number);
+            const firstDifferent = nextParts.findIndex((value, i) => value !== oldParts[i]);
+            assert(firstDifferent >= 0 && nextParts[firstDifferent] > oldParts[firstDifferent], 'Refusing to move latest backwards');
+            execFileSync('npm', ['publish', process.env.TARBALL, '--access', 'public', '--tag', 'latest', '--provenance'], { stdio: 'inherit' });
+          } else {
+            if (!response.ok) throw new Error(`Registry lookup failed: ${response.status}`);
+            assert.equal((await response.json()).dist.integrity, pkg.integrity, 'Published version differs from this tarball');
+            console.log('Identical version already published; verifying without republishing.');
+          }
+          let verified = false;
+          for (let attempt = 0; attempt < 12; attempt++) {
+            const published = await fetch(url);
+            if (published.ok) {
+              const metadata = await published.json();
+              assert.equal(metadata.dist.integrity, pkg.integrity);
+              assert.equal(metadata.dist.shasum, pkg.shasum);
+              fs.writeFileSync(`${process.env.RUNNER_TEMP}/release/registry.json`, JSON.stringify(metadata, null, 2));
+              verified = true;
+              break;
+            }
+            await new Promise(resolve => setTimeout(resolve, 5000));
+          }
+          assert(verified, 'Published metadata did not become available');
+          if (isNewVersion) {
+            const latest = await fetch(`https://registry.npmjs.org/${pkg.name}/latest`);
+            assert(latest.ok, 'Cannot verify latest');
+            assert.equal((await latest.json()).version, pkg.version, 'latest does not match release');
+          }
+          NODE
+      - name: Create GitHub release after registry verification
+        if: env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
+            echo 'GitHub release already exists; leaving its notes and assets intact.'
+          else
+            gh release create "$RELEASE_TAG" "$TARBALL" --verify-tag --generate-notes --title "$RELEASE_TAG"
+          fi
+      - name: Save registry receipt
+        if: env.DRY_RUN != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: registry-${{ env.RELEASE_TAG }}
+          path: ${{ runner.temp }}/release/registry.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -484,3 +484,5 @@ Both `provider` and `model` must be set explicitly — the executor model is nev
 ## License
 
 MIT
+
+Maintainers: see [Publishing releases](docs/publishing.md) for unattended npm publishing through GitHub Actions.

--- a/README.md
+++ b/README.md
@@ -485,4 +485,4 @@ Both `provider` and `model` must be set explicitly — the executor model is nev
 
 MIT
 
-Maintainers: see [Publishing releases](docs/publishing.md) for unattended npm publishing through GitHub Actions.
+Maintainers: see [Publishing releases](https://github.com/tmonk/pi-goal-x/blob/main/docs/publishing.md) for unattended npm publishing through GitHub Actions.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,39 @@
+# Publishing releases
+
+The `Publish npm` GitHub Actions workflow publishes through npm Trusted Publishing (OIDC). Agents need GitHub push/workflow access; no npm write token or recurring npm 2FA prompt is needed. Account 2FA stays enabled.
+
+Bump package.json and package-lock.json together, update the changelog, and merge the release into main. Push a stable version tag matching package metadata:
+
+```sh
+git tag -a vX.Y.Z -m 'Release vX.Y.Z'
+git push origin vX.Y.Z
+gh run list --workflow publish.yml
+```
+
+The workflow checks main ancestry and version metadata, runs validation, packs once, uploads the tarball, publishes it with provenance, verifies registry integrity, and creates a GitHub release. Stable releases only; publication is serialized. An existing npm version is accepted only if the tarball integrity matches. Existing GitHub release notes/assets are preserved.
+
+To rehearse without publishing, run the workflow on main with an existing tag:
+
+```sh
+gh workflow run publish.yml --ref main -f tag=v0.31.1 -f dry_run=true
+```
+
+To retry a release after fixing workflow infrastructure:
+
+```sh
+gh workflow run publish.yml --ref main -f tag=vX.Y.Z -f dry_run=false
+```
+
+Manual runs default to dry run. A dry run does not exercise npm OIDC authentication; only a real publish verifies the complete exchange. Do not publish an extra version solely to test authentication.
+
+## npm configuration
+
+The package trusts GitHub repository `tmonk/pi-goal-x`, workflow filename `publish.yml`, with direct `npm publish` permission and no approval environment. Setting up or changing npm trust requires interactive 2FA once. For setup:
+
+```sh
+npm trust github pi-goal-x --repo tmonk/pi-goal-x --file publish.yml --allow-publish --yes
+```
+
+Use GitHub-hosted runners; npm currently does not support self-hosted runners for trusted publishing. Keep `id-token: write` on the publishing job and use an OIDC-capable npm CLI. No `NPM_TOKEN` secret is required. Do not configure stage-only publishing or required environment reviewers if releases must run unattended.
+
+Reference: https://docs.npmjs.com/trusted-publishers/

--- a/specs/2026-09-08-npm-trusted-publishing/MILESTONES.md
+++ b/specs/2026-09-08-npm-trusted-publishing/MILESTONES.md
@@ -1,0 +1,3 @@
+# Milestones
+
+- Confirmed clean main and existing CI requirements. npm 11.19.0 supports npm trust github with --allow-publish. User authorized configuration for unattended publishing; retain account 2FA.

--- a/specs/2026-09-08-npm-trusted-publishing/PRODUCT.md
+++ b/specs/2026-09-08-npm-trusted-publishing/PRODUCT.md
@@ -1,0 +1,5 @@
+# Unattended npm publishing
+
+Agents release pi-goal-x through GitHub Actions without recurring npm 2FA or stored npm write tokens. Keep account 2FA enabled. Configure npm trust for tmonk/pi-goal-x, publish.yml, with direct publish permission.
+
+Stable vX.Y.Z tag pushes publish after validation. A manual workflow accepts an existing tag and defaults to dry run for safe rehearsal. Release tags must match package metadata and point to main history. Serialize publication, retain the tested tarball, verify registry integrity, and create a GitHub release. Do not publish another version just to test configuration.

--- a/specs/2026-09-08-npm-trusted-publishing/TECH.md
+++ b/specs/2026-09-08-npm-trusted-publishing/TECH.md
@@ -1,0 +1,7 @@
+# Design
+
+Use a GitHub-hosted Ubuntu runner, Node 24, npm 11.19.0 and job-scoped id-token:write for npm OIDC. No npm secret or approval environment. Checkout the requested immutable tag, verify stable version and main ancestry, run existing CI gates plus context/provider checks, pack once, and publish that exact tarball with provenance. Verify npm integrity before creating the GitHub release. Reruns accept an already published version only if its integrity matches; they never silently replace a release.
+
+Use workflow_dispatch on main with tag and dry_run inputs. Dry runs perform validation and npm publish --dry-run, which does not prove OIDC authentication. Configure trust only after the workflow is committed and validated. Record that first real publication is the end-to-end authentication test.
+
+Sources: https://docs.npmjs.com/trusted-publishers/ and installed npm 11.19.0 npm-trust manual.


### PR DESCRIPTION
Publishing currently requires the maintainer to complete npm 2FA for every release. Add a GitHub-hosted OIDC publishing workflow so agents can release by pushing a stable tag or dispatching an existing tag through gh.

The workflow checks version metadata and main ancestry, runs validation, retains and publishes one tarball, verifies registry integrity, and creates a GitHub release. Manual runs default to dry run; existing versions must match integrity. No npm write secret or approval environment is needed. Includes maintainer instructions and setup/validation records.

Validation: actionlint 1.7.12 and git diff --check pass. CI and a manual workflow rehearsal will be recorded before npm trust setup. No extra package version is published for testing.
