### PR TITLE
fix: stop empty-turn auto-continue loop after agent_settled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to pi-goal-x are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **Empty-turn auto-continue loop** — `agent_end` clears the turn_end continuation timer, then `agent_settled` re-queued with `force: true` even when the run called no goal-work tools. A no-tool reply (for example "Paused. No action." after `/goal-resume`) therefore injected another checkpoint forever. Auto-continue now waits for meaningful work in that agent run. User resume, goal creation, and session kickoff still start the first continuation.
+
 ## [0.31.2] — 2026-09-08
 
 ### Changed

--- a/extensions/goal-events.ts
+++ b/extensions/goal-events.ts
@@ -86,6 +86,11 @@ export function registerGoalEvents(core: GoalCore): void {
 	const { pi } = core;
 	let continuationAfterSettleFor: string | null = null;
 	let networkErrorRecoveryAfterSettleFor: string | null = null;
+	// Run-scoped empty-turn gate: turn_start resets the per-turn flag, so a text-only
+	// last turn after earlier work must not wipe the run. before_agent_start starts a
+	// new run. agent_settled must not auto-continue a run that did no goal work, or
+	// empty replies ("Paused. No action.") loop forever.
+	let goalWorkThisRun = false;
 
 	pi.on("context", async (event) => {
 		const filtered = filterGoalSessionContext(event.messages);
@@ -128,9 +133,10 @@ export function registerGoalEvents(core: GoalCore): void {
 					`End the turn with a brief summary and yield to the user.`,
 			};
 		}
-		// Track for #4 empty-turn gate.
+		// Track for #4 empty-turn gate (per-turn and per-run).
 		if (isMeaningfulProgressToolCall(event.toolName, asRecord(event)?.args)) {
 			core.goalWorkToolCalledThisTurn = true;
+			goalWorkThisRun = true;
 			// Issue #26: record a meaningful work attempt against armed Oracle
 			// advice. get_goal / echo-only reads are excluded upstream by
 			// isMeaningfulProgressToolCall.
@@ -339,6 +345,7 @@ export function registerGoalEvents(core: GoalCore): void {
 	});
 
 	pi.on("before_agent_start", async (event, ctx) => {
+		goalWorkThisRun = false;
 		core.advanceTurnSeq();
   if (!hasActiveDraft(core)) core.installGoalToolProfile(!loadGoalSettings(ctx.cwd).disableTasks);
 		const currentSystemPrompt = () => ctx.getSystemPrompt?.() || event.systemPrompt;
@@ -524,6 +531,10 @@ export function registerGoalEvents(core: GoalCore): void {
 		core.runtime.clearNetworkErrorBackoff();
 		core.persist(ctx);
 		core.updateUI(ctx);
+		// Empty-turn gate: agent_end clears any turn_end continuation timer, then
+		// agent_settled re-queues with force=true. Without this check, a no-tool
+		// reply (chat, or "Paused. No action." after resume) loops forever.
+		if (!goalWorkThisRun) return;
 		// agent_end runs before pi finishes retries, compaction, terminating-tool
 		// settlement, and queued messages. Starting the continuation timer here
 		// can poll a stale busy context for minutes on pi 0.84. agent_settled is

--- a/tests/goal-network-recovery.test.ts
+++ b/tests/goal-network-recovery.test.ts
@@ -160,6 +160,12 @@ async function countCheckpoints(h: ReturnType<typeof createHarness>): Promise<nu
 	).length;
 }
 
+async function markGoalWork(h: ReturnType<typeof createHarness>): Promise<void> {
+	await h.handlers["turn_start"]!({}, h.ctx);
+	await h.handlers["tool_call"]!({ toolName: "bash", args: { command: "ls" } }, h.ctx);
+	await h.handlers["tool_execution_end"]!({}, h.ctx);
+}
+
 // ── Classification unit coverage ─────────────────────────────────────────────
 
 test("classification: exact reported 503 server_error payload is a network error", () => {
@@ -480,6 +486,7 @@ test("lifecycle: a successful turn resets the recovery counter and clears pendin
 		// A successful turn uses the normal continuation path.
 		const checkpointsFromRecoveryTimers = await countCheckpoints(h);
 		const notificationsBeforeSuccess = h.notifications.length;
+		await markGoalWork(h);
 		await h.handlers["agent_end"]!({ messages: [{ role: "assistant", stopReason: "end_turn" }] }, idleCtx(h.ctx));
 		await h.handlers["agent_settled"]!({}, idleCtx(h.ctx));
 		assert.equal(await countCheckpoints(h), checkpointsFromRecoveryTimers + 1, "success queues the normal continuation");

--- a/tests/goal-stale-continuation-golden.test.ts
+++ b/tests/goal-stale-continuation-golden.test.ts
@@ -238,6 +238,13 @@ async function countCheckpoints(h: ReturnType<typeof createHarness>): Promise<nu
 	).length;
 }
 
+/** Mark this agent run as having done goal work (empty-turn gate). */
+async function markGoalWork(h: ReturnType<typeof createHarness>): Promise<void> {
+	await h.handlers["turn_start"]!({}, h.ctx);
+	await h.handlers["tool_call"]!({ toolName: "bash", args: { command: "ls" } }, h.ctx);
+	await h.handlers["tool_execution_end"]!({}, h.ctx);
+}
+
 test("provider-error guard: turn_end with stopReason=error never queues a continuation", async () => {
 	const { cwd, goal } = fixtureCwd();
 	const h = createHarness(cwd);
@@ -341,6 +348,7 @@ test("a successful Pi retry clears the pending network-error recovery", async ()
 		await h.handlers["agent_end"]!({
 			messages: [{ role: "assistant", stopReason: "error", errorMessage: "Provider finish_reason: network_error" }],
 		}, idleCtx(h.ctx));
+		await markGoalWork(h);
 		await h.handlers["agent_end"]!({
 			messages: [{ role: "assistant", stopReason: "end_turn" }],
 		}, idleCtx(h.ctx));
@@ -358,12 +366,33 @@ test("successful agent_end waits for agent_settled before queuing a continuation
 	const h = createHarness(cwd);
 	try {
 		await startSession(h.handlers, h.ctx, sessionEntriesFor(goal));
+		await markGoalWork(h);
 
 		await h.handlers["agent_end"]!({ messages: [{ role: "assistant", stopReason: "end_turn" }] }, idleCtx(h.ctx));
 		assert.equal(await countCheckpoints(h), 0, "agent_end runs before pi is truly idle");
 
 		await h.handlers["agent_settled"]!({}, idleCtx(h.ctx));
 		assert.equal(await countCheckpoints(h), 1, "agent_settled queues the continuation without idle polling");
+	} finally {
+		// temp dir cleanup is best-effort.
+	}
+});
+
+test("empty no-tool run does not auto-continue after agent_settled", async () => {
+	const { cwd, goal } = fixtureCwd();
+	const h = createHarness(cwd);
+	try {
+		await startSession(h.handlers, h.ctx, sessionEntriesFor(goal));
+		await h.handlers["before_agent_start"]!({
+			systemPrompt: "base",
+			prompt: "<pi_goal_continuation goal_id=\"" + goal.id + "\" kind=\"checkpoint\" v=\"2\"/>",
+			systemPromptOptions: {},
+		}, h.ctx);
+
+		await h.handlers["agent_end"]!({ messages: [{ role: "assistant", stopReason: "end_turn", content: [{ type: "text", text: "Paused. No action." }] }] }, idleCtx(h.ctx));
+		await h.handlers["agent_settled"]!({}, idleCtx(h.ctx));
+
+		assert.equal(await countCheckpoints(h), 0, "a no-tool reply must not re-queue auto-continuation");
 	} finally {
 		// temp dir cleanup is best-effort.
 	}


### PR DESCRIPTION
Fixes https://github.com/tmonk/pi-goal-x/issues/53

## Problem

`turn_end` already refuses to auto-continue a no-work turn. `agent_end` then clears that timer. `agent_settled` re-queued with `force: true` for any active auto-continue goal.

A no-tool reply therefore injected another checkpoint forever.

Session `01a08071-d8b5-70f8-8f27-82c68d3fcd2f`: after resume, 18 hidden checkpoints in ~20s (`seq` 14–31) with only `Paused. No action.` replies. Issue #30 made those checkpoints small. It did not stop the loop.

## Change

Track meaningful goal-work tools for the whole agent run (`goalWorkThisRun`). Reset on `before_agent_start`. `agent_settled` queues the next continuation only if that run did work.

Kickoff paths are unchanged: `/goal-resume`, goal create, and session start still start the first continuation.

A text-only last turn after earlier work in the same run still continues.

## Tests

- New: empty no-tool run does not auto-continue after `agent_settled`.
- Existing settle-path tests now mark goal work so they still cover the timing contract.
